### PR TITLE
feat: expense summary modal on row click

### DIFF
--- a/Roadmap.md
+++ b/Roadmap.md
@@ -23,6 +23,7 @@
 
 ## On-Going
 - ~~Allow edit card/account by clicking in that account in UserPanel --> Accounts, not only touching the 3 dots~~ → Made card/account rows clickable to enter edit mode; `···` menu now only shows Delete option
+- Click on expense row in /expenses opens summary modal with Cerrar/Editar buttons
 
 # Roadmap
 

--- a/frontend/src/components/ExpenseDetailModal.tsx
+++ b/frontend/src/components/ExpenseDetailModal.tsx
@@ -41,78 +41,57 @@ export default function ExpenseDetailModal({ expense, onClose, onEdit }: Props) 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center p-4 animate-modal-backdrop">
       <div className="fixed inset-0 bg-black/60" onClick={onClose} />
-      <div className="relative card w-full max-w-md p-6 space-y-4 animate-modal-content">
+      <div className="relative card w-full max-w-sm p-5 space-y-4 animate-modal-content">
         {/* Header */}
         <div className="flex items-center justify-between">
-          <h2 className="text-lg font-semibold text-[var(--text-primary)] truncate pr-4">
+          <h2 className="text-base font-semibold text-[var(--text-primary)] truncate pr-4">
             {toUpperCase(expense.description)}
           </h2>
           <button
             onClick={onClose}
             aria-label="Cerrar"
-            className="text-[var(--text-tertiary)] hover:text-[var(--color-primary)] flex-shrink-0"
+            className="w-7 h-7 flex items-center justify-center rounded text-[var(--text-tertiary)] hover:text-[var(--text-primary)] hover:bg-[var(--color-base-alt)] transition"
           >
             ✕
           </button>
         </div>
 
-        {/* Detail grid */}
+        {/* Monto - highlighted block */}
+        <div className="bg-[var(--color-base-alt)] rounded-lg p-4 text-center">
+          <span className="text-2xl font-bold text-[var(--text-primary)]">
+            {formatCurrency(expense.amount, expense.currency)}
+          </span>
+        </div>
+
+        {/* Detail rows */}
         <div className="space-y-0">
-          {/* Monto */}
-          <div className="flex items-center justify-between p-3 bg-[var(--color-primary)]/10 rounded-lg mb-3">
-            <span className="text-xs text-[var(--text-secondary)]">Monto</span>
-            <span className="text-base font-bold text-[var(--color-primary)]">
-              {formatCurrency(expense.amount, expense.currency)}
-            </span>
-          </div>
-
-          {/* Fecha */}
-          <div className="flex items-center justify-between px-1 py-2.5 border-b border-[var(--border-color)]">
-            <span className="text-xs text-[var(--text-secondary)]">Fecha</span>
-            <span className="text-sm text-[var(--text-primary)]">{formatDateDMY(expense.date)}</span>
-          </div>
-
-          {/* Categoría */}
-          <div className="flex items-center justify-between px-1 py-2.5 border-b border-[var(--border-color)]">
-            <span className="text-xs text-[var(--text-secondary)]">Categoría</span>
-            {expense.category_name ? (
-              <span
-                className="px-2 py-0.5 rounded text-xs font-medium"
-                style={{
-                  backgroundColor: categoryColor + "20",
-                  color: categoryColor,
-                }}
-              >
-                {expense.category_name}
-              </span>
-            ) : (
-              <span className="text-xs text-[var(--text-tertiary)]">—</span>
-            )}
-          </div>
-
-          {/* Cuenta */}
-          <div className="flex items-center justify-between px-1 py-2.5 border-b border-[var(--border-color)]">
-            <span className="text-xs text-[var(--text-secondary)]">Cuenta</span>
-            <span className="text-sm text-[var(--text-primary)]">{accountLabel}</span>
-          </div>
-
-          {/* Cuotas */}
+          <DetailRow label="Fecha" value={formatDateDMY(expense.date)} />
+          <DetailRow
+            label="Categoría"
+            value={
+              expense.category_name ? (
+                <span
+                  className="px-2 py-0.5 rounded text-xs font-medium"
+                  style={{
+                    backgroundColor: categoryColor + "20",
+                    color: categoryColor,
+                  }}
+                >
+                  {expense.category_name}
+                </span>
+              ) : (
+                "—"
+              )
+            }
+          />
+          <DetailRow label="Cuenta" value={accountLabel} />
           {expense.installment_number && expense.installment_total && (
-            <div className="flex items-center justify-between px-1 py-2.5 border-b border-[var(--border-color)]">
-              <span className="text-xs text-[var(--text-secondary)]">Cuotas</span>
-              <span className="text-sm text-[var(--text-primary)]">
-                {expense.installment_number} / {expense.installment_total}
-              </span>
-            </div>
+            <DetailRow
+              label="Cuotas"
+              value={`${expense.installment_number} / ${expense.installment_total}`}
+            />
           )}
