### PR TITLE
fix: Use correct SSH port 43422 for Linode server

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -64,6 +64,7 @@ jobs:
           host: ${{ secrets.LINODE_SERVER_IP }}
           username: ${{ secrets.LINODE_SSH_USER }}
           key: ${{ secrets.LINODE_SSH_KEY }}
+          port: 43422
           script: |
             # Install podman if not exists
             if ! command -v podman &> /dev/null; then


### PR DESCRIPTION
## Fix SSH Port

El server Linode usa el puerto SSH 43422 en lugar del puerto por defecto 22.

### Cambio
- Agregado  al step de SSH en el workflow de deploy

### Verificación
- El workflow debería conectarse correctamente al server Linode