### PR TITLE
fix: Use strict=False for JSON parsing

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -182,7 +182,8 @@ jobs:
             python3 -c "
             import json, sys
             with open('/tmp/secrets.json') as f:
-                data = json.load(f)
+                content = f.read()
+            data = json.loads(content, strict=False)
             for k, v in data.items():
                 print(f'{k}={v}')
             " >> /opt/creditcardanalyzer/.env


### PR DESCRIPTION
Allow control characters in JSON by using strict=False