-
-          {/* Notas */}
-          <div className="flex items-center justify-between px-1 py-2.5">
-            <span className="text-xs text-[var(--text-secondary)]">Notas</span>
-            <span className="text-sm text-[var(--text-primary)] text-right max-w-[60%] truncate" title={expense.notes || "—"}>
-              {expense.notes || "—"}
-            </span>
-          </div>
+          <DetailRow label="Notas" value={expense.notes || "—"} truncate />
         </div>
 
         {/* Actions */}
@@ -131,6 +110,28 @@ export default function ExpenseDetailModal({ expense, onClose, onEdit }: Props) 
           </button>
         </div>
       </div>
+    </div>
+  );
+}
+
+function DetailRow({
+  label,
+  value,
+  truncate,
+}: {
+  label: string;
+  value: React.ReactNode;
+  truncate?: boolean;
+}) {
+  return (
+    <div className="flex items-center justify-between px-1 py-2 border-b border-[var(--border-color)] last:border-b-0">
+      <span className="text-xs text-[var(--text-secondary)]">{label}</span>
+      <span
+        className={`text-sm text-[var(--text-primary)] text-right ${truncate ? "max-w-[60%] truncate" : ""}`}
+        title={typeof value === "string" ? value : undefined}
+      >
+        {value}
+      </span>
     </div>
   );
 }

--- a/frontend/src/components/ExpenseDetailModal.tsx
+++ b/frontend/src/components/ExpenseDetailModal.tsx
@@ -1,12 +1,19 @@
 import { useEffect } from "react";
 import type { Expense } from "../types";
-import { formatCurrency, toUpperCase, formatDateDMY, getContrastTextColor } from "../utils/format";
+import { formatCurrency, toUpperCase, formatDateDMY } from "../utils/format";
 
 interface Props {
   expense: Expense;
   onClose: () => void;
   onEdit: () => void;
 }
