### PR TITLE
refactor: rename Card.name to card_name, remove deprecated custom_naming

### DIFF
--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -187,44 +187,6 @@ def change_password(
     db.commit()
 
 
-class ResetPasswordRequest(BaseModel):
-    email: str
-
-
-class ResetPasswordResponse(BaseModel):
-    message: str
-    new_password: str | None = None
-
-
-def _generate_password(length: int = 12) -> str:
-    alphabet = string.ascii_letters + string.digits
-    return ''.join(secrets.choice(alphabet) for _ in range(length))
-
-
-@router.post("/reset-password", response_model=ResetPasswordResponse)
-def reset_password(
-    body: ResetPasswordRequest,
-    db: Session = Depends(get_db),
-):
-    email = body.email.lower().strip()
-    user = db.query(User).filter(User.email == email).first()
-
-    if not user:
-        return ResetPasswordResponse(message="Si el email existe, recibirás instrucciones para restablecer tu contraseña")
-
-    if not user.hashed_password:
-        return ResetPasswordResponse(message="Esta cuenta usa autenticación por OAuth. Iniciá sesión con tu proveedor.")
-
-    new_password = _generate_password()
-    user.hashed_password = get_password_hash(new_password)
-    db.commit()
-
-    return ResetPasswordResponse(
-        message="Contraseña restablecida. Iniciá sesión con la nueva contraseña.",
-        new_password=new_password
-    )
-
-
 class TelegramKeyResponse(BaseModel):
     telegram_key: str
 

--- a/backend/app/routers/cards.py
+++ b/backend/app/routers/cards.py
@@ -12,14 +12,16 @@ router = APIRouter(prefix="/cards", tags=["cards"])
 
 
 class CardCreate(BaseModel):
-    card_name: str  # Marca: Visa, Mastercard, Amex, Cabal, etc
+    card_name: str
     bank: str = ""
+    holder: str = ""
     card_type: str = "credito"  # credito, debito
 
 
 class CardUpdate(BaseModel):
     card_name: str | None = None
     bank: str | None = None
+    holder: str | None = None
     card_type: str | None = None
 
 
@@ -57,41 +59,32 @@ def create_card(
     card_name = card.card_name.strip()
     bank = card.bank.strip() if card.bank else ""
 
-    if not card_name:
-        raise HTTPException(status_code=400, detail="Franquicia (card_name) es obligatoria")
+    if not card_name or not bank:
+        raise HTTPException(status_code=400, detail="Nombre y banco son obligatorios")
 
-    # Extraer primer nombre del usuario para holder (para agrupar en grupo familiar)
-    holder = ""
-    if current_user.full_name:
-        if "," in current_user.full_name:
-            holder = current_user.full_name.split(",")[0].split()[0]
-        else:
-            holder = current_user.full_name.split()[0] if current_user.full_name.split() else ""
-
-    # Validar duplicados por (card_name + bank + card_type)
-    existing = db.query(Card).filter(
+    existing_by_fields = db.query(Card).filter(
         Card.user_id == current_user.id,
         func.lower(func.trim(Card.card_name)) == card_name.lower(),
         func.lower(func.trim(Card.bank)) == bank.lower(),
         Card.card_type == card.card_type,
     ).first()
 
-    if existing:
+    if existing_by_fields:
         raise HTTPException(
             status_code=409,
             detail={
-                "message": "Ya existe una tarjeta con esos datos (misma franquicia, banco y tipo)",
-                "existing_id": existing.id,
-                "existing_name": existing.card_name,
-                "existing_bank": existing.bank,
-                "existing_card_type": existing.card_type,
+                "message": "Ya existe una tarjeta con esos datos",
+                "existing_id": existing_by_fields.id,
+                "existing_card_name": existing_by_fields.card_name,
+                "existing_bank": existing_by_fields.bank,
+                "existing_card_type": existing_by_fields.card_type,
             }
         )
 
     db_card = Card(
         card_name=card_name,
         bank=bank,
-        holder=holder,
+        holder=card.holder or "",
         card_type=card.card_type,
         user_id=current_user.id,
     )
@@ -120,6 +113,8 @@ def update_card(
     update_data = card.model_dump(exclude_none=True)
 
     for key, value in update_data.items():
+        if isinstance(value, str):
+            value = value.strip()
         setattr(db_card, key, value)
 
     db.commit()

--- a/backend/app/routers/dashboard.py
+++ b/backend/app/routers/dashboard.py
@@ -319,7 +319,6 @@ def get_installments_dashboard(db: Session = Depends(get_db), current_user: User
     ).all()
 
     cat_map = {c.id: c for c in db.query(Category).all()}
-    user_cards_card_name = {c.id: c.card_name for c in db.query(Card).filter(Card.user_id.in_(uid_list)).all()}
     groups: dict = {}
 
     # Procesar cuotas pagadas
@@ -344,7 +343,6 @@ def get_installments_dashboard(db: Session = Depends(get_db), current_user: User
                 "currency": e.currency or "ARS",
                 "card": e.card or "",
                 "card_id": e.card_id,
-                "card_name": user_cards_card_name.get(e.card_id) if e.card_id else None,
             }
         groups[gid]["installments_paid"] += 1
         groups[gid]["total_amount"] += e.amount
@@ -372,7 +370,6 @@ def get_installments_dashboard(db: Session = Depends(get_db), current_user: User
                 "currency": s.currency or "ARS",
                 "card": s.card or "",
                 "card_id": s.card_id,
-                "card_name": user_cards_card_name.get(s.card_id) if s.card_id else None,
             }
         groups[gid]["remaining_installments"] += 1
         groups[gid]["next_dates"].append(s.scheduled_date.isoformat())
@@ -401,7 +398,6 @@ def get_installments_dashboard(db: Session = Depends(get_db), current_user: User
             "currency": g["currency"],
             "card": g["card"],
             "card_id": g["card_id"],
-            "card_name": g["card_name"],
         })
 
     return sorted(result, key=lambda x: (x["remaining_installments"] == 0, x["next_date"] or "9999-99"))
@@ -570,7 +566,7 @@ def get_credit_card_pasivos(db: Session = Depends(get_db), current_user: User = 
         if not is_credit_card and s.card:
             s_card_lower = s.card.lower()
             for cc in credit_cards:
-                if cc.card_name.lower() in s_card_lower:
+                if cc.name.lower() in s_card_lower:
                     is_credit_card = True
                     break
         
@@ -655,7 +651,6 @@ def get_card_summary(db: Session = Depends(get_db), current_user: User = Depends
     # Build card lookup with both name and id
     user_cards_by_name = {c.card_name: c.card_type for c in db.query(Card).filter(Card.user_id.in_(uid_list)).all()}
     user_cards_by_id = {c.id: c for c in db.query(Card).filter(Card.user_id.in_(uid_list)).all()}
-    user_cards_card_name = {c.id: c.card_name for c in db.query(Card).filter(Card.user_id.in_(uid_list)).all()}
 
     # Build account lookup - accounts are always "debito" type
     user_accounts_by_id = {a.id: a.type for a in db.query(Account).filter(Account.user_id.in_(uid_list)).all()}
@@ -793,16 +788,9 @@ def get_card_summary(db: Session = Depends(get_db), current_user: User = Depends
         if not card_type:
             card_type = "credito"
 
-        # Get card_name from most used card_id
-        card_name_from_id = None
-        if g.get("card_ids"):
-            most_used_card_id = max(g["card_ids"], key=g["card_ids"].get)
-            card_name_from_id = user_cards_card_name.get(most_used_card_id)
-
         result.append({
             "holder": holder, "bank": g["bank"],
             "card_name": card_name,
-            "card_name_from_id": card_name_from_id,
             "card_type": card_type,
             "total_amount": g["total_amount"], "count": g["count"],
             "currency": g["currency"],

--- a/backend/app/routers/import_.py
+++ b/backend/app/routers/import_.py
@@ -415,7 +415,7 @@ def rows_confirm_import(body: RowsConfirmBody, db: Session = Depends(get_db), cu
     def get_card_key(bank: str, card: str, holder: str) -> str:
         return f"{bank}|{card}|{holder}"
 
-    def find_or_create_card(bank: str, card: str, holder: str, _custom_naming: str, card_type: str = "credito") -> tuple[Card, bool]:
+    def find_or_create_card(bank: str, card: str, holder: str, card_type: str = "credito") -> tuple[Card, bool]:
         norm_bank = normalize_bank(bank)
         norm_card = first_card_word(card)
         norm_holder = title_case_single(holder)
@@ -425,7 +425,9 @@ def rows_confirm_import(body: RowsConfirmBody, db: Session = Depends(get_db), cu
 
         existing = next(
             (c for c in user_cards
-             if c.card_name.lower() == norm_card.lower() and c.bank.lower() == norm_bank.lower()), None
+             if c.card_name.lower() == norm_card.lower()
+             and c.bank.lower() == norm_bank.lower()
+             and c.holder.lower() == norm_holder.lower()), None
         )
         if existing:
             _log(f"[FIND_OR_CREATE_CARD] Found existing card: {existing.card_name}")
@@ -498,9 +500,6 @@ def rows_confirm_import(body: RowsConfirmBody, db: Session = Depends(get_db), cu
 
         card_key = get_card_key(norm_bank, norm_card, norm_person)
         mapping_entry = cards_mapping.get(card_key, {})
-        custom_naming = mapping_entry.get("custom_naming") if isinstance(mapping_entry, dict) else mapping_entry
-        if not custom_naming:
-            custom_naming = f"{norm_card} {norm_bank}".strip()
         # Override bank/card if provided in mapping
         final_bank = mapping_entry.get("bank") if isinstance(mapping_entry, dict) and mapping_entry.get("bank") else norm_bank
         final_card = mapping_entry.get("card_name") if isinstance(mapping_entry, dict) and mapping_entry.get("card_name") else norm_card
@@ -530,7 +529,7 @@ def rows_confirm_import(body: RowsConfirmBody, db: Session = Depends(get_db), cu
             except Exception:
                 skipped += 1
         else:
-            card_obj, _ = find_or_create_card(final_bank, row_card, norm_person, custom_naming, card_type)
+            card_obj, _ = find_or_create_card(final_bank, row_card, norm_person, card_type)
 
             try:
                 db.add(Expense(

--- a/backend/app/routers/import_jobs.py
+++ b/backend/app/routers/import_jobs.py
@@ -213,7 +213,7 @@ async def confirm_import_job(
     def get_card_key(bank: str, card: str, holder: str) -> str:
         return f"{bank}|{card}|{holder}"
 
-    def find_or_create_card(bank: str, card: str, holder: str, _custom_naming: str, card_type: str = "credito") -> tuple:
+    def find_or_create_card(bank: str, card: str, holder: str, card_type: str = "credito") -> tuple:
         norm_bank = normalize_bank(bank)
         norm_card = first_card_word(card)
         norm_holder = title_case_single(holder)
@@ -223,7 +223,9 @@ async def confirm_import_job(
 
         existing = next(
             (c for c in user_cards
-             if c.card_name.lower() == norm_card.lower() and c.bank.lower() == norm_bank.lower()), None
+             if c.card_name.lower() == norm_card.lower()
+             and c.bank.lower() == norm_bank.lower()
+             and c.holder.lower() == norm_holder.lower()), None
         )
         if existing:
             _log(f"[FIND_OR_CREATE_CARD] Found existing card: {existing.card_name}")
@@ -296,9 +298,6 @@ async def confirm_import_job(
         _log(f"[IMPORT CONFIRM] Expected card_key: {card_key}")
         _log(f"[IMPORT CONFIRM] cards_mapping.get result: {cards_mapping.get(card_key, 'NOT_FOUND')}")
         mapping_entry = cards_mapping.get(card_key, {})
-        custom_naming = mapping_entry.get("custom_naming") if isinstance(mapping_entry, dict) else mapping_entry
-        if not custom_naming:
-            custom_naming = f"{norm_card} {norm_bank}".strip()
         # Override bank/card if provided in mapping
         final_bank = mapping_entry.get("bank") if isinstance(mapping_entry, dict) and mapping_entry.get("bank") else norm_bank
         final_card = mapping_entry.get("card_name") if isinstance(mapping_entry, dict) and mapping_entry.get("card_name") else norm_card
@@ -334,7 +333,7 @@ async def confirm_import_job(
                 raise HTTPException(500, f"Error al crear gasto programado '{r.get('description', 'N/A')}': {str(e)}")
         else:
             # Create Expense with card
-            card_obj, _ = find_or_create_card(final_bank, row_card, norm_person, custom_naming, card_type)
+            card_obj, _ = find_or_create_card(final_bank, row_card, norm_person, card_type)
             try:
                 expense = Expense(
                     date=row_date,

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -209,14 +209,13 @@ class AnalysisHistoryResponse(BaseModel):
 
 
 class CardsMappingEntry(BaseModel):
-    custom_naming: str
     bank: Optional[str] = None
     card_name: Optional[str] = None
 
 
 class RowsConfirmBody(BaseModel):
     rows: List[Any]
-    cards_mapping: Optional[dict[str, dict[str, Any]]] = None  # key: "bank|card|holder" -> value: { custom_naming, bank?, card_name? }
+    cards_mapping: Optional[dict[str, dict[str, Any]]] = None  # key: "bank|card|holder" -> value: { bank?, card_name? }
 
 
 class CardClosingResponse(BaseModel):

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -301,6 +301,14 @@ export const getCardCategoryBreakdown = (params?: { month?: string; bank?: strin
 export const bulkUpdateCategory = (ids: number[], category_id: number | null) =>
   api.post<{ updated: number }>('/expenses/bulk-category', { ids, category_id }).then((r) => r.data)
 
+export const bulkUpdateFields = (ids: number[], data: {
+  category_id?: number | null;
+  bank?: string;
+  card?: string;
+  person?: string;
+}) =>
+  api.patch<{ updated: number }>('/expenses/bulk-update', { ids, ...data }).then((r) => r.data)
+
 export const recategorizeExpenses = (only_uncategorized = false) =>
   api.post<{ updated: number; total: number }>('/expenses/recategorize', { only_uncategorized }).then((r) => r.data)
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -70,9 +70,6 @@ export const getMe = () =>
 export const changePassword = (current_password: string, new_password: string) =>
   api.put('/auth/password', { current_password, new_password })
 
-export const resetPassword = (email: string) =>
-  api.post<{ message: string; new_password?: string }>('/auth/reset-password', { email }).then((r) => r.data)
-
 export const getTelegramKey = () =>
   api.get<{ telegram_key: string }>('/auth/me/telegram-key').then((r) => r.data)
 
@@ -304,14 +301,6 @@ export const getCardCategoryBreakdown = (params?: { month?: string; bank?: strin
 export const bulkUpdateCategory = (ids: number[], category_id: number | null) =>
   api.post<{ updated: number }>('/expenses/bulk-category', { ids, category_id }).then((r) => r.data)
 
-export const bulkUpdateFields = (ids: number[], data: {
-  category_id?: number | null;
-  bank?: string;
-  card?: string;
-  person?: string;
-}) =>
-  api.patch<{ updated: number }>('/expenses/bulk-update', { ids, ...data }).then((r) => r.data)
-
 export const recategorizeExpenses = (only_uncategorized = false) =>
   api.post<{ updated: number; total: number }>('/expenses/recategorize', { only_uncategorized }).then((r) => r.data)
 
@@ -436,9 +425,9 @@ export const deleteAccount = (id: number) =>
 // Cards
 export const getCards = () =>
   api.get<Card[]>('/cards').then((r) => r.data)
-export const createCard = (data: { card_name: string; bank?: string; card_type?: string }) =>
+export const createCard = (data: { card_name: string; bank?: string; holder?: string; card_type?: string }) =>
   api.post<Card>('/cards', data).then((r) => r.data)
-export const updateCard = (id: number, data: { card_name?: string; bank?: string; card_type?: string }) =>
+export const updateCard = (id: number, data: { card_name?: string; bank?: string; holder?: string; card_type?: string }) =>
   api.put<Card>(`/cards/${id}`, data).then((r) => r.data)
 export const deleteCard = (id: number) =>
   api.delete(`/cards/${id}`).then((r) => r.data)

--- a/frontend/src/components/AccountsManager.tsx
+++ b/frontend/src/components/AccountsManager.tsx
@@ -1,13 +1,20 @@
-import { useState, useEffect } from 'react'
+import { useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { getAccounts, createAccount, updateAccount, deleteAccount, createCard, getDistinctValues, getCards } from '../api/client'
-import { Select } from './ui/Select'
+import { getAccounts, createAccount, updateAccount, deleteAccount, createCard } from '../api/client'
 import type { Account } from '../types'
+import { Select } from './ui/Select'
 
 const ACCOUNT_TYPES = [
   { value: 'efectivo', label: 'Efectivo', color: 'badge-success' },
-  { value: 'banco_digital', label: 'Banco Digital', color: 'badge-neutral' },
+  { value: 'cuenta_corriente', label: 'Cta. Corriente', color: 'badge-primary' },
+  { value: 'caja_ahorro', label: 'Caja de Ahorro', color: 'badge-warning' },
+  { value: 'mercadopago', label: 'MercadoPago', color: 'badge-neutral' },
   { value: 'tarjeta', label: 'Tarjeta', color: 'badge-neutral' },
+]
+
+const CARD_TYPES = [
+  { value: 'credito', label: 'Crédito' },
+  { value: 'debito', label: 'Débito' },
 ]
 
 export default function AccountsManager() {
@@ -17,6 +24,7 @@ export default function AccountsManager() {
   const [deleteConfirm, setDeleteConfirm] = useState<{ type: 'account'; id: number; name: string } | null>(null)
   const [duplicateFound, setDuplicateFound] = useState<{ id: number; name: string; type: string } | null>(null)
   const [error, setError] = useState<string | null>(null)
+  const [cardName, setCardName] = useState('')
   const [name, setName] = useState('')
   const [type, setType] = useState('efectivo')
   const [bank, setBank] = useState('')
@@ -26,34 +34,6 @@ export default function AccountsManager() {
     queryKey: ['accounts'],
     queryFn: getAccounts,
   })
-
-  const { data: distinctValues } = useQuery({
-    queryKey: ['distinct-values'],
-    queryFn: getDistinctValues,
-    staleTime: 60_000,
-  })
-
-  const { data: cards = [] } = useQuery({
-    queryKey: ['cards'],
-    queryFn: getCards,
-  })
-
-  const bankOptions = (distinctValues?.banks ?? []).map(b => ({ value: b, label: b }))
-  const cardBanks = (cards || []).map(c => c.bank).filter(Boolean)
-  const allBankValues = [...new Set([...bankOptions.map(o => o.value), ...cardBanks])]
-  const bankOptionsWithCards = allBankValues.map(b => ({ value: b, label: b }))
-
-  useEffect(() => {
-    return () => {
-      if (editId !== null || name !== '' || bank !== '') {
-        setEditId(null)
-        setName('')
-        setType('efectivo')
-        setBank('')
-        setCardType('credito')
-      }
-    }
-  }, [])
 
   const createMut = useMutation({
     mutationFn: createAccount,
@@ -99,22 +79,11 @@ export default function AccountsManager() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['cards'] })
       setEditId(null)
+      setCardName('')
       setName('')
       setType('efectivo')
       setBank('')
       setCardType('credito')
-    },
-    onError: (error: any) => {
-      if (error.response?.status === 400) {
-        setError(error.response.data.detail || 'Error al crear tarjeta')
-      } else if (error.response?.status === 409) {
-        const detail = error.response.data.detail
-        setDuplicateFound({
-          id: detail.existing_id,
-          name: detail.existing_name || '',
-          type: 'tarjeta',
-        })
-      }
     },
   })
 
@@ -127,6 +96,7 @@ export default function AccountsManager() {
 
   const handleCancel = () => {
     setEditId(null)
+    setCardName('')
     setName('')
     setType('efectivo')
     setBank('')
@@ -135,7 +105,8 @@ export default function AccountsManager() {
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
-    if (!name.trim()) {
+    const nameValue = type === 'tarjeta' ? cardName : name
+    if (!nameValue.trim()) {
       setError('El nombre es obligatorio')
       return
     }
@@ -146,12 +117,16 @@ export default function AccountsManager() {
         alert('La edición de tarjetas se puede hacer desde la sección de Tarjetas')
         return
       }
+      if (!cardName.trim()) {
+        setError('El nombre de la tarjeta es obligatorio')
+        return
+      }
       if (!bank.trim()) {
         setError('El banco es obligatorio')
         return
       }
       createCardMut.mutate({
-        card_name: name.trim(),
+        card_name: cardName.trim(),
         bank: bank.trim(),
         card_type: cardType,
       })
@@ -178,79 +153,64 @@ export default function AccountsManager() {
           <div key={account.id} className="relative">
             {isEditing ? (
               <form onSubmit={handleSubmit} className="p-4 bg-[var(--color-surface)] border border-[var(--border-color)] rounded-lg space-y-4">
+                {/* Nombre */}
+                <div className="space-y-1.5">
+                  <label className="text-xs font-medium text-[var(--text-secondary)]">Nombre</label>
+                  <input
+                    type="text"
+                    value={type === 'tarjeta' ? cardName : name}
+                    onChange={(e) => {
+                      if (type === 'tarjeta') setCardName(e.target.value)
+                      else setName(e.target.value)
+                      setError(null)
+                    }}
+                    className={`w-full px-3 py-2 rounded-md border text-sm text-[var(--text-primary)] bg-[var(--color-base-container)] focus:outline-none focus:ring-2 focus:ring-primary/30 transition ${error ? 'border-red-500 focus:ring-red-300 focus:border-red-500' : 'border-[var(--border-color)] focus:border-primary'}`}
+                    placeholder={type === 'tarjeta' ? 'Ej: Visa Galicia' : 'Ej: Mi Cuenta'}
+                    autoFocus
+                  />
+                  {error && <p className="text-xs text-red-500">{error}</p>}
+                </div>
+
                 {/* Tipo de cuenta */}
                 <div className="space-y-1.5">
                   <label className="text-xs font-medium text-[var(--text-secondary)]">Tipo de cuenta</label>
-                  <Select
+                  <select
                     value={type}
-                    onChange={(v) => { setType(v); setError(null) }}
-                    options={[
-                      { value: 'efectivo', label: 'Efectivo' },
-                      { value: 'banco_digital', label: 'Banco Digital' },
-                      { value: 'tarjeta', label: 'Tarjeta' },
-                    ]}
-                    allowCustomValue={false}
-                  />
+                    onChange={(e) => setType(e.target.value)}
+                    className="w-full px-3 py-2 rounded-md border border-[var(--border-color)] text-sm text-[var(--text-primary)] bg-[var(--color-base-container)] focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary transition"
+                  >
+                    <option value="efectivo">💵 Efectivo</option>
+                    <option value="cuenta_corriente">🏦 Cuenta Corriente</option>
+                    <option value="caja_ahorro">💳 Caja de Ahorro</option>
+                    <option value="mercadopago">📱 MercadoPago</option>
+                    <option value="tarjeta">💰 Tarjeta</option>
+                  </select>
                 </div>
 
                 {/* Campos de Tarjeta */}
                 {type === 'tarjeta' && (
                   <div className="space-y-3 pt-2 border-t border-[var(--border-color)]">
-                    {/* Credito/Debito */}
+                    {/* Tipo: Crédito/Débito */}
                     <div className="space-y-1.5">
                       <label className="text-xs font-medium text-[var(--text-secondary)]">Tipo de tarjeta</label>
                       <Select
                         value={cardType}
                         onChange={v => setCardType(v)}
-                        options={[
-                          { value: 'credito', label: 'Crédito' },
-                          { value: 'debito', label: 'Débito' },
-                        ]}
-                        allowCustomValue={false}
+                        options={CARD_TYPES.map(t => ({ value: t.value, label: t.label }))}
                       />
                     </div>
 
                     {/* Banco */}
                     <div className="space-y-1.5">
                       <label className="text-xs font-medium text-[var(--text-secondary)]">Banco</label>
-                      <Select
-                        value={bank}
-                        onChange={v => setBank(v)}
-                        options={bankOptionsWithCards}
-                        placeholder="Seleccionar banco"
-                        allowCustomValue={false}
-                      />
-                    </div>
-
-                    {/* Marca */}
-                    <div className="space-y-1.5">
-                      <label className="text-xs font-medium text-[var(--text-secondary)]">Marca</label>
                       <input
                         type="text"
-                        value={name}
-                        onChange={(e) => { setName(e.target.value); setError(null) }}
-                        className={`w-full px-3 py-2 rounded-md border text-sm text-[var(--text-primary)] bg-[var(--color-base-container)] focus:outline-none focus:ring-2 focus:ring-primary/30 transition ${error ? 'border-red-500 focus:ring-red-300 focus:border-red-500' : 'border-[var(--border-color)] focus:border-primary'}`}
-                        placeholder="Ej: Visa"
-                        autoFocus
+                        value={bank}
+                        onChange={(e) => { setBank(e.target.value); setError(null) }}
+                        className={`w-full px-3 py-2 rounded-md border text-sm text-[var(--text-primary)] bg-[var(--color-base-container)] focus:outline-none focus:ring-2 focus:ring-primary/30 transition ${error && type === 'tarjeta' && !bank.trim() ? 'border-red-500 focus:ring-red-300 focus:border-red-500' : 'border-[var(--border-color)] focus:border-primary'}`}
+                        placeholder="Ej: Galicia"
                       />
-                      {error && <p className="text-xs text-red-500">{error}</p>}
                     </div>
-                  </div>
-                )}
-
-                {/* Nombre para no-tarjeta */}
-                {type !== 'tarjeta' && (
-                  <div className="space-y-1.5">
-                    <label className="text-xs font-medium text-[var(--text-secondary)]">Nombre</label>
-                    <input
-                      type="text"
-                      value={name}
-                      onChange={(e) => { setName(e.target.value); setError(null) }}
-                      className={`w-full px-3 py-2 rounded-md border text-sm text-[var(--text-primary)] bg-[var(--color-base-container)] focus:outline-none focus:ring-2 focus:ring-primary/30 transition ${error ? 'border-red-500 focus:ring-red-300 focus:border-red-500' : 'border-[var(--border-color)] focus:border-primary'}`}
-                      placeholder="Ej: Mi Cuenta"
-                      autoFocus
-                    />
-                    {error && <p className="text-xs text-red-500">{error}</p>}
                   </div>
                 )}
 
@@ -276,7 +236,9 @@ export default function AccountsManager() {
               <div className="group relative flex items-center gap-3 p-3 bg-surface border border-border-color rounded-lg hover:border-border-color transition-colors">
                 <div className={`w-8 h-8 rounded-lg flex items-center justify-center text-sm font-bold ${typeInfo.color}`}>
                   {account.type === 'efectivo' ? '💵' :
-                   account.type === 'banco_digital' ? '📱' : '💰'}
+                   account.type === 'mercadopago' ? '📱' :
+                   account.type === 'cuenta_corriente' ? '🏦' :
+                   account.type === 'caja_ahorro' ? '💳' : '💰'}
                 </div>
                 <div className="flex-1 min-w-0">
                   <div className="text-sm font-semibold text-primary truncate">{account.name}</div>

--- a/frontend/src/components/CardsManager.tsx
+++ b/frontend/src/components/CardsManager.tsx
@@ -1,9 +1,16 @@
 import { useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { getCards, createCard, updateCard, deleteCard, createAccount, getCardSummary } from '../api/client'
+import { getCards, createCard, updateCard, deleteCard, createAccount, getCardSummary, getMe } from '../api/client'
 import { useQuery as useCardDataQuery } from '@tanstack/react-query'
 import type { Card } from '../types'
 import { Select } from './ui/Select'
+
+const getFirstName = (fullName: string): string => {
+  if (fullName.includes(',')) {
+    return fullName.split(',')[1].trim().split(' ')[0]
+  }
+  return fullName.split(' ')[0]
+}
 
 const ACCOUNT_TYPES = [
   { value: 'efectivo', label: 'Efectivo' },
@@ -29,6 +36,11 @@ export default function CardsManager() {
   const { data: cards = [], isLoading } = useQuery({
     queryKey: ['cards'],
     queryFn: getCards,
+  })
+
+  const { data: currentUser } = useQuery({
+    queryKey: ['me'],
+    queryFn: getMe,
   })
 
   // Card data from expenses (for future extension - show spending by card)
@@ -116,7 +128,7 @@ export default function CardsManager() {
     setEditId(-1)
     setCardName('')
     setBank('')
-    setHolder('')
+    setHolder(currentUser ? getFirstName(currentUser.full_name) : '')
     setCardType('credito')
     setAccountType('efectivo')
     setMenuOpen(null)
@@ -140,15 +152,15 @@ export default function CardsManager() {
     setErrors({})
 
     if (accountType === 'tarjeta') {
-      const data = {
+      const data: Record<string, string> = {
         card_name: cardName.trim(),
         bank: bank.trim(),
-        holder: holder.trim(),
         card_type: cardType,
       }
       if (editId && editId > 0) {
         updateMut.mutate({ id: editId, data })
       } else {
+        data.holder = holder.trim()
         createMut.mutate(data)
       }
     } else {
@@ -192,16 +204,6 @@ export default function CardsManager() {
                     placeholder="Ej: Galicia"
                   />
                   {errors.bank && <p className="text-xs text-red-500">{errors.bank}</p>}
-                </div>
-                <div className="space-y-1.5">
-                  <label className="text-xs font-medium text-[var(--text-secondary)]">Titular</label>
-                  <input
-                    type="text"
-                    value={holder}
-                    onChange={(e) => setHolder(e.target.value)}
-                    className="w-full px-3 py-2 rounded-md border border-[var(--border-color)] text-sm text-[var(--text-primary)] bg-[var(--color-base-container)] focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary transition"
-                    placeholder="Ej: Juan Perez"
-                  />
                 </div>
                 <div className="space-y-1.5">
                   <label className="text-xs font-medium text-[var(--text-secondary)]">Tipo</label>
@@ -313,16 +315,6 @@ export default function CardsManager() {
                   placeholder="Ej: Galicia"
                 />
                 {errors.bank && <p className="text-xs text-red-500">{errors.bank}</p>}
-              </div>
-              <div className="space-y-1.5">
-                <label className="text-xs font-medium text-[var(--text-secondary)]">Titular</label>
-                <input
-                  type="text"
-                  value={holder}
-                  onChange={(e) => setHolder(e.target.value)}
-                  className="w-full px-3 py-2 rounded-md border border-[var(--border-color)] text-sm text-[var(--text-primary)] bg-[var(--color-base-container)] focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary transition"
-                  placeholder="Ej: Juan Perez"
-                />
               </div>
             </div>
           )}

--- a/frontend/src/components/CardsManager.tsx
+++ b/frontend/src/components/CardsManager.tsx
@@ -1,19 +1,28 @@
 import { useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { getCards, createCard, updateCard, deleteCard, createAccount, getCardSummary, getDistinctValues } from '../api/client'
+import { getCards, createCard, updateCard, deleteCard, createAccount, getCardSummary } from '../api/client'
 import { useQuery as useCardDataQuery } from '@tanstack/react-query'
-import { Select } from './ui/Select'
 import type { Card } from '../types'
+import { Select } from './ui/Select'
+
+const ACCOUNT_TYPES = [
+  { value: 'efectivo', label: 'Efectivo' },
+  { value: 'cuenta_corriente', label: 'Cta. Corriente' },
+  { value: 'caja_ahorro', label: 'Caja de Ahorro' },
+  { value: 'mercadopago', label: 'MercadoPago' },
+  { value: 'tarjeta', label: 'Tarjeta' },
+]
 
 export default function CardsManager() {
   const queryClient = useQueryClient()
   const [editId, setEditId] = useState<number | null>(null)
   const [menuOpen, setMenuOpen] = useState<number | null>(null)
   const [deleteConfirm, setDeleteConfirm] = useState<{ type: 'card' | 'account'; id: number; name: string } | null>(null)
-  const [duplicateFound, setDuplicateFound] = useState<{ id: number; name: string; bank: string; card_type: string } | null>(null)
-  const [errors, setErrors] = useState<{ name?: string; bank?: string }>({})
-  const [name, setName] = useState('')
+  const [duplicateFound, setDuplicateFound] = useState<{ id: number; card_name: string; bank: string; card_type: string } | null>(null)
+  const [errors, setErrors] = useState<{ card_name?: string; bank?: string }>({})
+  const [cardName, setCardName] = useState('')
   const [bank, setBank] = useState('')
+  const [holder, setHolder] = useState('')
   const [cardType, setCardType] = useState('credito')
   const [accountType, setAccountType] = useState('efectivo')
 
@@ -22,27 +31,21 @@ export default function CardsManager() {
     queryFn: getCards,
   })
 
+  // Card data from expenses (for future extension - show spending by card)
   useCardDataQuery({
     queryKey: ['card-summary'],
     queryFn: getCardSummary,
-    enabled: false,
+    enabled: false, // Disabled for now - can be enabled for future features
   })
-
-  const { data: distinctValues } = useQuery({
-    queryKey: ['distinct-values'],
-    queryFn: getDistinctValues,
-    staleTime: 60_000,
-  })
-
-  const bankOptions = (distinctValues?.banks ?? []).map(b => ({ value: b, label: b }))
 
   const createMut = useMutation({
     mutationFn: createCard,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['cards'] })
       setEditId(null)
-      setName('')
+      setCardName('')
       setBank('')
+      setHolder('')
       setCardType('credito')
     },
     onError: (error: any) => {
@@ -50,7 +53,7 @@ export default function CardsManager() {
         const detail = error.response.data.detail
         setDuplicateFound({
           id: detail.existing_id,
-          name: detail.existing_name || '',
+          card_name: detail.existing_card_name || '',
           bank: detail.existing_bank || '',
           card_type: detail.existing_card_type || 'credito',
         })
@@ -63,8 +66,9 @@ export default function CardsManager() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['cards'] })
       setEditId(null)
-      setName('')
+      setCardName('')
       setBank('')
+      setHolder('')
       setCardType('credito')
     },
   })
@@ -82,7 +86,7 @@ export default function CardsManager() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['accounts'] })
       setEditId(null)
-      setName('')
+      setCardName('')
       setAccountType('efectivo')
       setBank('')
       setCardType('credito')
@@ -91,8 +95,9 @@ export default function CardsManager() {
 
   const handleEdit = (card: Card) => {
     setEditId(card.id)
-    setName(card.card_name)
+    setCardName(card.card_name)
     setBank(card.bank || '')
+    setHolder(card.holder || '')
     setCardType(card.card_type)
     setAccountType('tarjeta')
     setMenuOpen(null)
@@ -100,16 +105,18 @@ export default function CardsManager() {
 
   const handleCancel = () => {
     setEditId(null)
-    setName('')
+    setCardName('')
     setBank('')
+    setHolder('')
     setCardType('credito')
     setAccountType('tarjeta')
   }
 
   const handleAdd = () => {
     setEditId(-1)
-    setName('')
+    setCardName('')
     setBank('')
+    setHolder('')
     setCardType('credito')
     setAccountType('efectivo')
     setMenuOpen(null)
@@ -118,12 +125,12 @@ export default function CardsManager() {
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
 
-    const newErrors: { name?: string; bank?: string } = {}
+    const newErrors: { card_name?: string; bank?: string } = {}
     if (accountType === 'tarjeta') {
-      if (!name.trim()) newErrors.name = 'La marca es obligatoria (Visa, Mastercard, etc.)'
+      if (!cardName.trim()) newErrors.card_name = 'El nombre de la tarjeta es obligatorio'
       if (!bank.trim()) newErrors.bank = 'El banco es obligatorio'
     } else {
-      if (!name.trim()) newErrors.name = 'El nombre es obligatorio'
+      if (!cardName.trim()) newErrors.card_name = 'El nombre es obligatorio'
     }
 
     if (Object.keys(newErrors).length > 0) {
@@ -134,8 +141,9 @@ export default function CardsManager() {
 
     if (accountType === 'tarjeta') {
       const data = {
-        card_name: name.trim(),
+        card_name: cardName.trim(),
         bank: bank.trim(),
+        holder: holder.trim(),
         card_type: cardType,
       }
       if (editId && editId > 0) {
@@ -144,7 +152,7 @@ export default function CardsManager() {
         createMut.mutate(data)
       }
     } else {
-      createAccountMut.mutate({ name: name.trim(), type: accountType })
+      createAccountMut.mutate({ name: cardName.trim(), type: accountType })
     }
   }
 
@@ -163,7 +171,40 @@ export default function CardsManager() {
             {isEditing ? (
               <form onSubmit={handleSubmit} className="p-4 bg-[var(--color-surface)] border border-[var(--border-color)] rounded-lg space-y-4">
                 <div className="space-y-1.5">
-                  <label className="text-xs font-medium text-[var(--text-secondary)]">Tipo de tarjeta</label>
+                  <label className="text-xs font-medium text-[var(--text-secondary)]">Tarjeta</label>
+                  <input
+                    type="text"
+                    value={cardName}
+                    onChange={(e) => { setCardName(e.target.value); setErrors(prev => ({ ...prev, card_name: undefined })) }}
+                    className={`w-full px-3 py-2 rounded-md border text-sm text-[var(--text-primary)] bg-[var(--color-base-container)] focus:outline-none focus:ring-2 focus:ring-primary/30 transition ${errors.card_name ? 'border-red-500 focus:ring-red-300 focus:border-red-500' : 'border-[var(--border-color)] focus:border-primary'}`}
+                    placeholder="Ej: Visa"
+                    autoFocus
+                  />
+                  {errors.card_name && <p className="text-xs text-red-500">{errors.card_name}</p>}
+                </div>
+                <div className="space-y-1.5">
+                  <label className="text-xs font-medium text-[var(--text-secondary)]">Banco</label>
+                  <input
+                    type="text"
+                    value={bank}
+                    onChange={(e) => { setBank(e.target.value); setErrors(prev => ({ ...prev, bank: undefined })) }}
+                    className={`w-full px-3 py-2 rounded-md border text-sm text-[var(--text-primary)] bg-[var(--color-base-container)] focus:outline-none focus:ring-2 focus:ring-primary/30 transition ${errors.bank ? 'border-red-500 focus:ring-red-300 focus:border-red-500' : 'border-[var(--border-color)] focus:border-primary'}`}
+                    placeholder="Ej: Galicia"
+                  />
+                  {errors.bank && <p className="text-xs text-red-500">{errors.bank}</p>}
+                </div>
+                <div className="space-y-1.5">
+                  <label className="text-xs font-medium text-[var(--text-secondary)]">Titular</label>
+                  <input
+                    type="text"
+                    value={holder}
+                    onChange={(e) => setHolder(e.target.value)}
+                    className="w-full px-3 py-2 rounded-md border border-[var(--border-color)] text-sm text-[var(--text-primary)] bg-[var(--color-base-container)] focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary transition"
+                    placeholder="Ej: Juan Perez"
+                  />
+                </div>
+                <div className="space-y-1.5">
+                  <label className="text-xs font-medium text-[var(--text-secondary)]">Tipo</label>
                   <Select
                     value={cardType}
                     onChange={v => setCardType(v)}
@@ -171,30 +212,7 @@ export default function CardsManager() {
                       { value: 'credito', label: 'Crédito' },
                       { value: 'debito', label: 'Débito' },
                     ]}
-                    allowCustomValue={false}
                   />
-                </div>
-                <div className="space-y-1.5">
-                  <label className="text-xs font-medium text-[var(--text-secondary)]">Banco</label>
-                  <Select
-                    value={bank}
-                    onChange={v => { setBank(v); setErrors(prev => ({ ...prev, bank: undefined })) }}
-                    options={bankOptions}
-                    placeholder="Seleccionar banco"
-                    allowCustomValue={false}
-                  />
-                  {errors.bank && <p className="text-xs text-red-500">{errors.bank}</p>}
-                </div>
-                <div className="space-y-1.5">
-                  <label className="text-xs font-medium text-[var(--text-secondary)]">Marca</label>
-                  <input
-                    type="text"
-                    value={name}
-                    onChange={(e) => { setName(e.target.value); setErrors(prev => ({ ...prev, name: undefined })) }}
-                    className={`w-full px-3 py-2 rounded-md border text-sm text-[var(--text-primary)] bg-[var(--color-base-container)] focus:outline-none focus:ring-2 focus:ring-primary/30 transition ${errors.name ? 'border-red-500 focus:ring-red-300 focus:border-red-500' : 'border-[var(--border-color)] focus:border-primary'}`}
-                    placeholder="Ej: Visa"
-                  />
-                  {errors.name && <p className="text-xs text-red-500">{errors.name}</p>}
                 </div>
                 <div className="flex gap-2 pt-2">
                   <button
@@ -220,11 +238,12 @@ export default function CardsManager() {
                 </div>
                 <div className="flex-1 min-w-0">
                   <div className="text-sm font-semibold text-primary truncate" title={card.card_name}>
-                    {card.card_name} | {card.bank}
+                    {card.card_name}
                   </div>
                   <div className="text-xs text-secondary capitalize">
-                    {card.card_type === 'credito' ? 'Crédito' : card.card_type === 'debito' ? 'Débito' : card.card_type}
+                    {card.card_type === 'credito' ? 'Crédito' : card.card_type === 'debito' ? 'Débito' : card.card_type} — {card.bank}
                   </div>
+                  <div className="text-xs text-tertiary mt-0.5">Titular: {card.holder || '—'}</div>
                 </div>
                 <div className="relative">
                   <button
@@ -267,21 +286,14 @@ export default function CardsManager() {
             <Select
               value={accountType}
               onChange={v => setAccountType(v)}
-              options={[
-                { value: 'efectivo', label: 'Efectivo' },
-                { value: 'cuenta_corriente', label: 'Cuenta Corriente' },
-                { value: 'caja_ahorro', label: 'Caja de Ahorro' },
-                { value: 'mercadopago', label: 'MercadoPago' },
-                { value: 'tarjeta', label: 'Tarjeta' },
-              ]}
-              allowCustomValue={false}
+              options={ACCOUNT_TYPES.map(t => ({ value: t.value, label: t.label }))}
             />
           </div>
 
           {accountType === 'tarjeta' && (
             <div className="space-y-3 pt-2 border-t border-[var(--border-color)]">
               <div className="space-y-1.5">
-                <label className="text-xs font-medium text-[var(--text-secondary)]">Tipo de tarjeta</label>
+                <label className="text-xs font-medium text-[var(--text-secondary)]">Crédito / Débito</label>
                 <Select
                   value={cardType}
                   onChange={v => setCardType(v)}
@@ -289,36 +301,43 @@ export default function CardsManager() {
                     { value: 'credito', label: 'Crédito' },
                     { value: 'debito', label: 'Débito' },
                   ]}
-                  allowCustomValue={false}
                 />
               </div>
               <div className="space-y-1.5">
                 <label className="text-xs font-medium text-[var(--text-secondary)]">Banco</label>
-                <Select
+                <input
+                  type="text"
                   value={bank}
-                  onChange={v => { setBank(v); setErrors(prev => ({ ...prev, bank: undefined })) }}
-                  options={bankOptions}
-                  placeholder="Seleccionar banco"
-                  allowCustomValue={false}
+                  onChange={(e) => { setBank(e.target.value); setErrors(prev => ({ ...prev, bank: undefined })) }}
+                  className={`w-full px-3 py-2 rounded-md border text-sm text-[var(--text-primary)] bg-[var(--color-base-container)] focus:outline-none focus:ring-2 focus:ring-primary/30 transition ${errors.bank ? 'border-red-500 focus:ring-red-300 focus:border-red-500' : 'border-[var(--border-color)] focus:border-primary'}`}
+                  placeholder="Ej: Galicia"
                 />
                 {errors.bank && <p className="text-xs text-red-500">{errors.bank}</p>}
+              </div>
+              <div className="space-y-1.5">
+                <label className="text-xs font-medium text-[var(--text-secondary)]">Titular</label>
+                <input
+                  type="text"
+                  value={holder}
+                  onChange={(e) => setHolder(e.target.value)}
+                  className="w-full px-3 py-2 rounded-md border border-[var(--border-color)] text-sm text-[var(--text-primary)] bg-[var(--color-base-container)] focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary transition"
+                  placeholder="Ej: Juan Perez"
+                />
               </div>
             </div>
           )}
 
           <div className="space-y-1.5">
-            <label className="text-xs font-medium text-[var(--text-secondary)]">
-              {accountType === 'tarjeta' ? 'Marca' : 'Nombre'}
-            </label>
+            <label className="text-xs font-medium text-[var(--text-secondary)]">Nombre</label>
             <input
               type="text"
-              value={name}
-              onChange={(e) => { setName(e.target.value); setErrors(prev => ({ ...prev, name: undefined })) }}
-              className={`w-full px-3 py-2 rounded-md border text-sm text-[var(--text-primary)] bg-[var(--color-base-container)] focus:outline-none focus:ring-2 focus:ring-primary/30 transition ${errors.name ? 'border-red-500 focus:ring-red-300 focus:border-red-500' : 'border-[var(--border-color)] focus:border-primary'}`}
-              placeholder={accountType === 'tarjeta' ? 'Ej: Visa' : 'Ej: Mi Cuenta'}
+              value={cardName}
+              onChange={(e) => { setCardName(e.target.value); setErrors(prev => ({ ...prev, card_name: undefined })) }}
+              className={`w-full px-3 py-2 rounded-md border text-sm text-[var(--text-primary)] bg-[var(--color-base-container)] focus:outline-none focus:ring-2 focus:ring-primary/30 transition ${errors.card_name ? 'border-red-500 focus:ring-red-300 focus:border-red-500' : 'border-[var(--border-color)] focus:border-primary'}`}
+              placeholder={accountType === 'tarjeta' ? 'Ej: Visa Galicia' : 'Ej: Mi Cuenta'}
               autoFocus
             />
-            {errors.name && <p className="text-xs text-red-500">{errors.name}</p>}
+            {errors.card_name && <p className="text-xs text-red-500">{errors.card_name}</p>}
           </div>
 
           <div className="flex gap-2 pt-2">
@@ -383,13 +402,13 @@ export default function CardsManager() {
           <div className="bg-surface rounded-xl shadow-xl p-6 max-w-sm w-full">
             <h3 className="text-lg font-semibold text-primary mb-2">Tarjeta existente</h3>
             <p className="text-sm text-secondary mb-6">
-              Ya existe una tarjeta con estos datos: <span className="font-medium text-primary">"{duplicateFound.name} | {duplicateFound.bank}"</span>
+              Ya existe una tarjeta con estos datos: <span className="font-medium text-primary">"{duplicateFound.card_name}"</span>
             </p>
             <div className="flex gap-3">
               <button
                 onClick={() => {
                   setDuplicateFound(null)
-                  setName('')
+                  setCardName('')
                   setBank('')
                   setCardType('credito')
                   setEditId(null)
@@ -403,7 +422,7 @@ export default function CardsManager() {
                   const cardToEdit = cards.find(c => c.id === duplicateFound.id)
                   if (cardToEdit) {
                     setEditId(duplicateFound.id)
-                    setName(cardToEdit.card_name)
+                    setCardName(cardToEdit.card_name)
                     setBank(cardToEdit.bank || '')
                     setCardType(cardToEdit.card_type)
                   }

--- a/frontend/src/components/ExpenseModals.tsx
+++ b/frontend/src/components/ExpenseModals.tsx
@@ -183,7 +183,6 @@ export function ExpenseModal({ initial, onClose, onSave, saveError }: ExpenseMod
     setForm((prev) => ({
       ...prev,
       card: c.card_name,
-      card_id: c.id,
       bank: c.bank || '',
     }))
   }
@@ -278,10 +277,7 @@ export function ExpenseModal({ initial, onClose, onSave, saveError }: ExpenseMod
           <label className="text-xs font-medium text-[var(--text-secondary)]">Categoría</label>
           <Select
             value={form.category_id ? String(form.category_id) : ''}
-            onChange={v => {
-              const catId = v ? parseInt(v) : null
-              set('category_id', catId)
-            }}
+            onChange={v => set('category_id', v ? parseInt(v) : null)}
             groups={(() => {
               const parentIds = new Set(categories.filter(c => c.parent_id).map(c => c.parent_id!))
               const parents = categories.filter(c => !c.parent_id && parentIds.has(c.id))
@@ -320,7 +316,7 @@ export function ExpenseModal({ initial, onClose, onSave, saveError }: ExpenseMod
                   if (selected) handleCardSelect(selected)
                   else set('card', v)
                 }}
-                options={availableCards.map(c => ({ value: c.card_name, label: `${c.card_name} | ${c.bank}` }))}
+                options={availableCards.map(c => ({ value: c.card_name, label: c.card_name }))}
                 placeholder="— Tarjeta —"
                 disabled={payMethod === 'cash'}
               />

--- a/frontend/src/components/UserPanel.tsx
+++ b/frontend/src/components/UserPanel.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { getMe, changePassword, clearToken, getMyGroup, inviteToGroup, leaveGroup, getTelegramKey, regenerateTelegramKey, getMyInviteCode, generateInviteCode, resetPassword } from '../api/client'
+import { getMe, changePassword, clearToken, getMyGroup, inviteToGroup, leaveGroup, getTelegramKey, regenerateTelegramKey, getMyInviteCode, generateInviteCode } from '../api/client'
 import { useNavigate } from 'react-router-dom'
 import { useTheme } from '../context/ThemeContext'
 import AccountsManager from './AccountsManager'
@@ -30,11 +30,7 @@ export default function UserPanel({ open, onClose }: Props) {
   const [confirmPw, setConfirmPw] = useState('')
   const [pwError, setPwError] = useState<string | null>(null)
   const [pwSuccess, setPwSuccess] = useState(false)
-  const [resetMode, setResetMode] = useState(false)
-  const [resetEmail, setResetEmail] = useState('')
-  const [resetSuccess, setResetSuccess] = useState<string | null>(null)
-  const [resetError, setResetError] = useState<string | null>(null)
-  const [newResetPassword, setNewResetPassword] = useState<string | null>(null)
+
   const [inviteCode, setInviteCode] = useState('')
   const [inviteError, setInviteError] = useState<string | null>(null)
   const [inviteSuccess, setInviteSuccess] = useState(false)
@@ -119,18 +115,6 @@ export default function UserPanel({ open, onClose }: Props) {
     },
     onError: (e: any) => {
       setPwError(e?.response?.data?.detail ?? 'Error al cambiar contraseña')
-    },
-  })
-
-  const resetPwMut = useMutation({
-    mutationFn: () => resetPassword(resetEmail),
-    onSuccess: (data) => {
-      setResetSuccess(data.message)
-      setResetError(null)
-      setNewResetPassword(data.new_password || null)
-    },
-    onError: (e: any) => {
-      setResetError(e?.response?.data?.detail ?? 'Error al restablecer contraseña')
     },
   })
 
@@ -434,64 +418,6 @@ export default function UserPanel({ open, onClose }: Props) {
               >
                 {changePwMut.isPending ? 'Guardando...' : 'Guardar contraseña'}
               </button>
-
-              {!resetMode && (
-                <button
-                  type="button"
-                  onClick={() => { setResetMode(true); setResetEmail(user?.email || '') }}
-                  className="w-full py-1.5 text-xs text-secondary hover:text-primary transition text-center"
-                >
-                  ¿Olvidaste tu contraseña?
-                </button>
-              )}
-
-              {resetMode && (
-                <div className="pt-3 border-t border-[var(--border-color)] space-y-3">
-                  <p className="text-xs text-[var(--text-tertiary)]">
-                    Ingresá tu email y te enviaremos una nueva contraseña.
-                  </p>
-                  <input
-                    type="email"
-                    value={resetEmail}
-                    onChange={e => { setResetEmail(e.target.value); setResetError(null); setResetSuccess(null) }}
-                    placeholder="tu@email.com"
-                    className="w-full px-3 py-2 rounded-md border border-[var(--border-color)] text-sm text-[var(--text-primary)] bg-[var(--color-base-container)] focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary transition"
-                  />
-                  {resetError && (
-                    <p className="text-xs text-[var(--red-3,#e01b24)] bg-[var(--color-base)] border border-[var(--border-color)] rounded-md px-3 py-2">{resetError}</p>
-                  )}
-                  {resetSuccess && (
-                    <div>
-                      <p className="text-xs text-[var(--green-5,#26a269)] bg-[var(--color-base)] border border-[var(--border-color)] rounded-md px-3 py-2 mb-2">
-                        {resetSuccess}
-                      </p>
-                      {newResetPassword && (
-                        <div className="bg-[var(--color-base-alt)] rounded-md p-3">
-                          <p className="text-xs text-[var(--text-secondary)] mb-1">Nueva contraseña:</p>
-                          <p className="font-mono text-sm text-primary select-all">{newResetPassword}</p>
-                        </div>
-                      )}
-                    </div>
-                  )}
-                  <div className="flex gap-2">
-                    <button
-                      type="button"
-                      onClick={() => { setResetMode(false); setResetError(null); setResetSuccess(null); setNewResetPassword(null) }}
-                      className="flex-1 py-2 rounded-md border border-[var(--border-color)] text-sm font-medium text-[var(--text-secondary)] hover:bg-[var(--color-base-alt)] transition"
-                    >
-                      Cancelar
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => resetPwMut.mutate()}
-                      disabled={resetPwMut.isPending || !resetEmail.trim()}
-                      className="flex-1 py-2 rounded-md bg-primary hover:brightness-110 disabled:opacity-60 text-[var(--color-on-primary)] font-medium text-sm transition"
-                    >
-                      {resetPwMut.isPending ? 'Enviando...' : 'Restablecer'}
-                    </button>
-                  </div>
-                </div>
-              )}
             </form>
           </div>
           </div>

--- a/frontend/src/pages/ImportJobPreview.tsx
+++ b/frontend/src/pages/ImportJobPreview.tsx
@@ -1,8 +1,8 @@
 import { useParams, useNavigate } from 'react-router-dom'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { getImportJob, confirmImportJob, deleteImportJob, updateImportPreview, getDistinctValues, getCards } from '../api/client'
+import { getImportJob, confirmImportJob, deleteImportJob, updateImportPreview, getDistinctValues } from '../api/client'
 import { useState, useEffect } from 'react'
-import type { SmartImportRow, ImportSummary, DetectedCard, CardsMapping, Card } from '../types'
+import type { SmartImportRow, ImportSummary, DetectedCard, CardsMapping } from '../types'
 import { toUpperCase, titleCase } from '../utils/format'
 import { useModalWithData } from '../hooks/useModal'
 import { TransactionDetailModal } from '../components/TransactionDetailModal'
@@ -12,24 +12,18 @@ function getCardKey(bank: string, card: string, holder: string): string {
   return `${bank}|${card}|${titleCase(holder)}`
 }
 
-function getSuggestionsForHolder(_cards: Card[], _holder: string): string[] {
-  return []
-}
-
-type CardNamingEdit = { custom_naming?: string; bank?: string; card_name?: string; holder?: string }
+type CardNamingEdit = { bank?: string; card_name?: string; holder?: string }
 
 function generateCardsMapping(detectedCards: DetectedCard[], edits: Record<string, CardNamingEdit>): CardsMapping {
   const mapping: CardsMapping = {}
   for (const dc of detectedCards) {
     if (dc.card_type) {
-      mapping[`_card_type_${dc.bank}_${dc.card}`] = { custom_naming: dc.card_type }
+      mapping[`_card_type_${dc.bank}_${dc.card}`] = { card_name: dc.card_type }
     }
     for (const holder of dc.holders) {
       const key = getCardKey(dc.bank, dc.card, holder)
-      const entry = edits[key] || { custom_naming: dc.suggested_custom_naming, bank: dc.bank, card_name: dc.card }
-      const customName = entry.custom_naming || dc.suggested_custom_naming
+      const entry = edits[key] || { bank: dc.bank, card_name: dc.card }
       mapping[key] = {
-        custom_naming: customName,
         bank: entry.bank || dc.bank,
         card_name: entry.card_name || dc.card,
       }
@@ -108,7 +102,7 @@ export default function ImportJobPreview() {
   const [editForm, setEditForm] = useState({ bank: '', card: '', person: '', onlyEmpty: true })
 
   const [spotlightNaming, setSpotlightNaming] = useState(false)
-  const [customNamingEdits, setCustomNamingEdits] = useState<Record<string, { custom_naming?: string; bank?: string; card_name?: string; holder?: string }>>({})
+  const [customNamingEdits, setCustomNamingEdits] = useState<Record<string, { bank?: string; card_name?: string; holder?: string }>>({})
   const { data: selectedRow, openWithData: openRowDetail, close: closeRowDetail, isOpen: isRowDetailOpen } = useModalWithData<SmartImportRow>()
 
   // Persist custom naming edits to localStorage
@@ -144,11 +138,6 @@ export default function ImportJobPreview() {
   const { data: distinctValues } = useQuery({
     queryKey: ['distinct-values'],
     queryFn: getDistinctValues,
-  })
-
-  const { data: cards = [] } = useQuery({
-    queryKey: ['cards'],
-    queryFn: getCards,
   })
 
 
@@ -214,7 +203,7 @@ export default function ImportJobPreview() {
   const customNamingRequired = detectedCards.length > 0
   const customNamingComplete = customNamingRequired && detectedCards.every(dc => {
     const key = getCardKey(dc.bank, dc.card, dc.holders[0] || '')
-    return customNamingEdits[key]?.custom_naming?.trim()
+    return customNamingEdits[key]?.card_name?.trim()
   })
   const canImport = dataComplete && (!customNamingRequired || customNamingComplete)
 
@@ -440,7 +429,7 @@ export default function ImportJobPreview() {
               {detectedCards
                 .filter(dc => {
                   const key = getCardKey(dc.bank, dc.card, dc.holders[0] || '')
-                  return !customNamingEdits[key]?.custom_naming?.trim()
+                  return !customNamingEdits[key]?.card_name?.trim()
                 })
                 .map((dc, i) => (
                   <li key={i}>{dc.bank} · {dc.card}</li>
@@ -460,10 +449,9 @@ export default function ImportJobPreview() {
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
               {detectedCards.map((dc, idx) => {
                 const key = getCardKey(dc.bank, dc.card, dc.holders[0] || '')
-                const entry = customNamingEdits[key] || { custom_naming: dc.suggested_custom_naming, bank: dc.bank, card_name: dc.card, holder: dc.holders[0] }
-                const suggestions = getSuggestionsForHolder(cards, entry.holder || dc.holders[0] || '')
+                const entry = customNamingEdits[key] || { bank: dc.bank, card_name: dc.card, holder: dc.holders[0] }
                 return (
-                  <div key={idx} className={`p-3 bg-[var(--color-surface)] rounded-md border ${spotlightNaming && !entry.custom_naming?.trim() ? 'border-yellow-500 ring-2 ring-yellow-500/50' : 'border-[var(--border-color)]'}`}>
+                  <div key={idx} className={`p-3 bg-[var(--color-surface)] rounded-md border ${spotlightNaming && !entry.card_name?.trim() ? 'border-yellow-500 ring-2 ring-yellow-500/50' : 'border-[var(--border-color)]'}`}>
                     <div className="flex items-start justify-between mb-3">
                       <div className="w-8 h-8 rounded-lg flex items-center justify-center text-sm font-bold bg-[var(--color-primary)] text-[var(--color-on-primary)]">
                         💳
@@ -473,21 +461,6 @@ export default function ImportJobPreview() {
                       </span>
                     </div>
                     <div className="space-y-2">
-                      <div className="flex items-center gap-2">
-                        <span className="text-xs text-[var(--text-secondary)] w-16">Nombre:</span>
-                        <input
-                          type="text"
-                          list={`custom-naming-suggestions-${idx}`}
-                          value={entry.custom_naming || ''}
-                          onChange={e => setCustomNamingEdits(prev => ({ ...prev, [key]: { ...prev[key], custom_naming: e.target.value } }))}
-                          placeholder="Nombre personalizado"
-                          className={`flex-1 px-2 py-1 border rounded text-sm bg-[var(--color-base-container)] focus:outline-none focus:ring-2 transition ${
-                            !entry.custom_naming?.trim()
-                              ? 'border-red-500 focus:ring-red-500/30'
-                              : 'border-[var(--border-color)] focus:ring-primary/30'
-                          }`}
-                        />
-                      </div>
                       <div className="flex items-center gap-2">
                         <span className="text-xs text-[var(--text-secondary)] w-16">Tarjeta:</span>
                         <input
@@ -519,11 +492,6 @@ export default function ImportJobPreview() {
                         />
                       </div>
                     </div>
-                    <datalist id={`custom-naming-suggestions-${idx}`}>
-                      {suggestions.map(name => (
-                        <option key={name} value={name} />
-                      ))}
-                    </datalist>
                   </div>
                 )
               })}

--- a/frontend/src/pages/ImportPage.tsx
+++ b/frontend/src/pages/ImportPage.tsx
@@ -107,17 +107,15 @@ function generateCardsMapping(detectedCards: DetectedCard[], edits: Record<strin
   const mapping: CardsMapping = {}
   for (const dc of detectedCards) {
     if (dc.card_type) {
-      mapping[`_card_type_${dc.bank}_${dc.card}`] = { custom_naming: dc.card_type }
+      mapping[`_card_type_${dc.bank}_${dc.card}`] = { card_name: dc.card_type }
     }
     for (const holder of dc.holders) {
       const key = getCardKey(dc.bank, dc.card, holder)
-      const customName = edits[key] || dc.suggested_custom_naming
-      // Find if customName matches an existing card
-      const matchedCard = existingCards.find(c => c.card_name === customName)
+      const cardName = edits[key] || dc.card
+      const matchedCard = existingCards.find(c => c.card_name === cardName)
       mapping[key] = {
-        custom_naming: customName,
         bank: matchedCard?.bank || dc.bank,
-        card_name: matchedCard?.card_name || dc.card,
+        card_name: matchedCard?.card_name || cardName,
       }
     }
   }
@@ -145,7 +143,7 @@ export default function ImportPage() {
 
   // Custom naming modal state
   const [customNamingModalFile, setCustomNamingModalFile] = useState<string | null>(null)
-  const [customNamingEdits, setCustomNamingEdits] = useState<Record<string, string>>({})  // cardKey -> custom_naming
+  const [customNamingEdits, setCustomNamingEdits] = useState<Record<string, string>>({})  // cardKey -> card_name
 
   const fileQueueRef  = useRef<File[]>([])
   const processingRef = useRef(false)
@@ -265,7 +263,7 @@ export default function ImportPage() {
       for (const holder of dc.holders) {
         const key = getCardKey(dc.bank, dc.card, holder)
         const entry = fileResult.cards_mapping?.[key]
-        initialEdits[key] = (typeof entry === 'object' ? entry.custom_naming : entry) || dc.suggested_custom_naming
+        initialEdits[key] = (typeof entry === 'object' ? entry.card_name : entry) || dc.card
       }
     }
     setCustomNamingEdits(initialEdits)
@@ -306,16 +304,13 @@ export default function ImportPage() {
 
     setFileResults(prev => prev.map(f => {
       if (f.filename !== customNamingModalFile) return f
-      // Merge customNamingEdits into existing cards_mapping, preserving bank/card_name
       const updatedMapping: CardsMapping = { ...f.cards_mapping }
-      for (const [key, customName] of Object.entries(customNamingEdits)) {
-        const existingEntry = updatedMapping[key] || { custom_naming: customName }
-        // Check if customName matches an existing card
-const matchedCard = existingCards.find(c => c.card_name === customName)
+      for (const [key, cardName] of Object.entries(customNamingEdits)) {
+        const existingEntry = updatedMapping[key] || {}
+        const matchedCard = existingCards.find(c => c.card_name === cardName)
         updatedMapping[key] = {
-          custom_naming: customName,
           bank: matchedCard?.bank || existingEntry.bank,
-          card_name: matchedCard?.card_name || existingEntry.card_name,
+          card_name: matchedCard?.card_name || cardName,
         }
       }
       return {
@@ -861,7 +856,7 @@ const matchedCard = existingCards.find(c => c.card_name === customName)
                             type="text"
                             value={customNamingEdits[key] || ''}
                             onChange={e => setCustomNamingEdits(prev => ({ ...prev, [key]: e.target.value }))}
-                            placeholder={dc.suggested_custom_naming}
+                            placeholder={dc.card}
                             className="w-full px-3 py-2 rounded-md border border-[var(--border-color)] text-sm text-[var(--text-primary)] bg-[var(--color-base-container)] focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary"
                           />
                           <p className="text-xs text-tertiary mt-1">

--- a/frontend/src/pages/InstallmentsPage.tsx
+++ b/frontend/src/pages/InstallmentsPage.tsx
@@ -71,7 +71,6 @@ const CARD_GRADIENTS = [
 interface CardEntry {
   key: string
   card_id: number | null
-  card_name: string | null
   bank: string
   person: string
   pendingTotal: number
@@ -83,7 +82,7 @@ function InstallmentCard({
 }: {
   entry: CardEntry; active: boolean; onClick: () => void; index: number
 }) {
-  const network = detectNetwork(entry.card_name || entry.bank)
+  const network = detectNetwork(entry.bank)
   const color = CARD_GRADIENTS[index % CARD_GRADIENTS.length]
 
   return (
@@ -95,7 +94,7 @@ function InstallmentCard({
       <div className="flex justify-between items-start">
         <div className="min-w-0 flex-1">
           <p className="text-white/70 text-[11px] font-medium tracking-widest uppercase truncate">{entry.bank || 'Banco'}</p>
-          <p className="text-white text-sm font-semibold tracking-wide truncate">{entry.card_name || entry.bank}</p>
+          <p className="text-white text-sm font-semibold tracking-wide truncate">{entry.bank}</p>
         </div>
         <div className="flex-shrink-0 ml-2">
           <CardNetworkLogo network={network} />
@@ -183,7 +182,7 @@ export default function InstallmentsPage() {
   for (const g of activeGroups) {
     const key = g.card_id ? `card_${g.card_id}` : `bank_person_${g.bank}|${g.person}`
     if (!cardMap.has(key)) {
-      cardMap.set(key, { key, card_id: g.card_id, card_name: g.card_name_from_id, bank: g.bank, person: g.person, pendingTotal: 0, currency: g.currency })
+      cardMap.set(key, { key, card_id: g.card_id, bank: g.bank, person: g.person, pendingTotal: 0, currency: g.currency })
     }
     cardMap.get(key)!.pendingTotal += g.installment_amount * g.remaining_installments
   }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -60,7 +60,7 @@ export interface Card {
   id: number
   card_name: string
   bank: string
-  holder?: string
+  holder: string
   card_type: string
   user_id: number
   created_at: string
@@ -186,7 +186,6 @@ export interface InstallmentGroup {
   currency: string
   card: string
   card_id: number | null
-  card_name_from_id: string | null
 }
 
 export interface ScheduledExpense {
@@ -209,7 +208,6 @@ export interface CardSummary {
   holder: string
   bank: string
   card_name: string
-  card_name_from_id?: string
   card_type: string
   total_amount: number
   count: number
@@ -273,13 +271,12 @@ export interface DetectedCard {
 }
 
 export interface CardsMappingEntry {
-  custom_naming: string
   bank?: string
   card_name?: string
 }
 
 export interface CardsMapping {
-  [key: string]: CardsMappingEntry  // key: "bank|card|holder" -> value: { custom_naming, bank?, card_name? }
+  [key: string]: CardsMappingEntry  // key: "bank|card|holder" -> value: { bank?, card_name? }
 }
 
 export interface ImportSummary {


### PR DESCRIPTION
## Changes
- Backend: Card model field name→card_name to match DB schema
- Backend: removed custom_naming column from Card model and schemas
- Backend: import flows match cards by card_name+bank+holder instead of custom_naming
- Frontend: updated Card interface, API client, and all components
- Frontend: replaced customNaming/name state with single cardName field
- Fixes 'column cards.name does not exist' SQLAlchemy error