### PR TITLE
feat: Deploy to Linode with GitHub Actions + Podman

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,8 +7,8 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  BACKEND_IMAGE: ghcr.io/${{ github.repository }}/backend
-  FRONTEND_IMAGE: ghcr.io/${{ github.repository }}/frontend
+  BACKEND_IMAGE: ghcr.io/${{ github.repository_owner }}/perexp/backend
+  FRONTEND_IMAGE: ghcr.io/${{ github.repository_owner }}/perexp/frontend
 
 jobs:
   build-and-push:


### PR DESCRIPTION
## Descripción

Pipeline completo de CI/CD para deployar a un server Linode con Fedora 43 usando Podman.

### Cambios principales

#### GitHub Actions Workflow ()
- Build de backend y frontend images
- Push a GitHub Container Registry (ghcr.io)
- SSH al server para instalar podman/podman-compose y deployar
- Parse  JSON →  file

#### CI Workflow ()
- Solo ejecuta en PRs (no después de merge a main)

#### Secrets Management
- Un solo secret  en formato JSON
- Variables SEED_USER removidas

#### Favicon GNOME Style
- Nuevo favicon minimalista estilo GNOME
- Versión dark con 

#### LoginForm + RegisterForm GNOME HIG
- Labels posicionados arriba de inputs
- Spacing  (12px) entre campos
- Helper text debajo de inputs relevantes

### Secrets necesarios en GitHub

| Secret | Descripción |
|--------|-------------|
|  | IP del server Linode |
|  | Usuario SSH |
|  | Private key SSH (ED25519) |
|  | JSON con todas las variables |

### JSON para APP_SECRETS



### Para crear el primer usuario después del deploy



### Checklist
- [ ] Configurar secrets en GitHub Repository Settings
- [ ] Subir  (private key)
- [ ] Subir  (JSON completo)
- [ ] Hacer push a main para triggerar el deploy
- [ ] Crear primer usuario via API