### PR TITLE
fix: category parent filter, telegram markdown, click-to-edit

### DIFF
--- a/Roadmap.md
+++ b/Roadmap.md
@@ -1,5 +1,8 @@
 # Bugs
 
+## Todo
+
+
 ## Fixed
 
 1. ~~el boton de eliminar todas las notificaciones no hace nada.~~ → Added `refresh()` call after `deleteAllRead` to force SSE re-sync
@@ -13,6 +16,13 @@
 9. ~~Filtro by card/account en /expenses no funciona. No filtra.~~ → Fixed currentCuenta to use IDs instead of names, reconstruct Select value from URL params
 10. ~~Cuando cargas un gasto en Efectivo/Transferencia pero no tenes una cuenta que corresponda, debería abrirte el warning para crear un account~~ → Added warning when payMethod is 'cash' and no accounts exist, with 'Crear cuenta' button
 11. ~~Cuando estas seleccionando una categoría desde el modal de Create Expenses, debería permitir crear una categoría si no está la que buscamos~~ → Added createCategory API call in category onChange handler
+12. ~~Unable to add Main Categories.~~ → Fixed `parentCats` filter to show all root categories (removed `childParentIds.has(c.id)` requirement)
+13. ~~Unable to add expense from Telegram in caja_ahorro account.~~ → Added `_escape_md()` helper to escape Markdown special characters in LLM-generated descriptions
+
+# Features
+
+## On-Going
+- ~~Allow edit card/account by clicking in that account in UserPanel --> Accounts, not only touching the 3 dots~~ → Made card/account rows clickable to enter edit mode; `···` menu now only shows Delete option
 
 # Roadmap
 

--- a/backend/app/telegram_bot.py
+++ b/backend/app/telegram_bot.py
@@ -261,7 +261,7 @@ def _build_cat_levels(category_id: int | None, db) -> list[str]:
 
 
 def _confirm_text(parsed: dict, payment_label: str, cat_levels: list[str] = None) -> str:
-    desc = parsed.get("description", "")
+    desc = _escape_md(parsed.get("description", ""))
     amount_str = _format_amount(parsed["amount"], parsed.get("currency", "ARS"))
     date_str = _format_date_es(parsed.get("date", date.today().strftime("%Y-%m-%d")))
     cat_tree = ""
@@ -334,6 +334,13 @@ _CAT_EMOJI: dict[str, str] = {
 }
 
 
+def _escape_md(text: str) -> str:
+    """Escape Telegram Markdown special characters to prevent parse errors."""
+    for ch in ("*", "_", "[", "`"):
+        text = text.replace(ch, f"\\{ch}")
+    return text
+
+
 def _cat_emoji(name: str) -> str:
     return _CAT_EMOJI.get(name.lower(), "📂")
 
@@ -351,7 +358,7 @@ def _saved_text(expense: "Expense", payment_label: str) -> str:
         tree_lines.append(f"{indent}{_cat_emoji(name)} {name}")
     # Description as final leaf
     leaf_indent = indents[min(len(levels), len(indents) - 1)]
-    tree_lines.append(f"{leaf_indent}📝 {expense.description}")
+    tree_lines.append(f"{leaf_indent}📝 {_escape_md(expense.description)}")
     cat_tree = "\n".join(tree_lines)
 
     return (
@@ -509,7 +516,7 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
         update.effective_user.full_name or update.effective_user.username or ""
     )
 
-    desc = parsed.get("description", "")
+    desc = _escape_md(parsed.get("description", ""))
     amount_str = _format_amount(parsed["amount"], parsed.get("currency", "ARS"))
     date_str = parsed.get("date", date.today().strftime("%Y-%m-%d"))
 

--- a/frontend/src/components/AccountsManager.tsx
+++ b/frontend/src/components/AccountsManager.tsx
@@ -295,7 +295,10 @@ export default function AccountsManager() {
                 </div>
               </form>
             ) : (
-              <div className="group relative flex items-center gap-3 p-3 bg-surface border border-border-color rounded-lg hover:border-border-color transition-colors">
+              <div
+                className="group relative flex items-center gap-3 p-3 bg-surface border border-border-color rounded-lg hover:border-border-color transition-colors cursor-pointer"
+                onClick={() => handleEdit(account)}
+              >
                 <div
                   className={`w-8 h-8 rounded-lg flex items-center justify-center text-sm font-bold ${typeInfo.color}`}
                 >
@@ -315,7 +318,10 @@ export default function AccountsManager() {
                 </div>
                 <div className="relative">
                   <button
-                    onClick={() => setMenuOpen(isMenuOpen ? null : account.id)}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setMenuOpen(isMenuOpen ? null : account.id);
+                    }}
                     className="w-7 h-7 flex items-center justify-center rounded text-tertiary hover:text-primary hover:bg-base-alt transition-colors"
                   >
                     ···
