### PR TITLE
fix: telegram bot stores card_id when selecting existing card

### DIFF
--- a/backend/app/telegram_bot.py
+++ b/backend/app/telegram_bot.py
@@ -645,6 +645,23 @@ async def handle_card_type(update: Update, context: ContextTypes.DEFAULT_TYPE) -
     context.user_data["card_selected"] = card
     context.user_data["payment_label"] = label
 
+    # Look up card_id from DB so the expense is linked to the card
+    db_card = SessionLocal()
+    try:
+        card_obj = (
+            db_card.query(Card)
+            .filter(
+                Card.user_id == context.user_data["user_id"],
+                func.lower(Card.card_name) == card.lower(),
+                func.lower(Card.bank) == bank.lower(),
+            )
+            .first()
+        )
+        if card_obj:
+            context.user_data["card_id"] = card_obj.id
+    finally:
+        db_card.close()
+
     # Run early categorization to determine if we need to ask about installments
     parsed = context.user_data["parsed"]
     db = SessionLocal()
@@ -1188,6 +1205,23 @@ async def handle_card_manual(update: Update, context: ContextTypes.DEFAULT_TYPE)
     label = f"{bank} {card_name}".strip() if bank else card_name
     context.user_data["card_selected"] = card_name
     context.user_data["payment_label"] = label
+
+    # Look up card_id from DB if the card exists
+    db_card = SessionLocal()
+    try:
+        card_obj = (
+            db_card.query(Card)
+            .filter(
+                Card.user_id == context.user_data["user_id"],
+                func.lower(Card.card_name) == card_name.lower(),
+                func.lower(Card.bank) == bank.lower() if bank else True,
+            )
+            .first()
+        )
+        if card_obj:
+            context.user_data["card_id"] = card_obj.id
+    finally:
+        db_card.close()
 
     # Run early categorization
     parsed = context.user_data["parsed"]


### PR DESCRIPTION
## Bug
Expenses created via Telegram bot were not linked to the correct card/account even though the bot confirmed it saved the data.

## Root Cause
When a user selected an existing card, `handle_card_type` stored the card name and bank but never looked up or stored the `card_id`. The `card_id` was always `None` when passed to `_save_expense`.

## Fix
- `handle_card_type`: look up `card_id` from DB using `(user_id, card_name, bank)` after card selection
- `handle_card_manual`: same lookup after manual card name entry
- `handle_card_create_confirm` and `handle_account_select` already worked correctly

### Files Changed
- backend/app/telegram_bot.py