### PR TITLE
fix(import): use LLM for CSV/XLSX + fix delimiter parsing

### DIFF
--- a/backend/app/tasks/import_processor.py
+++ b/backend/app/tasks/import_processor.py
@@ -29,11 +29,6 @@ redis_client = redis.from_url(os.getenv("REDIS_URL", "redis://localhost:6379/0")
 LOCK_TIMEOUT = 600
 
 
-def _is_structured_file(filename: str) -> bool:
-    """Check if file is CSV/XLSX (structured, no LLM needed)."""
-    return filename.lower().endswith((".csv", ".xls", ".xlsx"))
-
-
 @celery_app.task(name="app.tasks.import_processor.process_import_job")
 def process_import_job(job_id: int):
     """
@@ -64,37 +59,22 @@ def process_import_job(job_id: int):
 
         try:
             file_content = job.file_content
-            is_structured = _is_structured_file(job.filename)
 
-            if is_structured:
-                # CSV/XLSX: deterministic parsing (no LLM)
-                from app.services.csv_parser import run_deterministic_import
-
-                _log(f"[IMPORT JOB] Using deterministic parser for {job.filename}")
-                loop = asyncio.new_event_loop()
-                asyncio.set_event_loop(loop)
-                preview = loop.run_until_complete(
-                    run_deterministic_import(file_content, job.filename, db, job.user_id)
+            # Always use LLM-based parsing (works for PDF, CSV, XLSX)
+            _log(f"[IMPORT JOB] Processing {job.filename} with LLM")
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+            preview = loop.run_until_complete(
+                run_smart_import(
+                    file_content=file_content,
+                    filename=job.filename,
+                    db=db,
+                    user_id=job.user_id,
                 )
-                with suppress(RuntimeError):
-                    loop.close()
-                warnings.filterwarnings("ignore", message=".*Event loop is closed.*")
-            else:
-                # PDF: LLM-based parsing
-                _log(f"[IMPORT JOB] Using LLM parser for {job.filename}")
-                loop = asyncio.new_event_loop()
-                asyncio.set_event_loop(loop)
-                preview = loop.run_until_complete(
-                    run_smart_import(
-                        file_content=file_content,
-                        filename=job.filename,
-                        db=db,
-                        user_id=job.user_id,
-                    )
-                )
-                with suppress(RuntimeError):
-                    loop.close()
-                warnings.filterwarnings("ignore", message=".*Event loop is closed.*")
+            )
+            with suppress(RuntimeError):
+                loop.close()
+            warnings.filterwarnings("ignore", message=".*Event loop is closed.*")
             del file_content
             job.file_content = None
 


### PR DESCRIPTION
Fix CSV/XLSX import to use LLM instead of deterministic parser.

Changes:
- Use LLM for all file types (PDF, CSV, XLSX) - more reliable
- Fix _csv_split to auto-detect delimiter (tab, semicolon, comma)
- Fix _parse_amount to handle Argentine thousands separators

Benefits:
- More reliable across different bank formats
- Simpler code (removed deterministic parser branching)
- Cost: ~/usr/bin/zsh.003 per import

Files changed: backend/app/tasks/import_processor.py, backend/app/services/csv_parser.py