### PR TITLE
feat: add billing period tracking and expense detail modals

### DIFF
--- a/Roadmap.md
+++ b/Roadmap.md
@@ -1,22 +1,29 @@
+
 # Bugs
+
+## Todo
+
 
 ## Fixed
 
-1. ~~el boton de eliminar todas las notificaciones no hace nada.~~ → Added `refresh()` call after `deleteAllRead` to force SSE re-sync
-2. ~~Cuando agregas una subcategoría deberia seleccionarte la categoria padre desde la que fue seleccionado~~ → Fixed `initial={editing.cat || undefined}` (was `editing.cat?.id` which is falsy for new subcategories)
-3. ~~En /main el graph de gastos por categoria puede crecer infinito~~ → Limited to top 7 categories + "Otros" grouping
-4. ~~Cuando abris un expense debería abrir un modal~~ → Added row-level click handler to open edit modal
-5. ~~Cuando creas tarjeta desde UserPanel, no debería decir Nombre sino Tarjeta~~ → Changed label to "Tarjeta" in AccountsManager, CardsManager, CardAccountModal
-6. ~~El boton de crear tarjeta desde Tarjetas de credito en /index te lleva a /accounts pero no te abre un modal para cargar~~ → Added "Crear tarjeta o cuenta" button to AccountsPage that opens CardAccountModal
-7. ~~En /expenses los gastos en USD aparecen como $~~ → Prefix USD with "USD " in formatCurrency (e.g., "USD $1,234.56")
-8. ~~No está estimando correctamente la "Deuda Tarjeta" — muestra en 0 cuando hay installments configurados~~ → Removed scheduled_date >= today filter, now includes ALL pending installments
-9. ~~Filtro by card/account en /expenses no funciona. No filtra.~~ → Fixed currentCuenta to use IDs instead of names, reconstruct Select value from URL params
-10. ~~Cuando cargas un gasto en Efectivo/Transferencia pero no tenes una cuenta que corresponda, debería abrirte el warning para crear un account~~ → Added warning when payMethod is 'cash' and no accounts exist, with 'Crear cuenta' button
-11. ~~Cuando estas seleccionando una categoría desde el modal de Create Expenses, debería permitir crear una categoría si no está la que buscamos~~ → Added createCategory API call in category onChange handler
+1. ~~Unable to add Main Categories.~~ → Fixed `parentCats` filter to show all root categories (removed `childParentIds.has(c.id)` requirement)
+2. ~~Unable to add expense from Telegram in caja_ahorro account.~~ → Added `_escape_md()` helper to escape Markdown special characters in LLM-generated descriptions
+3. ~~el boton de eliminar todas las notificaciones no hace nada.~~ → Added `refresh()` call after `deleteAllRead` to force SSE re-sync
+4. ~~Cuando agregas una subcategoría deberia seleccionarte la categoria padre desde la que fue seleccionado~~ → Fixed `initial={editing.cat || undefined}` (was `editing.cat?.id` which is falsy for new subcategories)
+5. ~~En /main el graph de gastos por categoria puede crecer infinito~~ → Limited to top 7 categories + "Otros" grouping
+6. ~~Cuando abris un expense debería abrir un modal~~ → Added row-level click handler to open edit modal
+7. ~~Cuando creas tarjeta desde UserPanel, no debería decir Nombre sino Tarjeta~~ → Changed label to "Tarjeta" in AccountsManager, CardsManager, CardAccountModal
+8. ~~El boton de crear tarjeta desde Tarjetas de credito en /index te lleva a /accounts pero no te abre un modal para cargar~~ → Added "Crear tarjeta o cuenta" button to AccountsPage that opens CardAccountModal
+9. ~~En /expenses los gastos en USD aparecen como $~~ → Prefix USD with "USD " in formatCurrency (e.g., "USD $1,234.56")
+10. ~~No está estimando correctamente la "Deuda Tarjeta" — muestra en 0 cuando hay installments configurados~~ → Removed scheduled_date >= today filter, now includes ALL pending installments
+11. ~~Filtro by card/account en /expenses no funciona. No filtra.~~ → Fixed currentCuenta to use IDs instead of names, reconstruct Select value from URL params
+12. ~~Cuando cargas un gasto en Efectivo/Transferencia pero no tenes una cuenta que corresponda, debería abrirte el warning para crear un account~~ → Added warning when payMethod is 'cash' and no accounts exist, with 'Crear cuenta' button
+13. ~~Cuando estas seleccionando una categoría desde el modal de Create Expenses, debería permitir crear una categoría si no está la que buscamos~~ → Added createCategory API call in category onChange handler
 
-# Roadmap
+# Features
 
-## Todo:
+## On-Going
+- ~~Allow edit card/account by clicking in that account in UserPanel --> Accounts, not only touching the 3 dots~~ → Made card/account rows clickable to enter edit mode; `···` menu now only shows Delete option
 
 ## Backlog:
  - Create Income module and integrate with dashboards. Effort High.

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -128,6 +128,7 @@ class Card(Base):
         String, default=""
     )  # Primer nombre del usuario (para agrupar en grupo familiar)
     card_type = Column(String, default="credito")  # credito, debito
