### PR TITLE
fix(notifications): force SSE refresh after import confirmation

### DIFF
--- a/frontend/src/pages/ImportJobPreview.tsx
+++ b/frontend/src/pages/ImportJobPreview.tsx
@@ -7,11 +7,13 @@ import { formatCurrency } from "../utils/format";
 import { useModalWithData } from "../hooks/useModal";
 import { TransactionDetailModal } from "../components/TransactionDetailModal";
 import { Select } from "../components/ui/Select";
+import { useNotifications } from "../context/NotificationsContext";
 
 export default function ImportJobPreview() {
   const { jobId } = useParams<{ jobId: string }>();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
+  const { refresh } = useNotifications();
 
   const [showDiscardModal, setShowDiscardModal] = useState(false);
   const [showResultModal, setShowResultModal] = useState(false);

--- a/frontend/src/pages/ImportJobPreview.tsx
+++ b/frontend/src/pages/ImportJobPreview.tsx
@@ -62,6 +62,7 @@ export default function ImportJobPreview() {
       queryClient.invalidateQueries({ queryKey: ["cards"] });
       queryClient.invalidateQueries({ queryKey: ["notifications"] });
       queryClient.invalidateQueries({ queryKey: ["notifications-count"] });
+      refresh();
       setImportResult(result);
       setShowResultModal(true);
     },


### PR DESCRIPTION
Fix notification deletion delay after confirming import-job.

Problem: When confirming an import-job, the notification is deleted in the backend but the SSE stream doesn't detect deletions. The frontend keeps showing the stale notification until a manual refresh.

Fix: Add refresh() call in confirmMutation.onSuccess to force the SSE stream to re-fetch initial data after the notification is deleted.

Impact: 1 line added, no backend changes, immediate fix.

Files changed: frontend/src/pages/ImportJobPreview.tsx