### PR TITLE
feat(auth): add password recovery with Resend email

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -154,6 +154,8 @@ jobs:
                   GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID}
                   GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET}
                   SECRET_KEY: ${SECRET_KEY}
+                  RESEND_API_KEY: ${RESEND_API_KEY}
+                  FRONTEND_URL: https://expensas.chelo.ar
                 restart: unless-stopped
 
               celery_worker:

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -33,6 +33,8 @@ class User(Base):
     provider = Column(String, nullable=True)
     provider_id = Column(String, nullable=True, index=True)
     avatar_url = Column(String, nullable=True)
+    reset_token = Column(String(64), nullable=True, unique=True, index=True)
+    reset_token_expires = Column(DateTime, nullable=True)
 
 
 class Group(Base):

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -1,6 +1,7 @@
 import os
 import secrets
 import string
+from datetime import datetime, timedelta
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel
@@ -10,8 +11,10 @@ from app.database import get_db
 from app.models import User
 from app.schemas import (
     ChangePasswordRequest,
+    ForgotPasswordRequest,
     LoginRequest,
     OAuthRequest,
+    ResetPasswordRequest,
     Token,
     UserCreate,
     UserResponse,
@@ -24,6 +27,7 @@ from app.services.auth import (
     verify_google_token,
     verify_password,
 )
+from app.services.email import send_password_reset_email
 
 router = APIRouter(prefix="/auth", tags=["auth"])
 
@@ -256,3 +260,46 @@ def get_telegram_status(
 @router.post("/refresh", response_model=Token)
 def refresh_token(current_user: User = Depends(get_current_user)):
     return Token(access_token=create_access_token(current_user.id), token_type="bearer")
+
+
+RESET_TOKEN_EXPIRY_MINUTES = 15
+
+
+@router.post("/forgot-password", status_code=status.HTTP_200_OK)
+def forgot_password(body: ForgotPasswordRequest, db: Session = Depends(get_db)):
+    user = db.query(User).filter(User.email == body.email.lower().strip()).first()
+    if not user:
+        return {"detail": "Si el email existe, recibirás un enlace para restablecer tu contraseña"}
+
+    token = secrets.token_hex(32)
+    user.reset_token = token
+    user.reset_token_expires = datetime.utcnow() + timedelta(minutes=RESET_TOKEN_EXPIRY_MINUTES)
+    db.commit()
+
+    base_url = os.getenv("FRONTEND_URL", "http://localhost:8082")
+    send_password_reset_email(user.email, token, base_url)
+
+    return {"detail": "Si el email existe, recibirás un enlace para restablecer tu contraseña"}
+
+
+@router.post("/reset-password", status_code=status.HTTP_200_OK)
+def reset_password(body: ResetPasswordRequest, db: Session = Depends(get_db)):
+    user = db.query(User).filter(User.reset_token == body.token).first()
+    if not user:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Token inválido o expirado",
+        )
+
+    if user.reset_token_expires and user.reset_token_expires < datetime.utcnow():
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Token inválido o expirado",
+        )
+
+    user.hashed_password = get_password_hash(body.new_password)
+    user.reset_token = None
+    user.reset_token_expires = None
+    db.commit()
+
+    return {"detail": "Contraseña actualizada correctamente"}

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -73,6 +73,28 @@ class ChangePasswordRequest(BaseModel):
         return v
 
 
+class ForgotPasswordRequest(BaseModel):
+    email: str
+
+
+class ResetPasswordRequest(BaseModel):
+    token: str
+    new_password: str
+
+    @field_validator("new_password")
+    @classmethod
+    def validate_new_password(cls, v: str) -> str:
+        if len(v) < 8:
+            raise ValueError("La contraseña debe tener al menos 8 caracteres")
+        if not any(c.isupper() for c in v):
+            raise ValueError("La contraseña debe contener al menos una mayúscula")
+        if not any(c.islower() for c in v):
+            raise ValueError("La contraseña debe contener al menos una minúscula")
+        if not any(c.isdigit() for c in v):
+            raise ValueError("La contraseña debe contener al menos un número")
+        return v
+
+
 class InvestmentCreate(BaseModel):
     ticker: str = ""
     name: str = ""