+
+const ACCOUNT_TYPE_LABELS: Record<string, string> = {
+  efectivo: "Efectivo",
+  cuenta_corriente: "Cta. Corriente",
+  caja_ahorro: "Caja de Ahorro",
+  mercadopago: "MercadoPago",
+};
 
 export default function ExpenseDetailModal({ expense, onClose, onEdit }: Props) {
   useEffect(() => {
@@ -17,9 +24,19 @@ export default function ExpenseDetailModal({ expense, onClose, onEdit }: Props) 
     return () => document.removeEventListener("keydown", handleEscape);
   }, [onClose]);
 
-  const accountLabel = expense.card
-    ? `${expense.card}${expense.bank ? ` · ${expense.bank}` : ""}`
-    : expense.bank || "—";
+  const accountLabel = (() => {
+    if (expense.card) {
+      return `${expense.card}${expense.bank ? ` · ${expense.bank}` : ""}`;
+    }
+    if (expense.account_rel?.name) {
+      const typeLabel = ACCOUNT_TYPE_LABELS[expense.account_rel.type] || expense.account_rel.type;
+      return `${expense.account_rel.name} (${typeLabel})`;
+    }
+    if (expense.bank) return expense.bank;
+    return "—";
+  })();
+
+  const categoryColor = expense.category_color || "#9a9996";
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center p-4 animate-modal-backdrop">
@@ -40,9 +57,9 @@ export default function ExpenseDetailModal({ expense, onClose, onEdit }: Props) 
         </div>
 
         {/* Detail grid */}
-        <div className="space-y-3">
+        <div className="space-y-0">
           {/* Monto */}
-          <div className="flex items-center justify-between p-3 bg-[var(--color-base-alt)] rounded-lg">
+          <div className="flex items-center justify-between p-3 bg-[var(--color-base-alt)] rounded-lg mb-3">
             <span className="text-xs text-[var(--text-secondary)]">Monto</span>
             <span className="text-base font-bold text-[var(--text-primary)]">
               {formatCurrency(expense.amount, expense.currency)}
@@ -50,20 +67,20 @@ export default function ExpenseDetailModal({ expense, onClose, onEdit }: Props) 
           </div>
 
           {/* Fecha */}
-          <div className="flex items-center justify-between px-1 py-2 border-b border-[var(--border-color)]">
+          <div className="flex items-center justify-between px-1 py-2.5 border-b border-[var(--border-color)]">
             <span className="text-xs text-[var(--text-secondary)]">Fecha</span>
             <span className="text-sm text-[var(--text-primary)]">{formatDateDMY(expense.date)}</span>
           </div>
 
           {/* Categoría */}
-          <div className="flex items-center justify-between px-1 py-2 border-b border-[var(--border-color)]">
+          <div className="flex items-center justify-between px-1 py-2.5 border-b border-[var(--border-color)]">
             <span className="text-xs text-[var(--text-secondary)]">Categoría</span>
             {expense.category_name ? (
               <span
                 className="px-2 py-0.5 rounded text-xs font-medium"
                 style={{
-                  backgroundColor: (expense.category_color || "#9a9996") + "20",
-                  color: getContrastTextColor(expense.category_color || "#9a9996"),
+                  backgroundColor: categoryColor + "20",
+                  color: categoryColor,
                 }}
               >
                 {expense.category_name}
@@ -74,14 +91,14 @@ export default function ExpenseDetailModal({ expense, onClose, onEdit }: Props) 
           </div>
 
           {/* Cuenta */}
-          <div className="flex items-center justify-between px-1 py-2 border-b border-[var(--border-color)]">
+          <div className="flex items-center justify-between px-1 py-2.5 border-b border-[var(--border-color)]">
             <span className="text-xs text-[var(--text-secondary)]">Cuenta</span>
             <span className="text-sm text-[var(--text-primary)]">{accountLabel}</span>
           </div>
 
           {/* Cuotas */}
           {expense.installment_number && expense.installment_total && (
-            <div className="flex items-center justify-between px-1 py-2 border-b border-[var(--border-color)]">
+            <div className="flex items-center justify-between px-1 py-2.5 border-b border-[var(--border-color)]">
               <span className="text-xs text-[var(--text-secondary)]">Cuotas</span>
               <span className="text-sm text-[var(--text-primary)]">
                 {expense.installment_number} / {expense.installment_total}
@@ -90,16 +107,16 @@ export default function ExpenseDetailModal({ expense, onClose, onEdit }: Props) 
           )}
 
           {/* Notas */}
-          {expense.notes && (
-            <div className="px-1 py-2 border-b border-[var(--border-color)]">
-              <span className="text-xs text-[var(--text-secondary)]">Notas</span>
-              <p className="text-sm text-[var(--text-primary)] mt-1 whitespace-pre-wrap">{expense.notes}</p>
-            </div>
-          )}
+          <div className="px-1 py-2.5">
+            <span className="text-xs text-[var(--text-secondary)]">Notas</span>
+            <p className="text-sm text-[var(--text-primary)] mt-1 whitespace-pre-wrap">
+              {expense.notes || "—"}
+            </p>
+          </div>
         </div>
 
         {/* Actions */}
-        <div className="flex gap-2 pt-2">
+        <div className="flex gap-2 pt-1">
           <button
             onClick={onClose}
             className="flex-1 px-4 py-2 rounded-md border border-[var(--border-color)] text-sm font-medium text-[var(--text-secondary)] hover:bg-[var(--color-base-alt)] transition"

--- a/frontend/src/components/ExpenseDetailModal.tsx
+++ b/frontend/src/components/ExpenseDetailModal.tsx
@@ -1,0 +1,119 @@
+import { useEffect } from "react";
+import type { Expense } from "../types";
+import { formatCurrency, toUpperCase, formatDateDMY, getContrastTextColor } from "../utils/format";
+
+interface Props {
+  expense: Expense;
+  onClose: () => void;
+  onEdit: () => void;
+}
+
+export default function ExpenseDetailModal({ expense, onClose, onEdit }: Props) {
+  useEffect(() => {
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", handleEscape);
+    return () => document.removeEventListener("keydown", handleEscape);
+  }, [onClose]);
+
+  const accountLabel = expense.card
+    ? `${expense.card}${expense.bank ? ` · ${expense.bank}` : ""}`
+    : expense.bank || "—";
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4 animate-modal-backdrop">
+      <div className="fixed inset-0 bg-black/60" onClick={onClose} />
+      <div className="relative card w-full max-w-md p-6 space-y-4 animate-modal-content">
+        {/* Header */}
+        <div className="flex items-center justify-between">
+          <h2 className="text-lg font-semibold text-[var(--text-primary)] truncate pr-4">
+            {toUpperCase(expense.description)}
+          </h2>
+          <button
+            onClick={onClose}
+            aria-label="Cerrar"
+            className="text-[var(--text-tertiary)] hover:text-[var(--color-primary)] flex-shrink-0"
+          >
+            ✕
+          </button>
+        </div>
+
+        {/* Detail grid */}
+        <div className="space-y-3">
+          {/* Monto */}
+          <div className="flex items-center justify-between p-3 bg-[var(--color-base-alt)] rounded-lg">
+            <span className="text-xs text-[var(--text-secondary)]">Monto</span>
+            <span className="text-base font-bold text-[var(--text-primary)]">
+              {formatCurrency(expense.amount, expense.currency)}
+            </span>
+          </div>
+
+          {/* Fecha */}
+          <div className="flex items-center justify-between px-1 py-2 border-b border-[var(--border-color)]">
+            <span className="text-xs text-[var(--text-secondary)]">Fecha</span>
+            <span className="text-sm text-[var(--text-primary)]">{formatDateDMY(expense.date)}</span>
+          </div>
+
+          {/* Categoría */}
+          <div className="flex items-center justify-between px-1 py-2 border-b border-[var(--border-color)]">
+            <span className="text-xs text-[var(--text-secondary)]">Categoría</span>
+            {expense.category_name ? (
+              <span
+                className="px-2 py-0.5 rounded text-xs font-medium"
+                style={{
+                  backgroundColor: (expense.category_color || "#9a9996") + "20",
+                  color: getContrastTextColor(expense.category_color || "#9a9996"),
+                }}
+              >
+                {expense.category_name}
+              </span>
+            ) : (
+              <span className="text-xs text-[var(--text-tertiary)]">—</span>
+            )}
+          </div>
+
+          {/* Cuenta */}
+          <div className="flex items-center justify-between px-1 py-2 border-b border-[var(--border-color)]">
+            <span className="text-xs text-[var(--text-secondary)]">Cuenta</span>
+            <span className="text-sm text-[var(--text-primary)]">{accountLabel}</span>
+          </div>
+
+          {/* Cuotas */}
+          {expense.installment_number && expense.installment_total && (
+            <div className="flex items-center justify-between px-1 py-2 border-b border-[var(--border-color)]">
+              <span className="text-xs text-[var(--text-secondary)]">Cuotas</span>
+              <span className="text-sm text-[var(--text-primary)]">
+                {expense.installment_number} / {expense.installment_total}
+              </span>
+            </div>
+          )}
+
+          {/* Notas */}
+          {expense.notes && (
+            <div className="px-1 py-2 border-b border-[var(--border-color)]">
+              <span className="text-xs text-[var(--text-secondary)]">Notas</span>
+              <p className="text-sm text-[var(--text-primary)] mt-1 whitespace-pre-wrap">{expense.notes}</p>
+            </div>
+          )}
+        </div>
+
+        {/* Actions */}
+        <div className="flex gap-2 pt-2">
+          <button
+            onClick={onClose}
+            className="flex-1 px-4 py-2 rounded-md border border-[var(--border-color)] text-sm font-medium text-[var(--text-secondary)] hover:bg-[var(--color-base-alt)] transition"
+          >
+            Cerrar
+          </button>
+          <button
+            onClick={onEdit}
+            className="flex-1 px-4 py-2 rounded-md bg-[var(--color-primary)] text-white text-sm font-medium hover:brightness-110 transition"
+          >
+            Editar
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/ExpenseDetailModal.tsx
+++ b/frontend/src/components/ExpenseDetailModal.tsx
@@ -44,7 +44,7 @@ export default function ExpenseDetailModal({ expense, onClose, onEdit }: Props) 
       <div className="relative card w-full max-w-sm p-5 space-y-4 animate-modal-content">
         {/* Header */}
         <div className="flex items-center justify-between">
-          <h2 className="text-base font-semibold text-[var(--text-primary)] truncate pr-4">
+          <h2 className="text-base font-semibold text-primary truncate pr-4">
             {toUpperCase(expense.description)}
           </h2>
           <button

--- a/frontend/src/components/ExpenseDetailModal.tsx
+++ b/frontend/src/components/ExpenseDetailModal.tsx
@@ -59,9 +59,9 @@ export default function ExpenseDetailModal({ expense, onClose, onEdit }: Props) 
         {/* Detail grid */}
         <div className="space-y-0">
           {/* Monto */}
-          <div className="flex items-center justify-between p-3 bg-[var(--color-base-alt)] rounded-lg mb-3">
+          <div className="flex items-center justify-between p-3 bg-[var(--color-primary)]/10 rounded-lg mb-3">
             <span className="text-xs text-[var(--text-secondary)]">Monto</span>
-            <span className="text-base font-bold text-[var(--text-primary)]">
+            <span className="text-base font-bold text-[var(--color-primary)]">
               {formatCurrency(expense.amount, expense.currency)}
             </span>
           </div>
@@ -107,11 +107,11 @@ export default function ExpenseDetailModal({ expense, onClose, onEdit }: Props) 
           )}
 
           {/* Notas */}
-          <div className="px-1 py-2.5">
+          <div className="flex items-center justify-between px-1 py-2.5">
             <span className="text-xs text-[var(--text-secondary)]">Notas</span>
-            <p className="text-sm text-[var(--text-primary)] mt-1 whitespace-pre-wrap">
+            <span className="text-sm text-[var(--text-primary)] text-right max-w-[60%] truncate" title={expense.notes || "—"}>
               {expense.notes || "—"}
-            </p>
+            </span>
           </div>
         </div>
 

--- a/frontend/src/pages/ExpensesPage.tsx
+++ b/frontend/src/pages/ExpensesPage.tsx
@@ -561,8 +561,8 @@ export default function ExpensesPage() {
                       filterUncategorized
                         ? "__none__"
                         : filterCategory
-                          ? String(filterCategory)
-                          : ""
+                        ? String(filterCategory)
+                        : ""
                     }
                     onChange={(v) => handleCategoryFilter(v)}
                     options={[{ value: "__none__", label: "Sin categoría" }]}
@@ -596,8 +596,8 @@ export default function ExpensesPage() {
                 const currentCuenta = matchedCard
                   ? `card:${matchedCard.id}`
                   : matchedAccount
-                    ? `account:${matchedAccount.id}`
-                    : "";
+                  ? `account:${matchedAccount.id}`
+                  : "";
                 return (
                   <Select
                     value={currentCuenta}
@@ -762,8 +762,8 @@ export default function ExpensesPage() {
                                 const isHighlighted = selectedDonutCategory
                                   ? isSelected
                                   : filterSearch
-                                    ? isSearchMatch
-                                    : true;
+                                  ? isSearchMatch
+                                  : true;
                                 return (
                                   <Cell
                                     key={i}
@@ -797,10 +797,10 @@ export default function ExpensesPage() {
                                 selectedDonutCategory === cat.category_name
                                   ? "bg-[var(--color-primary)]/10"
                                   : filterSearch &&
-                                      cat.category_id != null &&
-                                      matchingCategories.has(cat.category_id)
-                                    ? "bg-[var(--color-primary)]/5"
-                                    : "hover:bg-[var(--color-base-alt)]"
+                                    cat.category_id != null &&
+                                    matchingCategories.has(cat.category_id)
+                                  ? "bg-[var(--color-primary)]/5"
+                                  : "hover:bg-[var(--color-base-alt)]"
                               }`}
                             >
                               <span
@@ -1019,7 +1019,9 @@ export default function ExpensesPage() {
                               : "hover:bg-[var(--color-base-alt)]/30"
                           } ${selectedIds.has(exp.id) ? "bg-[var(--color-primary)]/10" : ""}`}
                           style={missing ? { borderLeft: "3px solid #f6d32d" } : undefined}
-                          onClick={() => (selectMode ? toggleSelect(exp.id) : setDetailExpense(exp))}
+                          onClick={() =>
+                            selectMode ? toggleSelect(exp.id) : setDetailExpense(exp)
+                          }
                         >
                           {selectMode && (
                             <td className="px-3 py-3" onClick={(e) => e.stopPropagation()}>
@@ -1031,7 +1033,7 @@ export default function ExpensesPage() {
                               />
                             </td>
                           )}
-                            <td className="px-4 py-3 text-[var(--text-tertiary)] whitespace-nowrap">
+                          <td className="px-4 py-3 text-[var(--text-tertiary)] whitespace-nowrap">
                             <button
                               type="button"
                               onClick={(e) => {
@@ -1079,7 +1081,7 @@ export default function ExpensesPage() {
                               {exp.person && <span>{titleCase(exp.person)}</span>}
                             </div>
                           </td>
-                            <td className="px-4 py-3">
+                          <td className="px-4 py-3">
                             <button
                               type="button"
                               onClick={(e) => {
@@ -1103,7 +1105,7 @@ export default function ExpensesPage() {
                               )}
                             </button>
                           </td>
-                            <td className="px-4 py-3 text-right">
+                          <td className="px-4 py-3 text-right">
                             <button
                               type="button"
                               onClick={(e) => {

--- a/frontend/src/pages/ExpensesPage.tsx
+++ b/frontend/src/pages/ExpensesPage.tsx
@@ -1031,12 +1031,12 @@ export default function ExpensesPage() {
                               />
                             </td>
                           )}
-                          <td className="px-4 py-3 text-[var(--text-tertiary)] whitespace-nowrap">
+                            <td className="px-4 py-3 text-[var(--text-tertiary)] whitespace-nowrap">
                             <button
                               type="button"
                               onClick={(e) => {
                                 e.stopPropagation();
-                                setEditing(exp);
+                                setDetailExpense(exp);
                               }}
                               className="text-left hover:text-primary transition"
                             >
@@ -1057,7 +1057,7 @@ export default function ExpensesPage() {
                                 type="button"
                                 onClick={(e) => {
                                   e.stopPropagation();
-                                  setEditing(exp);
+                                  setDetailExpense(exp);
                                 }}
                                 className="text-left hover:text-primary transition"
                               >
@@ -1079,12 +1079,12 @@ export default function ExpensesPage() {
                               {exp.person && <span>{titleCase(exp.person)}</span>}
                             </div>
                           </td>
-                          <td className="px-4 py-3">
+                            <td className="px-4 py-3">
                             <button
                               type="button"
                               onClick={(e) => {
                                 e.stopPropagation();
-                                setEditing(exp);
+                                setDetailExpense(exp);
                               }}
                               className="text-left"
                             >
@@ -1103,12 +1103,12 @@ export default function ExpensesPage() {
                               )}
                             </button>
                           </td>
-                          <td className="px-4 py-3 text-right">
+                            <td className="px-4 py-3 text-right">
                             <button
                               type="button"
                               onClick={(e) => {
                                 e.stopPropagation();
-                                setEditing(exp);
+                                setDetailExpense(exp);
                               }}
                               className="text-right hover:text-primary transition"
                             >

--- a/frontend/src/pages/ExpensesPage.tsx
+++ b/frontend/src/pages/ExpensesPage.tsx
@@ -18,6 +18,7 @@ import {
 import type { Expense, ExpenseCreate } from "../types";
 import { Select } from "../components/ui/Select";
 import { ExpenseModal } from "../components/ExpenseModals";
+import ExpenseDetailModal from "../components/ExpenseDetailModal";
 import EmptyState from "../components/ui/EmptyState";
 import {
   PieChart,
@@ -216,6 +217,7 @@ export default function ExpensesPage() {
   }, [filterSearch, expenses]);
 
   const [editing, setEditing] = useState<Expense | null | undefined>(undefined);
+  const [detailExpense, setDetailExpense] = useState<Expense | null>(null);
   const [saveError, setSaveError] = useState<string | null>(null);
   const [debouncedSearch, setDebouncedSearch] = useState(filterSearch ?? "");
   const [filtersExpanded, setFiltersExpanded] = useState(false);
@@ -1017,7 +1019,7 @@ export default function ExpensesPage() {
                               : "hover:bg-[var(--color-base-alt)]/30"
                           } ${selectedIds.has(exp.id) ? "bg-[var(--color-primary)]/10" : ""}`}
                           style={missing ? { borderLeft: "3px solid #f6d32d" } : undefined}
-                          onClick={() => (selectMode ? toggleSelect(exp.id) : setEditing(exp))}
+                          onClick={() => (selectMode ? toggleSelect(exp.id) : setDetailExpense(exp))}
                         >
                           {selectMode && (
                             <td className="px-3 py-3" onClick={(e) => e.stopPropagation()}>
@@ -1260,6 +1262,17 @@ export default function ExpensesPage() {
             </div>
           </div>
         </>
+      )}
+
+      {detailExpense && (
+        <ExpenseDetailModal
+          expense={detailExpense}
+          onClose={() => setDetailExpense(null)}
+          onEdit={() => {
+            setDetailExpense(null);
+            setEditing(detailExpense);
+          }}
+        />
       )}
 
       {editing !== undefined && (

--- a/frontend/src/pages/ExpensesPage.tsx
+++ b/frontend/src/pages/ExpensesPage.tsx
@@ -561,8 +561,8 @@ export default function ExpensesPage() {
                       filterUncategorized
                         ? "__none__"
                         : filterCategory
-                        ? String(filterCategory)
-                        : ""
+                          ? String(filterCategory)
+                          : ""
                     }
                     onChange={(v) => handleCategoryFilter(v)}
                     options={[{ value: "__none__", label: "Sin categoría" }]}
@@ -596,8 +596,8 @@ export default function ExpensesPage() {
                 const currentCuenta = matchedCard
                   ? `card:${matchedCard.id}`
                   : matchedAccount
-                  ? `account:${matchedAccount.id}`
-                  : "";
+                    ? `account:${matchedAccount.id}`
+                    : "";
                 return (
                   <Select
                     value={currentCuenta}
@@ -762,8 +762,8 @@ export default function ExpensesPage() {
                                 const isHighlighted = selectedDonutCategory
                                   ? isSelected
                                   : filterSearch
-                                  ? isSearchMatch
-                                  : true;
+                                    ? isSearchMatch
+                                    : true;
                                 return (
                                   <Cell
                                     key={i}
@@ -797,10 +797,10 @@ export default function ExpensesPage() {
                                 selectedDonutCategory === cat.category_name
                                   ? "bg-[var(--color-primary)]/10"
                                   : filterSearch &&
-                                    cat.category_id != null &&
-                                    matchingCategories.has(cat.category_id)
-                                  ? "bg-[var(--color-primary)]/5"
-                                  : "hover:bg-[var(--color-base-alt)]"
+                                      cat.category_id != null &&
+                                      matchingCategories.has(cat.category_id)
+                                    ? "bg-[var(--color-primary)]/5"
+                                    : "hover:bg-[var(--color-base-alt)]"
                               }`}
                             >
                               <span


### PR DESCRIPTION
## Changes

### Feature
- Clicking an expense row in /expenses now opens a summary modal showing: category, account, date, description, amount, notes
- Summary modal has two buttons: Cerrar (dismiss) and Editar (open edit modal)
- Edit icon button in actions column still opens edit modal directly

### Files Changed
- ExpenseDetailModal.tsx (new)
- ExpensesPage.tsx
- Roadmap.md