### PR TITLE
fix: installment system — 5 bugs (Issue #48)

### DIFF
--- a/backend/app/routers/dashboard.py
+++ b/backend/app/routers/dashboard.py
@@ -326,8 +326,31 @@ def get_summary(
             groups[e.installment_group_id] = []
         groups[e.installment_group_id].append(e)
 
+    # Also query ScheduledExpenses to avoid double-counting
+    from app.models import ScheduledExpense
+
+    scheduled = (
+        db.query(ScheduledExpense)
+        .filter(
+            ScheduledExpense.user_id.in_(uid_list),
+            ScheduledExpense.status == "PENDING",
+            ScheduledExpense.installment_group_id.isnot(None),
+        )
+        .all()
+    )
+    scheduled_months: dict = {}
+    for se in scheduled:
+        if se.installment_group_id not in scheduled_months:
+            scheduled_months[se.installment_group_id] = set()
+        smonth = (
+            se.scheduled_date.strftime("%Y-%m")
+            if isinstance(se.scheduled_date, date)
+            else str(se.scheduled_date)[:7]
+        )
+        scheduled_months[se.installment_group_id].add(smonth)
+
     trend_future: dict = {}
-    for _gid, exps in groups.items():
+    for gid, exps in groups.items():
         exps_sorted = sorted(exps, key=lambda x: x.installment_number or 0)
         total_inst = exps_sorted[0].installment_total or 0
         paid = len(exps_sorted)
@@ -340,6 +363,9 @@ def get_summary(
         for i in range(1, remaining + 1):
             future_date = add_months(last_date, i)
             future_key = future_date.strftime("%Y-%m")
+            # Skip months that already have scheduled expenses
+            if gid in scheduled_months and future_key in scheduled_months[gid]:
+                continue
             if future_key not in trend_future:
                 trend_future[future_key] = 0.0
             trend_future[future_key] += inst_amount
@@ -632,7 +658,7 @@ def get_installments_monthly_load(
             }
         groups[gid]["paid"].append((e.installment_number or 0, e.date))
 
-    for g in groups.values():
+    for gid, g in groups.items():
         paid = len(g["paid"])
         remaining = max(0, g["installment_total"] - paid)
         if remaining == 0 or not g["paid"]:
@@ -643,11 +669,7 @@ def get_installments_monthly_load(
             charge_date = add_months(next_date, i)
             key = charge_date.strftime("%Y-%m")
             # Skip months that already have scheduled expenses
-            gid = max(
-                (k for k, v in groups.items() if v["paid"] == g["paid"]),
-                default=None,
-            )
-            if gid and gid in scheduled_months and key in scheduled_months[gid]:
+            if gid in scheduled_months and key in scheduled_months[gid]:
                 continue
             if key >= current_month and key in monthly:
                 monthly[key]["total"] += g["amount"]

--- a/backend/app/routers/import_jobs.py
+++ b/backend/app/routers/import_jobs.py
@@ -347,6 +347,18 @@ async def confirm_import_job(
         if is_scheduled:
             # Create ScheduledExpense
             try:
+                # Resolve card_id from mapping
+                scheduled_card_id = None
+                if isinstance(mapping_entry, dict) and mapping_entry.get("card_id"):
+                    scheduled_card_id = mapping_entry["card_id"]
+                elif isinstance(mapping_entry, dict) and mapping_entry.get("bank"):
+                    card_obj, _ = find_or_create_card(
+                        mapping_entry.get("bank", ""),
+                        mapping_entry.get("card_name", ""),
+                        mapping_entry.get("card_type", "credito"),
+                    )
+                    scheduled_card_id = card_obj.id if card_obj else None
+
                 scheduled = ScheduledExpense(
                     scheduled_date=row_date,
                     description=_normalize_text(r.get("description", "")),
@@ -359,6 +371,7 @@ async def confirm_import_job(
                     installment_group_id=r.get("installment_group_id"),
                     status="PENDING",
                     user_id=user.id,
+                    card_id=scheduled_card_id,
                 )
                 db.add(scheduled)
                 scheduled_count += 1

--- a/backend/app/services/import_utils.py
+++ b/backend/app/services/import_utils.py
@@ -456,13 +456,13 @@ def _detect_installment_pattern(description: str) -> tuple[int, int] | None:
     m = re.search(r"(\d{1,2})/(\d{1,2})$", s)
     if m:
         num, total = int(m.group(1)), int(m.group(2))
-        if total >= 2 and num >= 2 and 1 <= num <= total:
+        if total >= 2 and 1 <= num <= total:
             return (num, total)
 
     m = re.search(r"(\d{1,2})/(\d{1,2})(?:\s|$)", s)
     if m:
         num, total = int(m.group(1)), int(m.group(2))
-        if total >= 2 and num >= 2 and 1 <= num <= total:
+        if total >= 2 and 1 <= num <= total:
             return (num, total)
 
     return None

--- a/backend/app/telegram_bot.py
+++ b/backend/app/telegram_bot.py
@@ -1191,6 +1191,29 @@ async def handle_confirm(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
                 predicted_category_id=predicted_category_id,
             )
 
+        # Create ScheduledExpenses for future installments (2..N)
+        if installment_total and installment_group_id and installment_total >= 2:
+            from app.models import ScheduledExpense
+            from app.services.date_utils import add_months
+
+            for i in range(2, installment_total + 1):
+                scheduled = ScheduledExpense(
+                    installment_group_id=installment_group_id,
+                    installment_number=i,
+                    installment_total=installment_total,
+                    scheduled_date=add_months(expense.date, i - 1),
+                    amount=expense.amount,
+                    currency=expense.currency,
+                    description=expense.description,
+                    card_id=expense.card_id,
+                    account_id=expense.account_id,
+                    category_id=expense.category_id,
+                    status="PENDING",
+                    user_id=user_id,
+                )
+                db.add(scheduled)
+            db.commit()
+
         await query.edit_message_text(
             _saved_text(expense, payment_label),
             parse_mode="Markdown",


### PR DESCRIPTION
## Changes

### Bug 1: Telegram bot creates ScheduledExpenses for future installments
- After first Expense, creates N-1 ScheduledExpense records with proper dates
- Includes card_id, account_id, category_id from first expense

### Bug 2: Fix monthly-load projection double-avoidance logic
- Changed loop to use items() instead of values() to get group key
- Removed broken max() lookup that matched wrong group

### Bug 3: Unify projection algorithms between /summary and /monthly-load
- /summary now queries ScheduledExpenses and skips months with existing records
- Both endpoints use same logic to avoid double-counting

### Bug 4: Fix pattern detection for 1/N installments
- Removed 'num >= 2' restriction from regex patterns
- Now detects '1/6' (first installment)

### Bug 5: Add card_id to ScheduledExpenses from imports
- ScheduledExpense now resolves card_id from cards_mapping

**Fixes Issue:** #48