--- a/backend/app/services/email.py
+++ b/backend/app/services/email.py
@@ -1,0 +1,52 @@
+import logging
+import os
+
+import resend
+
+logger = logging.getLogger(__name__)
+
+resend_api_key = os.getenv("RESEND_API_KEY")
+if resend_api_key:
+    resend.api_key = resend_api_key
+
+FROM_EMAIL = os.getenv("SMTP_FROM", "Financial Planning <onboarding@resend.dev>")
+
+
+def send_password_reset_email(to: str, token: str, base_url: str) -> bool:
+    if not resend_api_key:
+        logger.warning("RESEND_API_KEY not set — cannot send password reset email")
+        return False
+
+    reset_url = f"{base_url}/reset-password?token={token}"
+
+    html = f"""
+    <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; max-width: 480px; margin: 0 auto; padding: 32px;">
+      <div style="text-align: center; margin-bottom: 32px;">
+        <div style="display: inline-block; width: 48px; height: 48px; border-radius: 8px; background: #3b82f6; color: white; font-weight: bold; font-size: 20px; line-height: 48px;">F</div>
+      </div>
+      <h1 style="font-size: 20px; font-weight: 600; color: #1a1a1a; margin-bottom: 8px;">Restablecer contraseña</h1>
+      <p style="color: #666; font-size: 14px; line-height: 1.5; margin-bottom: 24px;">
+        Recibimos una solicitud para restablecer tu contraseña en Financial Planning. Haz clic en el botón de abajo para elegir una nueva contraseña.
+      </p>
+      <div style="text-align: center; margin-bottom: 24px;">
+        <a href="{reset_url}" style="display: inline-block; padding: 12px 24px; background: #3b82f6; color: white; text-decoration: none; border-radius: 6px; font-weight: 500; font-size: 14px;">Restablecer contraseña</a>
+      </div>
+      <p style="color: #999; font-size: 12px; line-height: 1.5;">
+        Este enlace expira en 15 minutos. Si no solicitaste este cambio, podés ignorar este email.
+      </p>
+    </div>
+    """
+
+    try:
+        params: resend.Emails.SendParams = {
+            "from": FROM_EMAIL,
+            "to": [to],
+            "subject": "Restablecer contraseña — Financial Planning",
+            "html": html,
+        }
+        result = resend.Emails.send(params)
+        logger.info(f"Password reset email sent to {to}: {result}")
+        return True
+    except Exception as e:
+        logger.error(f"Failed to send password reset email to {to}: {e}")
+        return False

--- a/backend/docker-entrypoint.sh
+++ b/backend/docker-entrypoint.sh
@@ -30,6 +30,7 @@ load_secret "TELEGRAM_BOT_TOKEN" "creditcard_backend_telegram_bot_token" "credit
 load_secret "GOOGLE_CLIENT_ID" "creditcard_backend_google_client_id" "creditcard_backend_dev_google_client_id"
 load_secret "GOOGLE_CLIENT_SECRET" "creditcard_backend_google_client_secret" "creditcard_backend_dev_google_client_secret"
 load_secret "SECRET_KEY" "creditcard_backend_secret_key" "creditcard_backend_dev_secret_key"
+load_secret "RESEND_API_KEY" "creditcard_backend_resend_api_key" "creditcard_backend_dev_resend_api_key"
 
 # Create database indices if needed (idempotent - safe to run multiple times)
 echo "Checking database indices..."

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -23,3 +23,6 @@ alembic>=1.13.0
 # Celery + Redis
 celery>=5.4.0
 redis>=5.0.0
+
+# Email (password recovery)
+resend>=2.0.0

