### PR TITLE
fix(import, dashboard): CSV/XLSX via LLM + transaction list height

### DIFF
--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -506,7 +506,7 @@ export default function Dashboard() {
         </div>
 
         {/* Right: Transacciones */}
-        <div className="card min-h-[200px] flex flex-col">
+        <div className="card min-h-[200px] max-h-[340px] flex flex-col">
           <div className="px-4 py-3 border-b border-border-color flex items-center justify-between flex-shrink-0">
             <h2 className="text-sm font-semibold text-primary">
               Transacciones — Mes corriente


### PR DESCRIPTION
Import fixes:
- Use LLM for all file types (PDF, CSV, XLSX) instead of deterministic parser
- Fix CSV delimiter detection (tab, semicolon, comma)
- Fix amount parsing for Argentine thousands separators

Dashboard fix:
- Limit transaction list height to 7-8 rows with max-h-[340px]

Files changed: backend/app/tasks/import_processor.py, backend/app/services/csv_parser.py, frontend/src/pages/Dashboard.tsx