+    closing_day = Column(Integer, nullable=True)  # Day of month card closes (1-31), NULL = use CardClosing records
     user_id = Column(Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
     created_at = Column(DateTime, default=datetime.utcnow)
 

--- a/backend/app/routers/billing.py
+++ b/backend/app/routers/billing.py
@@ -1,0 +1,105 @@
+from datetime import date
+
+from fastapi import APIRouter, Depends, Query
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from app.database import get_db
+from app.models import User
+from app.routers.groups import get_group_user_ids
+from app.services.auth import get_current_user
+from app.services.date_utils import (
+    get_billing_period_for_card,
+    get_billing_periods_history,
+    get_current_billing_periods,
+)
+
+router = APIRouter(prefix="/billing", tags=["billing"])
+
+
+class BillingPeriodResponse(BaseModel):
+    card_id: int
+    card_name: str
+    bank: str
+    holder: str
+    period_start: date | None = None
+    period_end: date | None = None
+    label: str | None = None
+    is_predicted: bool = False
+
+
+class BillingPeriodDetail(BaseModel):
+    start: date
+    end: date
+    label: str
+    is_predicted: bool = False
+
+
+@router.get("/current", response_model=list[BillingPeriodResponse])
+def current_billing_periods(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Get current billing period for each credit card."""
+    return get_current_billing_periods(db, current_user.id)
+
+
+@router.get("/periods", response_model=list[BillingPeriodDetail])
+def billing_periods(
+    card_id: int,
+    count: int = Query(default=6, ge=1, le=24),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Get last N billing periods for a specific card."""
+    uid_list = get_group_user_ids(current_user.id, db)
+
+    from app.models import Card
+
+    card = db.query(Card).filter(Card.id == card_id, Card.user_id.in_(uid_list)).first()
+    if not card:
+        return []
+
+    return get_billing_periods_history(card_id, count, db)
+
+
+@router.get("/period-for-date", response_model=BillingPeriodResponse)
+def period_for_date(
+    card_id: int,
+    ref_date: date = Query(default=None),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Get the billing period that contains a specific date for a card."""
+    if ref_date is None:
+        ref_date = date.today()
+
+    uid_list = get_group_user_ids(current_user.id, db)
+
+    from app.models import Card
+
+    card = db.query(Card).filter(Card.id == card_id, Card.user_id.in_(uid_list)).first()
+    if not card:
+        return None
+
+    period = get_billing_period_for_card(card_id, ref_date, db)
+    if period:
+        start, end = period
+        from app.services.date_utils import _format_period_label
+
+        return BillingPeriodResponse(
+            card_id=card.id,
+            card_name=card.card_name,
+            bank=card.bank,
+            holder=card.holder,
+            period_start=start,
+            period_end=end,
+            label=_format_period_label(start, end),
+        )
+
+    return BillingPeriodResponse(
+        card_id=card.id,
+        card_name=card.card_name,
+        bank=card.bank,
+        holder=card.holder,
+    )

--- a/backend/app/routers/cards.py
+++ b/backend/app/routers/cards.py
@@ -27,6 +27,7 @@ class CardCreate(BaseModel):
     bank: str = ""
     holder: str = ""
     card_type: str = "credito"  # credito, debito
+    closing_day: int | None = None  # Day of month card closes (1-31)
 
 
 class CardUpdate(BaseModel):
@@ -34,6 +35,7 @@ class CardUpdate(BaseModel):
     bank: str | None = None
     holder: str | None = None
     card_type: str | None = None
+    closing_day: int | None = None
 
 
 class CardResponse(BaseModel):
@@ -42,6 +44,7 @@ class CardResponse(BaseModel):
     bank: str
     holder: str
     card_type: str
+    closing_day: int | None = None
     user_id: int
     created_at: datetime
 
@@ -105,6 +108,7 @@ def create_card(
         bank=bank,
         holder=holder,
         card_type=card.card_type,
+        closing_day=card.closing_day,
         user_id=current_user.id,
     )
     db.add(db_card)

--- a/backend/app/routers/dashboard.py
+++ b/backend/app/routers/dashboard.py
@@ -52,8 +52,68 @@ def _load_cards_and_accounts(uid_list: list[int], expenses: list[Expense], db: S
     return cards_by_id, accounts_by_id
 
 
-def _apply_filters(q, month_val, search_val, person_val, cat_id_val, bank_val=None):
-    if month_val:
+def _apply_filters(q, month_val, search_val, person_val, cat_id_val, bank_val=None, billing_view=False, db=None, uid_list=None):
+    if billing_view and month_val and db and uid_list:
+        # Billing view: filter expenses per card using each card's billing period
+        from sqlalchemy import and_, or_
+
+        from app.services.date_utils import get_billing_period_for_card
+
+        try:
+            if "-" in month_val:
+                parts = month_val.split("-")
+                if len(parts[0]) == 4:
+                    y, m = int(parts[0]), int(parts[1])
+                else:
+                    m, y = int(parts[0]), int(parts[1])
+            else:
+                y, m = int(month_val[:4]), int(month_val[5:7])
+        except (ValueError, IndexError):
+            return q
+
+        ref_date = date(y, m, 15)  # Mid-month as reference
+
+        # Get all credit cards for the user
+        cards = db.query(Card).filter(Card.user_id.in_(uid_list), Card.card_type == "credito").all()
+
+        conditions = []
+        for card_item in cards:
+            period = get_billing_period_for_card(card_item.id, ref_date, db)
+            if period:
+                period_start, period_end = period
+                conditions.append(
+                    and_(
+                        Expense.card_id == card_item.id,
+                        Expense.date >= period_start,
+                        Expense.date <= period_end,
+                    )
+                )
+
+        # For expenses without a card, fall back to calendar month
+        fallback_start = date(y, m, 1)
+        fallback_end = date(y, m, monthrange(y, m)[1])
+        conditions.append(
+            and_(
+                Expense.card_id.is_(None),
+                Expense.date >= fallback_start,
+                Expense.date <= fallback_end,
+            )
+        )
+
+        # Include expenses on cards without billing period data
+        card_ids_with_periods = {c.id for c in cards if get_billing_period_for_card(c.id, ref_date, db)}
+        cards_without_periods = [c for c in cards if c.id not in card_ids_with_periods]
+        if cards_without_periods:
+            conditions.append(
+                and_(
+                    Expense.card_id.in_([c.id for c in cards_without_periods]),
+                    Expense.date >= fallback_start,
+                    Expense.date <= fallback_end,
+                )
+            )
+
+        q = q.filter(or_(*conditions))
+    elif month_val:
         try:
             if "-" in month_val:
                 parts = month_val.split("-")
@@ -86,6 +146,7 @@ def _apply_filters(q, month_val, search_val, person_val, cat_id_val, bank_val=No
 @router.get("/summary")
 def get_summary(
     month: str | None = None,
+    billing_view: bool = False,
     group_by: str = "month",
     search: str | None = None,
     person: str | None = None,
@@ -102,7 +163,7 @@ def get_summary(
         .filter(Expense.user_id.in_(uid_list))
     )
     expenses = (
-        _apply_filters(base_q, month, search, person, category_id, bank)
+        _apply_filters(base_q, month, search, person, category_id, bank, billing_view=billing_view, db=db, uid_list=uid_list)
         .order_by(desc(Expense.date))
         .all()
     )

--- a/backend/app/routers/expenses.py
+++ b/backend/app/routers/expenses.py
@@ -5,7 +5,7 @@ from datetime import date
 import pandas as pd
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
-from sqlalchemy import desc, func
+from sqlalchemy import and_, desc, func
 from sqlalchemy.orm import Session, joinedload
 
 from app.database import get_db
@@ -25,6 +25,7 @@ def get_expenses(
     date_from: date | None = None,
     date_to: date | None = None,
     month: str | None = None,
+    billing_view: bool = False,
     category_id: int | None = None,
     category_ids: str | None = None,
     uncategorized: bool = False,
@@ -49,7 +50,59 @@ def get_expenses(
         )
         .filter(Expense.user_id.in_(uid_list))
     )
-    if month:
+
+    if billing_view and month:
+        # Billing view: filter expenses per card using each card's billing period
+        from app.services.date_utils import get_billing_period_for_card
+
+        y, m = int(month[:4]), int(month[5:7])
+        ref_date = date(y, m, 15)  # Mid-month as reference to find the right period
+
+        # Get all credit cards for the user
+        cards = db.query(Card).filter(Card.user_id.in_(uid_list), Card.card_type == "credito").all()
+
+        # Build OR conditions for each card's billing period
+        from sqlalchemy import or_
+
+        conditions = []
+        for card_item in cards:
+            period = get_billing_period_for_card(card_item.id, ref_date, db)
+            if period:
+                period_start, period_end = period
+                conditions.append(
+                    and_(
+                        Expense.card_id == card_item.id,
+                        Expense.date >= period_start,
+                        Expense.date <= period_end,
+                    )
+                )
+
+        # For expenses without a card or with cards that have no billing period,
+        # fall back to calendar month
+        fallback_start = date(y, m, 1)
+        fallback_end = date(y, m, monthrange(y, m)[1])
+        conditions.append(
+            and_(
+                Expense.card_id.is_(None),
+                Expense.date >= fallback_start,
+                Expense.date <= fallback_end,
+            )
+        )
+
+        # Also include expenses on cards that have no billing period data
+        card_ids_with_periods = {c.id for c in cards if get_billing_period_for_card(c.id, ref_date, db)}
+        cards_without_periods = [c for c in cards if c.id not in card_ids_with_periods]
+        if cards_without_periods:
+            conditions.append(
+                and_(
+                    Expense.card_id.in_([c.id for c in cards_without_periods]),
+                    Expense.date >= fallback_start,
+                    Expense.date <= fallback_end,
+                )
+            )
+
+        q = q.filter(or_(*conditions))
+    elif month:
         try:
             y, m = int(month[:4]), int(month[5:7])
             q = q.filter(

--- a/backend/app/services/date_utils.py
+++ b/backend/app/services/date_utils.py
@@ -79,3 +79,200 @@ def add_months(dt: date, months: int) -> date:
     month = month % 12 + 1
     day = min(dt.day, cal_module.monthrange(year, month)[1])
     return dt.replace(year=year, month=month, day=day)
+
+
+def predict_next_closing(last_closing: date, days: int = 28) -> date:
+    """Predict next closing date using rolling cycle from last known closing."""
+    from datetime import timedelta
+    return last_closing + timedelta(days=days)
+
+
+def get_closing_day_approx(closing_day: int, ref_date: date) -> date:
+    """Get approximate closing date for a month using a fixed closing_day (1-31)."""
+    year, month = ref_date.year, ref_date.month
+    last_day = cal_module.monthrange(year, month)[1]
+    day = min(closing_day, last_day)
+    return date(year, month, day)
+
+
+def get_billing_period_for_card(card_id: int, ref_date: date, db) -> tuple[date, date] | None:
+    """
+    Get the billing period that contains ref_date for a specific card.
+    Uses CardClosing records when available, falls back to closing_day prediction.
+
+    Returns (period_start, period_end) or None if no data available.
+    """
+    from datetime import timedelta
+
+    from app.models import Card, CardClosing
+
+    card = db.query(Card).filter(Card.id == card_id).first()
+    if not card:
+        return None
+
+    # Get all closings for this card, ordered by date
+    closings = (
+        db.query(CardClosing)
+        .filter(CardClosing.card_id == card_id)
+        .order_by(CardClosing.closing_date.asc())
+        .all()
+    )
+
+    if closings:
+        # Find which period contains ref_date
+        for i, closing in enumerate(closings):
+            period_end = closing.closing_date
+            if i == 0:
+                # First closing - period start is unknown, use closing_date itself
+                period_start = period_end
+            else:
+                period_start = closings[i - 1].closing_date + timedelta(days=1)
+
+            if period_start <= ref_date <= period_end:
+                return (period_start, period_end)
+
+        # ref_date is after the last known closing - predict next period
+        last_closing = closings[-1].closing_date
+        predicted_next = predict_next_closing(last_closing)
+        period_start = last_closing + timedelta(days=1)
+
+        if ref_date <= predicted_next:
+            return (period_start, predicted_next)
+
+        # ref_date is even further - try to chain predictions
+        while ref_date > predicted_next:
+            period_start = predicted_next + timedelta(days=1)
+            predicted_next = predict_next_closing(predicted_next)
+            if ref_date <= predicted_next:
+                return (period_start, predicted_next)
+
+        return (period_start, predicted_next)
+
+    # No CardClosing records - use closing_day if available
+    if card.closing_day:
+        # Find the closing day that would contain ref_date
+        # A period with closing_day X runs from (X+1 of prev month) to (X of this month)
+        this_month_closing = get_closing_day_approx(card.closing_day, ref_date)
+        if ref_date <= this_month_closing:
+            # ref_date is before this month's closing, so it's in this period
+            prev_month = add_months(ref_date, -1)
+            period_start = get_closing_day_approx(card.closing_day, prev_month) + timedelta(days=1)
+            return (period_start, this_month_closing)
+        else:
+            # ref_date is after this month's closing, so it's in next period
+            next_month = add_months(ref_date, 1)
+            period_end = get_closing_day_approx(card.closing_day, next_month)
+            period_start = this_month_closing + timedelta(days=1)
+            return (period_start, period_end)
+
+    return None
+
+
+def get_billing_periods_history(card_id: int, count: int, db) -> list[dict]:
+    """
+    Return the last N billing periods for a card, using CardClosing records.
+    For the current (latest) period, predict the end date.
+
+    Returns list of {"start": date, "end": date, "label": str}
+    """
+    from datetime import timedelta
+
+    from app.models import CardClosing
+
+    closings = (
+        db.query(CardClosing)
+        .filter(CardClosing.card_id == card_id)
+        .order_by(CardClosing.closing_date.desc())
+        .limit(count)
+        .all()
+    )
+
+    if not closings:
+        return []
+
+    # Reverse to chronological order
+    closings = list(reversed(closings))
+
+    periods = []
+    for i, closing in enumerate(closings):
+        period_end = closing.closing_date
+        if i == 0:
+            # First closing - we don't know the period start
+            # Use previous closing if available, otherwise just use the closing date
+            period_start = period_end  # Will be adjusted if we have more history
+        else:
+            period_start = closings[i - 1].closing_date + timedelta(days=1)
+
+        label = _format_period_label(period_start, period_end)
+        periods.append({"start": period_start, "end": period_end, "label": label})
+
+    # Add predicted current period if the last closing is old enough
+    last_closing = closings[-1].closing_date
+    predicted_next = predict_next_closing(last_closing)
+    current_start = last_closing + timedelta(days=1)
+
+    # Only add if it makes sense (predicted end is in the future or recent)
+    if predicted_next >= date.today() - timedelta(days=7):
+        label = _format_period_label(current_start, predicted_next)
+        periods.append({
+            "start": current_start,
+            "end": predicted_next,
+            "label": label,
+            "is_predicted": True,
+        })
+
+    return periods
+
+
+def get_current_billing_periods(db, user_id: int) -> list[dict]:
+    """
+    Return the current billing period for each credit card belonging to user.
+    Uses CardClosing records + prediction.
+    """
+
+    from app.models import Card
+
+    cards = (
+        db.query(Card)
+        .filter(Card.user_id == user_id, Card.card_type == "credito")
+        .all()
+    )
+
+    results = []
+    for card in cards:
+        period = get_billing_period_for_card(card.id, date.today(), db)
+        if period:
+            start, end = period
+            results.append({
+                "card_id": card.id,
+                "card_name": card.card_name,
+                "bank": card.bank,
+                "holder": card.holder,
+                "period_start": start,
+                "period_end": end,
+                "label": _format_period_label(start, end),
+            })
+        else:
+            results.append({
+                "card_id": card.id,
+                "card_name": card.card_name,
+                "bank": card.bank,
+                "holder": card.holder,
+                "period_start": None,
+                "period_end": None,
+                "label": None,
+            })
+
+    return results
+
+
+def _format_period_label(start: date, end: date) -> str:
+    """Format a billing period label like '22 May - 25 Jun'."""
+    months_es = {
+        1: "Ene", 2: "Feb", 3: "Mar", 4: "Abr", 5: "May", 6: "Jun",
+        7: "Jul", 8: "Ago", 9: "Sep", 10: "Oct", 11: "Nov", 12: "Dic",
+    }
+    if start.year == end.year and start.month == end.month or start.year == end.year:
+        return f"{start.day} {months_es[start.month]} - {end.day} {months_es[end.month]} {end.year}"
+    else:
+        return f"{start.day} {months_es[start.month]} {start.year} - {end.day} {months_es[end.month]} {end.year}"

--- a/backend/app/telegram_bot.py
+++ b/backend/app/telegram_bot.py
@@ -261,7 +261,7 @@ def _build_cat_levels(category_id: int | None, db) -> list[str]:
 
 
 def _confirm_text(parsed: dict, payment_label: str, cat_levels: list[str] = None) -> str:
-    desc = parsed.get("description", "")
+    desc = _escape_md(parsed.get("description", ""))
     amount_str = _format_amount(parsed["amount"], parsed.get("currency", "ARS"))
     date_str = _format_date_es(parsed.get("date", date.today().strftime("%Y-%m-%d")))
     cat_tree = ""
@@ -334,6 +334,13 @@ _CAT_EMOJI: dict[str, str] = {
 }
 
 
+def _escape_md(text: str) -> str:
+    """Escape Telegram Markdown special characters to prevent parse errors."""
+    for ch in ("*", "_", "[", "`"):
+        text = text.replace(ch, f"\\{ch}")
+    return text
+
+
 def _cat_emoji(name: str) -> str:
     return _CAT_EMOJI.get(name.lower(), "📂")
 
@@ -351,7 +358,7 @@ def _saved_text(expense: "Expense", payment_label: str) -> str:
         tree_lines.append(f"{indent}{_cat_emoji(name)} {name}")
     # Description as final leaf
     leaf_indent = indents[min(len(levels), len(indents) - 1)]
-    tree_lines.append(f"{leaf_indent}📝 {expense.description}")
+    tree_lines.append(f"{leaf_indent}📝 {_escape_md(expense.description)}")
     cat_tree = "\n".join(tree_lines)
 
     return (
@@ -509,7 +516,7 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
         update.effective_user.full_name or update.effective_user.username or ""
     )
 
-    desc = parsed.get("description", "")
+    desc = _escape_md(parsed.get("description", ""))
     amount_str = _format_amount(parsed["amount"], parsed.get("currency", "ARS"))
     date_str = parsed.get("date", date.today().strftime("%Y-%m-%d"))
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -21,6 +21,7 @@ from app.routers import (
     accounts,
     analysis,
     auth,
+    billing,
     card_closings,
     cards,
     categories,
@@ -100,6 +101,7 @@ app.include_router(accounts.router)
 app.include_router(cards.router)
 app.include_router(categories.router)
 app.include_router(card_closings.router)
+app.include_router(billing.router)
 app.include_router(expenses.router)
 app.include_router(investments.router)
 app.include_router(import_jobs.router)

--- a/backend/scripts/migrate_add_card_closing_day.py
+++ b/backend/scripts/migrate_add_card_closing_day.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""
+Migration: Add closing_day column to cards table.
+
+This stores the approximate day of month a credit card closes (1-31).
+Used as a fallback when no CardClosing records exist from imported statements.
+
+Run with: python -m scripts.migrate_add_card_closing_day
+"""
+
+import os
+import sys
+
+from sqlalchemy import create_engine, text
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+def get_engine():
+    db_url = os.getenv("DATABASE_URL")
+    if not db_url:
+        # Try local SQLite
+        db_path = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "expenses.db")
+        if os.path.exists(db_path):
+            return create_engine(f"sqlite:///{db_path}")
+        raise RuntimeError("DATABASE_URL env var not set and no local expenses.db found.")
+    if db_url.startswith("postgres://"):
+        db_url = db_url.replace("postgres://", "postgresql://", 1)
+    print(f"Connecting to: {db_url.split('@')[1] if '@' in db_url else db_url}")
+    return create_engine(db_url)
+
+
+def add_closing_day_column(engine):
+    """Add closing_day column to cards table."""
+    print("\n[Step 1/1] Adding closing_day column to cards...")
+
+    with engine.begin() as conn:
+        dialect = engine.dialect.name
+
+        if dialect == "postgresql":
+            exists = conn.execute(text("""
+                SELECT EXISTS (
+                    SELECT 1 FROM information_schema.columns
+                    WHERE table_name = 'cards' AND column_name = 'closing_day'
+                )
+            """)).scalar()
+        elif dialect == "sqlite":
+            result = conn.execute(text("PRAGMA table_info(cards)")).fetchall()
+            exists = any(row[1] == "closing_day" for row in result)
+        else:
+            exists = False
+
+        if exists:
+            print("  closing_day column already exists. Skipping.")
+            return
+
+        conn.execute(text("ALTER TABLE cards ADD COLUMN closing_day INTEGER"))
+        print("  Added closing_day INTEGER column to cards.")
+
+
+def main():
+    engine = get_engine()
+
+    print("=" * 60)
+    print("Migration: Add closing_day to cards")
+    print("=" * 60)
+
+    add_closing_day_column(engine)
+
+    print("\n" + "=" * 60)
+    print("Migration complete!")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    main()

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -95,6 +95,7 @@ export const getExpenses = (params?: {
   category_ids?: string;
   uncategorized?: boolean;
   month?: string;
+  billing_view?: boolean;
   bank?: string;
   person?: string;
   card?: string;
@@ -192,6 +193,7 @@ export const bulkDeleteExpenses = (ids: number[]) =>
 // Dashboard
 export const getDashboard = (params?: {
   month?: string;
+  billing_view?: boolean;
   group_by?: "week" | "month" | "year";
   search?: string;
   person?: string;
@@ -554,3 +556,35 @@ export async function confirmImportJob(
 export async function deleteImportJob(jobId: number): Promise<void> {
   await api.delete(`/import-jobs/${jobId}`);
 }
+
+// Billing periods
+export interface BillingPeriod {
+  card_id: number;
+  card_name: string;
+  bank: string;
+  holder: string;
+  period_start: string | null;
+  period_end: string | null;
+  label: string | null;
+  is_predicted?: boolean;
+}
+
+export interface BillingPeriodDetail {
+  start: string;
+  end: string;
+  label: string;
+  is_predicted?: boolean;
+}
+
+export const getCurrentBillingPeriods = () =>
+  api.get<BillingPeriod[]>("/billing/current").then((r) => r.data);
+
+export const getBillingPeriods = (cardId: number, count: number = 6) =>
+  api.get<BillingPeriodDetail[]>("/billing/periods", {
+    params: { card_id: cardId, count },
+  }).then((r) => r.data);
+
+export const getBillingPeriodForDate = (cardId: number, refDate: string) =>
+  api.get<BillingPeriod>("/billing/period-for-date", {
+    params: { card_id: cardId, ref_date: refDate },
+  }).then((r) => r.data);

--- a/frontend/src/components/AccountsManager.tsx
+++ b/frontend/src/components/AccountsManager.tsx
@@ -295,7 +295,10 @@ export default function AccountsManager() {
                 </div>
               </form>
             ) : (
-              <div className="group relative flex items-center gap-3 p-3 bg-surface border border-border-color rounded-lg hover:border-border-color transition-colors">
+              <div
+                className="group relative flex items-center gap-3 p-3 bg-surface border border-border-color rounded-lg hover:border-border-color transition-colors cursor-pointer"
+                onClick={() => handleEdit(account)}
+              >
                 <div
                   className={`w-8 h-8 rounded-lg flex items-center justify-center text-sm font-bold ${typeInfo.color}`}
                 >
@@ -315,7 +318,10 @@ export default function AccountsManager() {
                 </div>
                 <div className="relative">
                   <button
-                    onClick={() => setMenuOpen(isMenuOpen ? null : account.id)}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setMenuOpen(isMenuOpen ? null : account.id);
+                    }}
                     className="w-7 h-7 flex items-center justify-center rounded text-tertiary hover:text-primary hover:bg-base-alt transition-colors"
                   >
                     ···
@@ -325,19 +331,14 @@ export default function AccountsManager() {
                       <div className="fixed inset-0 z-40" onClick={() => setMenuOpen(null)} />
                       <div className="absolute right-0 top-8 z-50 w-28 bg-surface border border-border-color rounded-lg shadow-lg overflow-hidden">
                         <button
-                          onClick={() => handleEdit(account)}
-                          className="w-full px-3 py-2 text-xs text-left text-primary hover:bg-base-alt transition-colors"
-                        >
-                          ✏️ Editar
-                        </button>
-                        <button
-                          onClick={() =>
+                          onClick={(e) => {
+                            e.stopPropagation();
                             setDeleteConfirm({
                               type: "account",
                               id: account.id,
                               name: account.name,
-                            })
-                          }
+                            });
+                          }}
                           disabled={deleteMut.isPending}
                           className="w-full px-3 py-2 text-xs text-left text-danger hover:bg-danger/10 transition-colors disabled:opacity-50"
                         >

--- a/frontend/src/components/CardsManager.tsx
+++ b/frontend/src/components/CardsManager.tsx
@@ -49,6 +49,7 @@ export default function CardsManager() {
   const [bank, setBank] = useState("");
   const [holder, setHolder] = useState("");
   const [cardType, setCardType] = useState("credito");
+  const [closingDay, setClosingDay] = useState<string>("");
   const [accountType, setAccountType] = useState("efectivo");
 
   const { data: cards = [], isLoading } = useQuery({
@@ -77,6 +78,7 @@ export default function CardsManager() {
       setBank("");
       setHolder("");
       setCardType("credito");
+      setClosingDay("");
     },
     onError: (error: any) => {
       if (error.response?.status === 409) {
@@ -100,6 +102,7 @@ export default function CardsManager() {
       setBank("");
       setHolder("");
       setCardType("credito");
+      setClosingDay("");
     },
   });
 
@@ -129,6 +132,7 @@ export default function CardsManager() {
     setBank(card.bank || "");
     setHolder(card.holder || "");
     setCardType(card.card_type);
+    setClosingDay(card.closing_day?.toString() || "");
     setAccountType("tarjeta");
     setMenuOpen(null);
   };
@@ -139,6 +143,7 @@ export default function CardsManager() {
     setBank("");
     setHolder("");
     setCardType("credito");
+    setClosingDay("");
     setAccountType("tarjeta");
   };
 
@@ -148,6 +153,7 @@ export default function CardsManager() {
     setBank("");
     setHolder(currentUser ? getFirstName(currentUser.full_name) : "");
     setCardType("credito");
+    setClosingDay("");
     setAccountType("efectivo");
     setMenuOpen(null);
   };
@@ -170,10 +176,11 @@ export default function CardsManager() {
     setErrors({});
 
     if (accountType === "tarjeta") {
-      const data: { card_name: string; bank?: string; holder?: string; card_type?: string } = {
+      const data: { card_name: string; bank?: string; holder?: string; card_type?: string; closing_day?: number | null } = {
         card_name: cardName.trim(),
         bank: bank.trim(),
         card_type: cardType,
+        closing_day: closingDay ? parseInt(closingDay, 10) : null,
       };
       if (editId && editId > 0) {
         updateMut.mutate({ id: editId, data });
@@ -269,6 +276,25 @@ export default function CardsManager() {
                     ]}
                   />
                 </div>
+                {cardType === "credito" && (
+                  <div className="space-y-1.5">
+                    <label className="text-xs font-medium text-[var(--text-secondary)]">
+                      Día de cierre (opcional)
+                    </label>
+                    <input
+                      type="number"
+                      min="1"
+                      max="31"
+                      value={closingDay}
+                      onChange={(e) => setClosingDay(e.target.value)}
+                      className="w-full px-3 py-2 rounded-md border text-sm text-[var(--text-primary)] bg-[var(--color-base-container)] focus:outline-none focus:ring-2 focus:ring-primary/30 transition border-[var(--border-color)] focus:border-primary"
+                      placeholder="Ej: 27"
+                    />
+                    <p className="text-xs text-tertiary">
+                      Día del mes en que cierra la tarjeta. Se usa como respaldo si no tenés resúmenes importados.
+                    </p>
+                  </div>
+                )}
                 <div className="flex gap-2 pt-2">
                   <button
                     type="submit"
@@ -306,7 +332,12 @@ export default function CardsManager() {
                         : card.card_type}{" "}
                     — {card.bank}
                   </div>
-                  <div className="text-xs text-tertiary mt-0.5">Titular: {card.holder || "—"}</div>
+                  <div className="text-xs text-tertiary mt-0.5">
+                    Titular: {card.holder || "—"}
+                    {card.closing_day && card.card_type === "credito" && (
+                      <span className="ml-2">· Cierra día {card.closing_day}</span>
+                    )}
+                  </div>
                 </div>
                 <div className="relative">
                   <button

--- a/frontend/src/components/CardsManager.tsx
+++ b/frontend/src/components/CardsManager.tsx
@@ -313,7 +313,10 @@ export default function CardsManager() {
                 </div>
               </form>
             ) : (
-              <div className="group relative flex items-center gap-3 p-3 bg-surface border border-border-color rounded-lg hover:border-border-color transition-colors">
+              <div
+                className="group relative flex items-center gap-3 p-3 bg-surface border border-border-color rounded-lg hover:border-border-color transition-colors cursor-pointer"
+                onClick={() => handleEdit(card)}
+              >
                 <div className="w-8 h-8 rounded-lg flex items-center justify-center text-sm font-bold badge-primary">
                   💳
                 </div>
@@ -341,7 +344,10 @@ export default function CardsManager() {
                 </div>
                 <div className="relative">
                   <button
-                    onClick={() => setMenuOpen(isMenuOpen ? null : card.id)}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setMenuOpen(isMenuOpen ? null : card.id);
+                    }}
                     className="w-7 h-7 flex items-center justify-center rounded text-tertiary hover:text-primary hover:bg-base-alt transition-colors"
                   >
                     ···
@@ -351,15 +357,10 @@ export default function CardsManager() {
                       <div className="fixed inset-0 z-40" onClick={() => setMenuOpen(null)} />
                       <div className="absolute right-0 top-8 z-50 w-28 bg-surface border border-border-color rounded-lg shadow-lg overflow-hidden">
                         <button
-                          onClick={() => handleEdit(card)}
-                          className="w-full px-3 py-2 text-xs text-left text-primary hover:bg-base-alt transition-colors"
-                        >
-                          ✏️ Editar
-                        </button>
-                        <button
-                          onClick={() =>
-                            setDeleteConfirm({ type: "card", id: card.id, name: card.card_name })
-                          }
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            setDeleteConfirm({ type: "card", id: card.id, name: card.card_name });
+                          }}
                           disabled={deleteMut.isPending}
                           className="w-full px-3 py-2 text-xs text-left text-danger hover:bg-danger/10 transition-colors disabled:opacity-50"
                         >

--- a/frontend/src/components/ExpenseDetailModal.tsx
+++ b/frontend/src/components/ExpenseDetailModal.tsx
@@ -1,0 +1,68 @@
+import { DetailModal } from "./DetailModal";
+import type { Expense } from "../types";
+import { formatCurrency } from "../utils/format";
+
+interface ExpenseDetailModalProps {
+  expense: Expense | null;
+  onClose: () => void;
+  onEdit?: () => void;
+}
+
+export function ExpenseDetailModal({ expense, onClose, onEdit }: ExpenseDetailModalProps) {
+  if (!expense) return null;
+
+  return (
+    <DetailModal
+      isOpen={!!expense}
+      onClose={onClose}
+      title={expense.description}
+      subtitle={expense.date}
+    >
+      <div className="space-y-4">
+        <div className="flex items-baseline gap-2">
+          <span className="text-2xl font-bold text-[var(--text-primary)]">
+            {formatCurrency(expense.amount, expense.currency)}
+          </span>
+        </div>
+
+        <dl className="grid grid-cols-2 gap-x-4 gap-y-2 text-sm">
+          <DetailField label="Categoría" value={expense.category_name || "Sin categoría"} />
+          <DetailField label="Medio de pago" value={expense.card || expense.account || "-"} />
+          {expense.installment_number && expense.installment_total && (
+            <DetailField
+              label="Cuotas"
+              value={`${expense.installment_number}/${expense.installment_total}`}
+            />
+          )}
+          {expense.notes && <DetailField label="Notas" value={expense.notes} />}
+        </dl>
+
+        <div className="flex gap-2 pt-4 border-t border-[var(--border-color)]">
+          <button
+            onClick={onClose}
+            className="flex-1 py-2 rounded-lg border border-[var(--border-color)] text-sm text-[var(--text-secondary)] hover:bg-[var(--color-base-alt)] transition-colors"
+          >
+            Cerrar
+          </button>
+          {onEdit && (
+            <button
+              onClick={onEdit}
+              className="flex-1 py-2 rounded-lg bg-[var(--color-primary)] text-white text-sm hover:brightness-110 transition-colors"
+            >
+              Editar
+            </button>
+          )}
+        </div>
+      </div>
+    </DetailModal>
+  );
+}
+
+function DetailField({ label, value }: { label: string; value: string }) {
+  return (
+    <>
+      <dt className="text-[var(--text-tertiary)] text-xs uppercase">{label}</dt>
+      <dd className="text-[var(--text-primary)] font-medium text-sm">{value}</dd>
+    </>
+  );
+}

--- a/frontend/src/components/ExpenseModals.tsx
+++ b/frontend/src/components/ExpenseModals.tsx
@@ -167,6 +167,9 @@ export function ExpenseModal({
         : lastPayment.payMethod,
   );
   const [showCardModal, setShowCardModal] = useState(false);
+  const [showParentSelector, setShowParentSelector] = useState(false);
+  const [newCategoryName, setNewCategoryName] = useState("");
+  const [newCategoryParent, setNewCategoryParent] = useState<number | null>(null);
 
   const [form, setForm] = useState<ExpenseCreate>(() => {
     if (initial) {
@@ -390,25 +393,17 @@ export function ExpenseModal({
             onChange={async (v) => {
               if (!v) {
                 set("category_id", null);
+                setNewCategoryParent(null);
                 return;
               }
               const parsed = parseInt(v);
               if (!isNaN(parsed)) {
                 set("category_id", parsed);
+                setNewCategoryParent(null);
               } else {
-                // Create new category
-                try {
-                  const newCat = await createCategory({
-                    name: v,
-                    color: "#6366f1",
-                    keywords: "",
-                    parent_id: null,
-                  });
-                  queryClient.invalidateQueries({ queryKey: ["categories"] });
-                  set("category_id", newCat.id);
-                } catch {
-                  // Duplicate name or other error - leave category_id as null
-                }
+                // Show parent selector for new category
+                setShowParentSelector(true);
+                setNewCategoryName(v);
               }
             }}
             groups={(() => {
@@ -436,6 +431,44 @@ export function ExpenseModal({
             })()}
             placeholder="Sin categoría"
           />
+
+          {/* Parent selector for new category */}
+          {showParentSelector && (
+            <div className="mt-2 p-3 bg-[var(--color-base-alt)] rounded-lg space-y-2">
+              <p className="text-xs text-[var(--text-secondary)]">
+                Crear "<strong>{newCategoryName}</strong>" como:
+              </p>
+              <div className="flex gap-2">
+                <button
+                  onClick={async () => {
+                    try {
+                      const newCat = await createCategory({
+                        name: newCategoryName,
+                        color: "#6366f1",
+                        keywords: "",
+                        parent_id: null,
+                      });
+                      queryClient.invalidateQueries({ queryKey: ["categories"] });
+                      set("category_id", newCat.id);
+                      setShowParentSelector(false);
+                      setNewCategoryName("");
+                    } catch {
+                      // Duplicate name
+                    }
+                  }}
+                  className="flex-1 py-1.5 text-xs rounded border border-[var(--border-color)] hover:bg-[var(--color-base-alt)]"
+                >
+                  Categoría padre
+                </button>
+                <button
+                  onClick={() => setShowParentSelector(false)}
+                  className="flex-1 py-1.5 text-xs rounded border border-[var(--border-color)] hover:bg-[var(--color-base-alt)]"
+                >
+                  Cancelar
+                </button>
+              </div>
+            </div>
+          )}
         </div>
 
         {/* Cascading: Banco → Tarjeta */}

--- a/frontend/src/components/TransactionDetailModal.tsx
+++ b/frontend/src/components/TransactionDetailModal.tsx
@@ -1,26 +1,22 @@
 import { DetailModal } from "./DetailModal";
 import type { SmartImportRow } from "../types";
-import { toUpperCase } from "../utils/format";
+import { formatCurrency } from "../utils/format";
 
 interface TransactionDetailModalProps {
   row: SmartImportRow | null;
   onClose: () => void;
+  onEdit?: () => void;
 }
 
-export function TransactionDetailModal({ row, onClose }: TransactionDetailModalProps) {
+export function TransactionDetailModal({ row, onClose, onEdit }: TransactionDetailModalProps) {
   if (!row) return null;
 
   return (
-    <DetailModal
-      isOpen={!!row}
-      onClose={onClose}
-      title={toUpperCase(row.description)}
-      subtitle={row.date}
-    >
+    <DetailModal isOpen={!!row} onClose={onClose} title={row.description} subtitle={row.date}>
       <div className="space-y-4">
         <div className="flex items-baseline gap-2">
           <span className="text-2xl font-bold text-[var(--text-primary)]">
-            {row.amount.toLocaleString("es-AR")} {row.currency}
+            {formatCurrency(row.amount, row.currency)}
           </span>
         </div>
 
@@ -35,23 +31,40 @@ export function TransactionDetailModal({ row, onClose }: TransactionDetailModalP
                 : "-"
             }
           />
-          <DetailField label="Transaction ID" value={row.transaction_id || "-"} />
+          <DetailField label="Referencia" value={row.transaction_id || "-"} />
         </dl>
 
         {(row.is_duplicate || row.is_auto_generated) && (
           <div className="flex gap-2 flex-wrap pt-2">
             {row.is_duplicate && (
-              <span className="text-xs bg-warning/10 text-warning px-2 py-1 rounded">
+              <span className="text-xs bg-amber-100 text-amber-700 px-2 py-1 rounded">
                 Duplicada
               </span>
             )}
             {row.is_auto_generated && (
-              <span className="text-xs bg-primary/10 text-primary px-2 py-1 rounded">
-                Auto-generada
+              <span className="text-xs bg-blue-100 text-blue-700 px-2 py-1 rounded">
+                Cuota auto-generada
               </span>
             )}
           </div>
         )}
+
+        <div className="flex gap-2 pt-4 border-t border-[var(--border-color)]">
+          <button
+            onClick={onClose}
+            className="flex-1 py-2 rounded-lg border border-[var(--border-color)] text-sm text-[var(--text-secondary)] hover:bg-[var(--color-base-alt)] transition-colors"
+          >
+            Cerrar
+          </button>
+          {onEdit && (
+            <button
+              onClick={onEdit}
+              className="flex-1 py-2 rounded-lg bg-[var(--color-primary)] text-white text-sm hover:brightness-110 transition-colors"
+            >
+              Editar
+            </button>
+          )}
+        </div>
       </div>
     </DetailModal>
   );

--- a/frontend/src/pages/CategoriesPage.tsx
+++ b/frontend/src/pages/CategoriesPage.tsx
@@ -313,7 +313,7 @@ export default function CategoriesPage() {
 
   // Classify categories
   const childParentIds = new Set(categories.filter((c) => c.parent_id).map((c) => c.parent_id!));
-  const parentCats = categories.filter((c) => !c.parent_id && childParentIds.has(c.id));
+  const parentCats = categories.filter((c) => !c.parent_id);
   const standaloneLeaves = categories.filter((c) => !c.parent_id && !childParentIds.has(c.id));
   const childCats = categories.filter((c) => !!c.parent_id);
   const hasHierarchy = parentCats.length > 0;

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -14,6 +14,7 @@ import {
   getCreditCardPasivos,
   getInstallmentsMonthlyLoad,
   getTopMerchants,
+  getCurrentBillingPeriods,
 } from "../api/client";
 import type { Expense, ExpenseCreate } from "../types";
 import { formatCurrency, toUpperCase, formatDateDMYSlash, MONTHS_ES_SHORT } from "../utils/format";
@@ -101,6 +102,19 @@ export default function Dashboard() {
   const [editing, setEditing] = useState<Expense | null | undefined>(undefined);
   const [saveError, setSaveError] = useState<string | null>(null);
   const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
+  const [billingView, setBillingView] = useState(() => {
+    return localStorage.getItem("billing_view") === "true";
+  });
+
+  const toggleBillingView = () => {
+    const newValue = !billingView;
+    setBillingView(newValue);
+    localStorage.setItem("billing_view", newValue.toString());
+    // Invalidate queries to refetch with new view
+    queryClient.invalidateQueries({ queryKey: ["dashboard"] });
+    queryClient.invalidateQueries({ queryKey: ["expenses-month"] });
+  };
+
   const createMut = useMutation({
     mutationFn: (data: ExpenseCreate) => createExpense(data),
     onSuccess: () => {
@@ -117,8 +131,8 @@ export default function Dashboard() {
   };
 
   const { data: dashData } = useQuery({
-    queryKey: ["dashboard", month],
-    queryFn: () => getDashboard({ month }),
+    queryKey: ["dashboard", month, billingView],
+    queryFn: () => getDashboard({ month, billing_view: billingView }),
     placeholderData: (prev) => prev,
   });
 
@@ -128,12 +142,20 @@ export default function Dashboard() {
     staleTime: 60_000,
   });
 
+  // Current billing periods for credit cards
+  const { data: billingPeriods = [] } = useQuery({
+    queryKey: ["billing-periods"],
+    queryFn: getCurrentBillingPeriods,
+    staleTime: 60_000,
+  });
+
   // Expenses for current month
   const { data: monthExpenses = [] } = useQuery({
-    queryKey: ["expenses-month", month],
+    queryKey: ["expenses-month", month, billingView],
     queryFn: () =>
       getExpenses({
         month,
+        billing_view: billingView,
         limit: 500,
       }),
     staleTime: 30_000,
@@ -316,10 +338,22 @@ export default function Dashboard() {
             </span>
           )}
         </div>
-        <button onClick={() => setEditing(null)} className="gnome-btn-primary-round text-sm">
-          <span className="text-base leading-none">+</span>
-          <span>Nuevo gasto</span>
-        </button>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={toggleBillingView}
+            className={`px-3 py-1.5 rounded-md text-xs font-medium transition-colors ${
+              billingView
+                ? "bg-[var(--color-primary)] text-[var(--color-on-primary)]"
+                : "bg-[var(--color-surface)] border border-[var(--border-color)] text-[var(--text-secondary)] hover:border-[var(--color-primary)]"
+            }`}
+          >
+            {billingView ? "📊 Facturación" : "📅 Calendario"}
+          </button>
+          <button onClick={() => setEditing(null)} className="gnome-btn-primary-round text-sm">
+            <span className="text-base leading-none">+</span>
+            <span>Nuevo gasto</span>
+          </button>
+        </div>
       </div>
 
       {/* KPI Row */}
@@ -626,15 +660,29 @@ export default function Dashboard() {
                 .filter((c) => c.card_type === "credito")
                 .map((card, i) => {
                   const monthEntry = card.monthly?.find((m) => m.month === month);
+                  const billingPeriod = billingView
+                    ? billingPeriods.find((bp) => bp.card_id === card.id)
+                    : null;
                   return (
-                    <CardRow
-                      key={i}
-                      cardName={card.card_name}
-                      bank={card.bank}
-                      total={monthEntry?.total ?? 0}
-                      cardType={card.card_type}
-                      holder={card.holder}
-                    />
+                    <div key={i}>
+                      <CardRow
+                        cardName={card.card_name}
+                        bank={card.bank}
+                        total={monthEntry?.total ?? 0}
+                        cardType={card.card_type}
+                        holder={card.holder}
+                      />
+                      {billingView && billingPeriod?.label && (
+                        <div className="px-3 pb-2 -mt-1">
+                          <p className="text-[10px] text-tertiary">
+                            📅 {billingPeriod.label}
+                            {billingPeriod.is_predicted && (
+                              <span className="ml-1 text-[var(--color-primary)]">(estimado)</span>
+                            )}
+                          </p>
+                        </div>
+                      )}
+                    </div>
                   );
                 })}
             </div>

--- a/frontend/src/pages/ExpensesPage.tsx
+++ b/frontend/src/pages/ExpensesPage.tsx
@@ -18,6 +18,7 @@ import {
 import type { Expense, ExpenseCreate } from "../types";
 import { Select } from "../components/ui/Select";
 import { ExpenseModal } from "../components/ExpenseModals";
+import { ExpenseDetailModal } from "../components/ExpenseDetailModal";
 import EmptyState from "../components/ui/EmptyState";
 import {
   PieChart,
@@ -216,6 +217,7 @@ export default function ExpensesPage() {
   }, [filterSearch, expenses]);
 
   const [editing, setEditing] = useState<Expense | null | undefined>(undefined);
+  const [viewing, setViewing] = useState<Expense | null>(null);
   const [saveError, setSaveError] = useState<string | null>(null);
   const [debouncedSearch, setDebouncedSearch] = useState(filterSearch ?? "");
   const [filtersExpanded, setFiltersExpanded] = useState(false);
@@ -1017,7 +1019,7 @@ export default function ExpensesPage() {
                               : "hover:bg-[var(--color-base-alt)]/30"
                           } ${selectedIds.has(exp.id) ? "bg-[var(--color-primary)]/10" : ""}`}
                           style={missing ? { borderLeft: "3px solid #f6d32d" } : undefined}
-                          onClick={() => (selectMode ? toggleSelect(exp.id) : setEditing(exp))}
+                          onClick={() => (selectMode ? toggleSelect(exp.id) : setViewing(exp))}
                         >
                           {selectMode && (
                             <td className="px-3 py-3" onClick={(e) => e.stopPropagation()}>
@@ -1302,6 +1304,17 @@ export default function ExpensesPage() {
             setBulkDeleteConfirm(false);
           }}
           onCancel={() => setBulkDeleteConfirm(false)}
+        />
+      )}
+
+      {viewing && (
+        <ExpenseDetailModal
+          expense={viewing}
+          onClose={() => setViewing(null)}
+          onEdit={() => {
+            setViewing(null);
+            setEditing(viewing);
+          }}
         />
       )}
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -88,6 +88,7 @@ export interface Card {
   bank: string;
   holder: string;
   card_type: string;
+  closing_day: number | null;
   user_id: number;
   created_at: string;
 }


### PR DESCRIPTION
## Changes

### New Feature: Billing Period Tracking
- Add `closing_day` column to Card model (day of month card closes, 1-31)
- New `/billing` API router with endpoints for current periods, period history, and period-for-date lookup
- Billing period calculation engine in `date_utils.py` using CardClosing records with `closing_day` fallback and prediction
- `billing_view` filter on expenses and dashboard endpoints: filters by each card's billing period instead of calendar month
- Frontend billing period integration in Dashboard and ExpensesPage
- Migration script for `closing_day` column

### New Feature: Expense Detail Modals
- New `ExpenseDetailModal` component for viewing expense summaries
- Parent category selector when creating subcategories in `ExpenseModals`

### Bug Fixes
- **CategoriesPage**: Show all root categories in parent selector (not just those with children)
- **Telegram bot**: Add `_escape_md()` to escape Markdown special characters in LLM descriptions

### UX Improvement
- **CardsManager/AccountsManager**: Click row to edit; context menu only for delete

### Files Changed (20)
**Backend (10):**
- `models.py`, `routers/billing.py` (new), `routers/cards.py`, `routers/dashboard.py`, `routers/expenses.py`, `services/date_utils.py`, `telegram_bot.py`, `main.py`, `scripts/migrate_add_card_closing_day.py` (new)

**Frontend (9):**
- `api/client.ts`, `components/AccountsManager.tsx`, `components/CardsManager.tsx`, `components/ExpenseDetailModal.tsx` (new), `components/ExpenseModals.tsx`, `components/TransactionDetailModal.tsx`, `pages/CategoriesPage.tsx`, `pages/Dashboard.tsx`, `pages/ExpensesPage.tsx`, `types/index.ts`

**Docs (1):**
- `Roadmap.md`