@@ -325,19 +331,14 @@ export default function AccountsManager() {
                       <div className="fixed inset-0 z-40" onClick={() => setMenuOpen(null)} />
                       <div className="absolute right-0 top-8 z-50 w-28 bg-surface border border-border-color rounded-lg shadow-lg overflow-hidden">
                         <button
-                          onClick={() => handleEdit(account)}
-                          className="w-full px-3 py-2 text-xs text-left text-primary hover:bg-base-alt transition-colors"
-                        >
-                          ✏️ Editar
-                        </button>
-                        <button
-                          onClick={() =>
+                          onClick={(e) => {
+                            e.stopPropagation();
                             setDeleteConfirm({
                               type: "account",
                               id: account.id,
                               name: account.name,
-                            })
-                          }
+                            });
+                          }}
                           disabled={deleteMut.isPending}
                           className="w-full px-3 py-2 text-xs text-left text-danger hover:bg-danger/10 transition-colors disabled:opacity-50"
                         >

--- a/frontend/src/components/CardsManager.tsx
+++ b/frontend/src/components/CardsManager.tsx
@@ -287,7 +287,10 @@ export default function CardsManager() {
                 </div>
               </form>
             ) : (
-              <div className="group relative flex items-center gap-3 p-3 bg-surface border border-border-color rounded-lg hover:border-border-color transition-colors">
+              <div
+                className="group relative flex items-center gap-3 p-3 bg-surface border border-border-color rounded-lg hover:border-border-color transition-colors cursor-pointer"
+                onClick={() => handleEdit(card)}
+              >
                 <div className="w-8 h-8 rounded-lg flex items-center justify-center text-sm font-bold badge-primary">
                   💳
                 </div>
@@ -310,7 +313,10 @@ export default function CardsManager() {
                 </div>
                 <div className="relative">
                   <button
-                    onClick={() => setMenuOpen(isMenuOpen ? null : card.id)}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setMenuOpen(isMenuOpen ? null : card.id);
+                    }}
                     className="w-7 h-7 flex items-center justify-center rounded text-tertiary hover:text-primary hover:bg-base-alt transition-colors"
                   >
                     ···
@@ -320,15 +326,10 @@ export default function CardsManager() {
                       <div className="fixed inset-0 z-40" onClick={() => setMenuOpen(null)} />
                       <div className="absolute right-0 top-8 z-50 w-28 bg-surface border border-border-color rounded-lg shadow-lg overflow-hidden">
                         <button
-                          onClick={() => handleEdit(card)}
-                          className="w-full px-3 py-2 text-xs text-left text-primary hover:bg-base-alt transition-colors"
-                        >
-                          ✏️ Editar
-                        </button>
-                        <button
-                          onClick={() =>
-                            setDeleteConfirm({ type: "card", id: card.id, name: card.card_name })
-                          }
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            setDeleteConfirm({ type: "card", id: card.id, name: card.card_name });
+                          }}
                           disabled={deleteMut.isPending}
                           className="w-full px-3 py-2 text-xs text-left text-danger hover:bg-danger/10 transition-colors disabled:opacity-50"
                         >

--- a/frontend/src/pages/CategoriesPage.tsx
+++ b/frontend/src/pages/CategoriesPage.tsx
@@ -313,7 +313,7 @@ export default function CategoriesPage() {
 
   // Classify categories
   const childParentIds = new Set(categories.filter((c) => c.parent_id).map((c) => c.parent_id!));
-  const parentCats = categories.filter((c) => !c.parent_id && childParentIds.has(c.id));
+  const parentCats = categories.filter((c) => !c.parent_id);
   const standaloneLeaves = categories.filter((c) => !c.parent_id && !childParentIds.has(c.id));
   const childCats = categories.filter((c) => !!c.parent_id);
   const hasHierarchy = parentCats.length > 0;


### PR DESCRIPTION
## Changes

### Bug Fixes
- **Unable to add Main Categories** - Fixed parentCats filter to show all root categories
- **Unable to add expense from Telegram** - Added _escape_md() helper to escape Markdown special characters

### Feature
- **Click card/account to edit** - Made rows clickable in UserPanel Accounts tab; menu now only shows Delete

### Files Changed
- CategoriesPage.tsx
- telegram_bot.py
- CardsManager.tsx
- AccountsManager.tsx
- Roadmap.md