### PR TITLE
fix: Remove backend port exposure for security

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -148,8 +148,6 @@ jobs:
                   GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID}
                   GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET}
                   SECRET_KEY: ${SECRET_KEY}
-                ports:
-                  - "8000:8000"
                 restart: unless-stopped
 
               celery_worker:


### PR DESCRIPTION
Backend should only be accessible via frontend nginx proxy, not directly from internet