--- a/backend/scripts/migrate_add_reset_token.py
+++ b/backend/scripts/migrate_add_reset_token.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""
+Migration: Add reset_token and reset_token_expires columns to users table.
+
+Run with: python -m scripts.migrate_add_reset_token
+"""
+
+import os
+import sys
+
+from sqlalchemy import create_engine, text
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+def get_engine():
+    db_url = os.getenv("DATABASE_URL")
+    if not db_url:
+        raise RuntimeError("DATABASE_URL env var not set. Aborting.")
+    if db_url.startswith("postgres://"):
+        db_url = db_url.replace("postgres://", "postgresql://", 1)
+    print(f"Connecting to: {db_url.split('@')[1] if '@' in db_url else db_url}")
+    return create_engine(db_url)
+
+
+def main():
+    engine = get_engine()
+
+    print("=" * 60)
+    print("Migration: Add password reset token columns to users")
+    print("=" * 60)
+
+    with engine.begin() as conn:
+        dialect = engine.dialect.name
+
+        if dialect == "postgresql":
+            # Check if columns already exist
+            exists = conn.execute(text("""
+                SELECT EXISTS (
+                    SELECT 1 FROM information_schema.columns
+                    WHERE table_name = 'users' AND column_name = 'reset_token'
+                )
+            """)).scalar()
+
+            if exists:
+                print("Columns already exist. Skipping.")
+            else:
+                print("Adding reset_token column...")
+                conn.execute(text("""
+                    ALTER TABLE users
+                    ADD COLUMN reset_token VARCHAR(64) UNIQUE
+                """))
+
+                print("Adding reset_token_expires column...")
+                conn.execute(text("""
+                    ALTER TABLE users
+                    ADD COLUMN reset_token_expires TIMESTAMP
+                """))
+
+                print("Creating index on reset_token...")
+                conn.execute(text("""
+                    CREATE INDEX ix_users_reset_token ON users (reset_token)
+                """))
+
+                print("Migration complete!")
+        else:
+            print(f"Skipping migration for dialect '{dialect}' (PostgreSQL only).")
+
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    main()

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -23,6 +23,7 @@ const CategoryDashboard = lazy(() => import("./pages/CategoryDashboard"));
 const InstallmentsPage = lazy(() => import("./pages/InstallmentsPage"));
 const InvestmentsPage = lazy(() => import("./pages/InvestmentsPage"));
 const LoginPage = lazy(() => import("./pages/LoginPage"));
+const ResetPasswordPage = lazy(() => import("./pages/ResetPasswordPage"));
 
 const TABS = [
   { path: "/", label: "Inicio", icon: "home", exact: true },
@@ -54,6 +55,8 @@ export default function App() {
   const location = useLocation();
 
   if (location.pathname === "/login") return <LoginPage />;
+
+  if (location.pathname === "/reset-password") return <ResetPasswordPage />;
 
   if (!getStoredToken()) return <Navigate to="/login" replace />;
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -69,6 +69,12 @@ export const getMe = () => api.get<User>("/auth/me").then((r) => r.data);
 export const changePassword = (current_password: string, new_password: string) =>
   api.put("/auth/password", { current_password, new_password });
 
+export const forgotPassword = (email: string) =>
+  api.post("/auth/forgot-password", { email }).then((r) => r.data);
+
+export const resetPassword = (token: string, new_password: string) =>
+  api.post("/auth/reset-password", { token, new_password }).then((r) => r.data);
+
 export const getTelegramKey = () =>
   api.get<{ telegram_key: string }>("/auth/me/telegram-key").then((r) => r.data);
 export const getTelegramStatus = () =>
@@ -199,9 +205,9 @@ export const getInstallmentsDashboard = () =>
 
 export const getInstallmentsMonthlyLoad = () =>
   api
-    .get<
-      { month: string; total: number; count: number; is_past: boolean; is_current: boolean }[]
-    >("/dashboard/installments/monthly-load")
+    .get<{ month: string; total: number; count: number; is_past: boolean; is_current: boolean }[]>(
+      "/dashboard/installments/monthly-load",
+    )
     .then((r) => r.data);
 
 export const getScheduledSummary = () =>
@@ -434,9 +440,10 @@ export const fetchUsdRate = () =>
 
 export const lookupSymbols = (symbols: string[]) =>
   api
-    .get<
-      Record<string, { symbol: string; name: string; price: number | null; currency: string }>
-    >("/investments/lookup-batch", { params: { symbols: symbols.join(",") } })
+    .get<Record<string, { symbol: string; name: string; price: number | null; currency: string }>>(
+      "/investments/lookup-batch",
+      { params: { symbols: symbols.join(",") } },
+    )
     .then((r) => r.data);
 
 export const deleteInvestment = (id: number) =>
@@ -475,9 +482,9 @@ export const refreshManualPrices = () =>
 
 export const getManualCashBalances = () =>
   api
-    .get<
-      Record<string, { ars: number | null; usd: number | null }>
-    >("/investments/manual-cash-balances")
+    .get<Record<string, { ars: number | null; usd: number | null }>>(
+      "/investments/manual-cash-balances",
+    )
     .then((r) => r.data);
 
 export const putManualCashBalance = (broker: string, ars: number | null, usd: number | null) =>

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -205,9 +205,9 @@ export const getInstallmentsDashboard = () =>
 
 export const getInstallmentsMonthlyLoad = () =>
   api
-    .get<{ month: string; total: number; count: number; is_past: boolean; is_current: boolean }[]>(
-      "/dashboard/installments/monthly-load",
-    )
+    .get<
+      { month: string; total: number; count: number; is_past: boolean; is_current: boolean }[]
+    >("/dashboard/installments/monthly-load")
     .then((r) => r.data);
 
 export const getScheduledSummary = () =>
@@ -440,10 +440,9 @@ export const fetchUsdRate = () =>
 
 export const lookupSymbols = (symbols: string[]) =>
   api
-    .get<Record<string, { symbol: string; name: string; price: number | null; currency: string }>>(
-      "/investments/lookup-batch",
-      { params: { symbols: symbols.join(",") } },
-    )
+    .get<
+      Record<string, { symbol: string; name: string; price: number | null; currency: string }>
+    >("/investments/lookup-batch", { params: { symbols: symbols.join(",") } })
     .then((r) => r.data);
 
 export const deleteInvestment = (id: number) =>
@@ -482,9 +481,9 @@ export const refreshManualPrices = () =>
 
 export const getManualCashBalances = () =>
   api
-    .get<Record<string, { ars: number | null; usd: number | null }>>(
-      "/investments/manual-cash-balances",
-    )
+    .get<
+      Record<string, { ars: number | null; usd: number | null }>
+    >("/investments/manual-cash-balances")
     .then((r) => r.data);
 
 export const putManualCashBalance = (broker: string, ars: number | null, usd: number | null) =>

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,10 +1,10 @@
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { login, register, storeToken } from "../api/client";
+import { forgotPassword, login, register, storeToken } from "../api/client";
 
 export default function LoginPage() {
   const navigate = useNavigate();
-  const [mode, setMode] = useState<"login" | "register">("login");
+  const [mode, setMode] = useState<"login" | "register" | "forgot">("login");
 
   return (
     <div className="min-h-screen bg-base flex items-center justify-center px-4">
@@ -18,17 +18,31 @@ export default function LoginPage() {
           </h1>
         </div>
 
-        {mode === "login" ? (
-          <LoginForm onRegister={() => setMode("register")} onSuccess={() => navigate("/")} />
-        ) : (
+        {mode === "login" && (
+          <LoginForm
+            onRegister={() => setMode("register")}
+            onForgotPassword={() => setMode("forgot")}
+            onSuccess={() => navigate("/")}
+          />
+        )}
+        {mode === "register" && (
           <RegisterForm onLogin={() => setMode("login")} onSuccess={() => navigate("/")} />
         )}
+        {mode === "forgot" && <ForgotPasswordForm onBack={() => setMode("login")} />}
       </div>
     </div>
   );
 }
 
-function LoginForm({ onRegister, onSuccess }: { onRegister: () => void; onSuccess: () => void }) {
+function LoginForm({
+  onRegister,
+  onForgotPassword,
+  onSuccess,
+}: {
+  onRegister: () => void;
+  onForgotPassword: () => void;
+  onSuccess: () => void;
+}) {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
@@ -85,6 +99,16 @@ function LoginForm({ onRegister, onSuccess }: { onRegister: () => void; onSucces
           />
         </div>
 
+        <div className="flex justify-end">
+          <button
+            type="button"
+            onClick={onForgotPassword}
+            className="text-xs text-[var(--color-primary)] hover:underline"
+          >
+            ¿Olvidaste tu contraseña?
+          </button>
+        </div>
+
         {error && <div className="alert-error">{error}</div>}
 
         <button type="submit" disabled={loading} className="gnome-btn-primary w-full mt-1">
@@ -102,6 +126,120 @@ function LoginForm({ onRegister, onSuccess }: { onRegister: () => void; onSucces
           Registrarse
         </button>
       </p>
+    </div>
+  );
+}
+
+function ForgotPasswordForm({ onBack }: { onBack: () => void }) {
+  const [email, setEmail] = useState("");
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [sent, setSent] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError("");
+    setLoading(true);
+    try {
+      await forgotPassword(email.trim().toLowerCase());
+      setSent(true);
+    } catch (err: any) {
+      const detail = err?.response?.data?.detail;
+      setError(typeof detail === "string" ? detail : "Error al enviar el email. Intentá de nuevo.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="bg-[var(--color-surface)] border border-[var(--border-color)] rounded-lg shadow-gnome p-6 flex flex-col gap-4">
+      <div className="flex items-center justify-between">
+        <button
+          type="button"
+          onClick={onBack}
+          className="text-sm text-[var(--text-secondary)] hover:text-[var(--text-primary)] transition flex items-center gap-1"
+        >
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+            <path
+              d="M10 12L6 8l4-4"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+          Volver
+        </button>
+      </div>
+
+      {sent ? (
+        <div className="text-center py-4">
+          <div className="w-12 h-12 rounded-full bg-[var(--green-5,#26a269)]/10 flex items-center justify-center mx-auto mb-3">
+            <svg
+              width="24"
+              height="24"
+              viewBox="0 0 24 24"
+              fill="none"
+              className="text-[var(--green-5,#26a269)]"
+            >
+              <path
+                d="M5 13l4 4L19 7"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+          </div>
+          <h2 className="text-lg font-semibold text-[var(--text-primary)] mb-2">Email enviado</h2>
+          <p className="text-sm text-[var(--text-secondary)] mb-4">
+            Si el email <strong>{email}</strong> está registrado, recibirás un enlace para
+            restablecer tu contraseña.
+          </p>
+          <button type="button" onClick={onBack} className="gnome-btn-primary w-full">
+            Volver al inicio de sesión
+          </button>
+        </div>
+      ) : (
+        <>
+          <div>
+            <h2 className="text-lg font-semibold text-[var(--text-primary)]">
+              Restablecer contraseña
+            </h2>
+            <p className="text-sm text-[var(--text-secondary)] mt-1">
+              Ingresá tu email y te enviaremos un enlace para crear una nueva contraseña.
+            </p>
+          </div>
+
+          <form onSubmit={handleSubmit} className="flex flex-col gap-3">
+            <div className="flex flex-col gap-1">
+              <label
+                className="text-sm font-medium text-[var(--text-primary)]"
+                htmlFor="forgot-email"
+              >
+                Correo electrónico
+              </label>
+              <input
+                id="forgot-email"
+                type="email"
+                inputMode="email"
+                autoComplete="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                placeholder="tu@email.com"
+                required
+                className="input"
+              />
+            </div>
+
+            {error && <div className="alert-error">{error}</div>}
+
+            <button type="submit" disabled={loading} className="gnome-btn-primary w-full mt-1">
+              {loading ? "Enviando..." : "Enviar enlace"}
+            </button>
+          </form>
+        </>
+      )}
     </div>
   );
 }

--- a/frontend/src/pages/ResetPasswordPage.tsx
+++ b/frontend/src/pages/ResetPasswordPage.tsx
@@ -1,0 +1,196 @@
+import { useState } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
+import { resetPassword } from "../api/client";
+
+export default function ResetPasswordPage() {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const token = searchParams.get("token");
+
+  const [password, setPassword] = useState("");
+  const [confirm, setConfirm] = useState("");
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [success, setSuccess] = useState(false);
+
+  if (!token) {
+    return (
+      <div className="min-h-screen bg-base flex items-center justify-center px-4">
+        <div className="w-full max-w-sm">
+          <div className="flex flex-col items-center mb-8 gap-3">
+            <div className="w-12 h-12 rounded-lg bg-[var(--color-primary)] text-white flex items-center justify-center font-bold text-xl shadow-gnome">
+              F
+            </div>
+            <h1 className="text-2xl font-bold text-[var(--text-primary)] tracking-tight">
+              Financial <span className="text-[var(--color-primary)]">Planning</span>
+            </h1>
+          </div>
+          <div className="bg-[var(--color-surface)] border border-[var(--border-color)] rounded-lg shadow-gnome p-6 text-center">
+            <h2 className="text-lg font-semibold text-[var(--text-primary)] mb-2">
+              Enlace inválido
+            </h2>
+            <p className="text-sm text-[var(--text-secondary)] mb-4">
+              El enlace para restablecer la contraseña no es válido o ya fue utilizado.
+            </p>
+            <button
+              type="button"
+              onClick={() => navigate("/login")}
+              className="gnome-btn-primary w-full"
+            >
+              Ir al inicio de sesión
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError("");
+
+    if (password !== confirm) {
+      setError("Las contraseñas no coinciden");
+      return;
+    }
+    if (password.length < 8) {
+      setError("Mínimo 8 caracteres");
+      return;
+    }
+    if (!/[A-Z]/.test(password)) {
+      setError("Debe contener al menos una mayúscula");
+      return;
+    }
+    if (!/[a-z]/.test(password)) {
+      setError("Debe contener al menos una minúscula");
+      return;
+    }
+    if (!/[0-9]/.test(password)) {
+      setError("Debe contener al menos un número");
+      return;
+    }
+
+    setLoading(true);
+    try {
+      await resetPassword(token, password);
+      setSuccess(true);
+    } catch (err: any) {
+      const detail = err?.response?.data?.detail;
+      setError(typeof detail === "string" ? detail : "Error al restablecer la contraseña");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-base flex items-center justify-center px-4">
+      <div className="w-full max-w-sm">
+        <div className="flex flex-col items-center mb-8 gap-3">
+          <div className="w-12 h-12 rounded-lg bg-[var(--color-primary)] text-white flex items-center justify-center font-bold text-xl shadow-gnome">
+            F
+          </div>
+          <h1 className="text-2xl font-bold text-[var(--text-primary)] tracking-tight">
+            Financial <span className="text-[var(--color-primary)]">Planning</span>
+          </h1>
+        </div>
+
+        <div className="bg-[var(--color-surface)] border border-[var(--border-color)] rounded-lg shadow-gnome p-6 flex flex-col gap-4">
+          {success ? (
+            <div className="text-center py-4">
+              <div className="w-12 h-12 rounded-full bg-[var(--green-5,#26a269)]/10 flex items-center justify-center mx-auto mb-3">
+                <svg
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  className="text-[var(--green-5,#26a269)]"
+                >
+                  <path
+                    d="M5 13l4 4L19 7"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                </svg>
+              </div>
+              <h2 className="text-lg font-semibold text-[var(--text-primary)] mb-2">
+                Contraseña actualizada
+              </h2>
+              <p className="text-sm text-[var(--text-secondary)] mb-4">
+                Tu contraseña fue restablecida correctamente. Ya podés iniciar sesión con tu nueva
+                contraseña.
+              </p>
+              <button
+                type="button"
+                onClick={() => navigate("/login")}
+                className="gnome-btn-primary w-full"
+              >
+                Iniciar sesión
+              </button>
+            </div>
+          ) : (
+            <>
+              <div>
+                <h2 className="text-lg font-semibold text-[var(--text-primary)]">
+                  Nueva contraseña
+                </h2>
+                <p className="text-sm text-[var(--text-secondary)] mt-1">
+                  Elegí una nueva contraseña para tu cuenta.
+                </p>
+              </div>
+
+              <form onSubmit={handleSubmit} className="flex flex-col gap-3">
+                <div className="flex flex-col gap-1">
+                  <label
+                    className="text-sm font-medium text-[var(--text-primary)]"
+                    htmlFor="new-password"
+                  >
+                    Nueva contraseña
+                  </label>
+                  <input
+                    id="new-password"
+                    type="password"
+                    name="new-password"
+                    autoComplete="new-password"
+                    value={password}
+                    onChange={(e) => setPassword(e.target.value)}
+                    placeholder="Mínimo 8 caracteres"
+                    required
+                    className="input"
+                  />
+                </div>
+
+                <div className="flex flex-col gap-1">
+                  <label
+                    className="text-sm font-medium text-[var(--text-primary)]"
+                    htmlFor="confirm-password"
+                  >
+                    Confirmar contraseña
+                  </label>
+                  <input
+                    id="confirm-password"
+                    type="password"
+                    name="new-password"
+                    autoComplete="new-password"
+                    value={confirm}
+                    onChange={(e) => setConfirm(e.target.value)}
+                    placeholder="••••••••"
+                    required
+                    className="input"
+                  />
+                </div>
+
+                {error && <div className="alert-error">{error}</div>}
+
+                <button type="submit" disabled={loading} className="gnome-btn-primary w-full mt-1">
+                  {loading ? "Guardando..." : "Restablecer contraseña"}
+                </button>
+              </form>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/podman-compose.yml
+++ b/podman-compose.yml
@@ -49,6 +49,7 @@ services:
       - creditcard_backend_dev_google_client_id
       - creditcard_backend_dev_google_client_secret
       - creditcard_backend_dev_secret_key
+      - creditcard_backend_dev_resend_api_key
     environment:
       PYTHONPATH: /app
       DATABASE_URL: postgresql://expenses_user:${POSTGRES_PASSWORD_DEV}@db:5432/expenses
@@ -144,6 +145,9 @@ secrets:
   creditcard_backend_dev_secret_key:
     external: true
     env: SECRET_KEY_DEV
+  creditcard_backend_dev_resend_api_key:
+    external: true
+    env: RESEND_API_KEY_DEV
   creditcard_frontend_dev_google_client_id:
     external: true
     env: GOOGLE_CLIENT_ID_DEV


### PR DESCRIPTION
## Summary

Adds a complete password recovery flow using Resend API for email delivery.

### User Flow
1. User clicks 'Olvidaste tu contraseña?' on login form
2. Inline email input appears (no page navigation)
3. User submits email → backend generates 15min token, sends email via Resend
4. User sees 'Te enviamos un email' confirmation
5. User clicks link in email → goes to /reset-password?token=xxx
6. User enters new password → backend validates token, updates password

### Backend Changes
- Add  and  columns to User model
- Add  endpoint (generates token, sends email, prevents enumeration)
- Add  endpoint (validates token + expiry, updates password)
- Add email service using Resend API
- Add migration script for reset token columns

### Frontend Changes
- Add '¿Olvidaste tu contraseña?' link to login form
- Add inline ForgotPasswordForm component with email input and success state
- Add /reset-password page for setting new password via token
- Add forgotPassword and resetPassword API client functions

### Config Changes
- Add RESEND_API_KEY to podman-compose, docker-entrypoint, deploy.yml
- Add FRONTEND_URL to deploy.yml for reset link generation

### Security
- Token is 32-char random (secrets module), expires in 15 minutes
- Always returns 200 for forgot-password (prevents email enumeration)
- Token is single-use (invalidated after reset)
- Password validation matches existing rules (8 chars, uppercase, lowercase, digit)