### PR TITLE
fix: dashboard layout — equal height boxes, category limit, transaction scroll

### DIFF
--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -401,9 +401,9 @@ export default function Dashboard() {
       </div>
 
       {/* Gastos por Categoría + Transacciones — side by side */}
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 max-h-[420px]">
         {/* Left: Gastos por Categoría */}
-        <div className="card p-4 min-h-[200px] h-full flex flex-col">
+        <div className="card p-4 min-h-[200px] h-full flex flex-col overflow-hidden">
           <div className="flex items-center justify-between mb-3">
             <div className="flex items-center gap-2">
               <h2 className="text-sm font-semibold text-primary">Gastos por Categoría</h2>

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -219,17 +219,17 @@ export default function Dashboard() {
       .filter((c) => c.total > 0)
       .sort((a, b) => b.total - a.total);
 
-    if (allCats.length <= 7) return allCats;
+    if (allCats.length <= 6) return allCats;
 
-    const top7 = allCats.slice(0, 7);
-    const othersTotal = allCats.slice(7).reduce((sum, c) => sum + c.total, 0);
+    const top6 = allCats.slice(0, 6);
+    const othersTotal = allCats.slice(6).reduce((sum, c) => sum + c.total, 0);
 
     if (othersTotal > 0) {
       const othersPreviousTotal = allCats
-        .slice(7)
+        .slice(6)
         .reduce((sum, c) => sum + (c.previous_total ?? 0), 0);
       return [
-        ...top7,
+        ...top6,
         {
           category_name: "Otros",
           category_color: "#94a3b8",
@@ -239,7 +239,7 @@ export default function Dashboard() {
         },
       ];
     }
-    return top7;
+    return top6;
   }, [dashData?.by_category]);
 
   const maxCatTotal = categories[0]?.total ?? 1;
@@ -432,7 +432,7 @@ export default function Dashboard() {
               description="Los gastos por categoría aparecerán aquí"
             />
           ) : (
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 overflow-y-auto flex-1 min-h-0">
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 flex-1">
               {/* Pie chart */}
               <div className="flex items-center justify-center">
                 <ResponsiveContainer width="100%" height={220}>
@@ -480,7 +480,7 @@ export default function Dashboard() {
               </div>
 
               {/* Bars */}
-              <div className="space-y-2 overflow-y-auto flex-1 min-h-0 p-1">
+              <div className="space-y-1.5 p-1">
                 {categories.map((cat, i) => {
                   const pct = (cat.total / maxCatTotal) * 100;
                   const color = cat.category_color || FALLBACK_COLORS[i % FALLBACK_COLORS.length];

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -401,9 +401,9 @@ export default function Dashboard() {
       </div>
 
       {/* Gastos por Categoría + Transacciones — side by side */}
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 max-h-[420px]">
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         {/* Left: Gastos por Categoría */}
-        <div className="card p-4 min-h-[200px] h-full flex flex-col overflow-hidden">
+        <div className="card p-4 h-[420px] flex flex-col overflow-hidden">
           <div className="flex items-center justify-between mb-3">
             <div className="flex items-center gap-2">
               <h2 className="text-sm font-semibold text-primary">Gastos por Categoría</h2>
@@ -544,7 +544,7 @@ export default function Dashboard() {
         </div>
 
         {/* Right: Transacciones */}
-        <div className="card min-h-[200px] h-full flex flex-col">
+        <div className="card h-[420px] flex flex-col">
           <div className="px-4 py-3 border-b border-border-color flex items-center justify-between flex-shrink-0">
             <div className="flex items-center gap-2">
               <h2 className="text-sm font-semibold text-primary">


### PR DESCRIPTION
## Changes

### Dashboard Fixes
- Transacciones card scrolls instead of growing infinitely (Issue #45)
- Both Gastos por Categoría and Transacciones boxes same height (fixed h-[420px])
- Gastos por Categoría shows top 6 categories + Others (was 7)
- Removed scrolling from category bars list
- Grid max-h constraint replaced with per-card fixed height to prevent overlap with Tarjetas/Programados section

**Fixes Issues:** #45