### PR TITLE
fix: dashboard credit cards — debt projection + show all payment methods

### DIFF
--- a/backend/app/routers/dashboard.py
+++ b/backend/app/routers/dashboard.py
@@ -804,6 +804,7 @@ def get_credit_card_pasivos(
     )
     credit_card_ids = {c.id for c in credit_cards}
 
+    # 1) Sum PENDING ScheduledExpenses for credit cards
     pending_pasivos = (
         db.query(ScheduledExpense)
         .filter(
@@ -822,12 +823,14 @@ def get_credit_card_pasivos(
 
     total_pasivos = 0.0
     pasivos_detail = []
+    scheduled_gids: set = set()
 
     for s in pending_pasivos:
         is_credit_card = s.card_id is not None and s.card_id in credit_card_ids
 
         if is_credit_card:
             total_pasivos += s.amount
+            scheduled_gids.add(s.installment_group_id)
         card_name, card_bank = "", ""
         if s.card_id and s.card_id in cards_by_id:
             c = cards_by_id[s.card_id]
@@ -845,6 +848,63 @@ def get_credit_card_pasivos(
                     "bank": card_bank,
                 }
             )
+
+    # 2) Project future installments from Expenses for credit cards
+    #    (only for groups that don't already have ScheduledExpenses)
+    installment_exp = (
+        db.query(Expense)
+        .filter(
+            Expense.user_id.in_(uid_list),
+            Expense.installment_group_id != None,
+            Expense.installment_group_id != "",
+            Expense.card_id.in_(credit_card_ids),
+        )
+        .all()
+    )
+
+    groups: dict = {}
+    for e in installment_exp:
+        gid = e.installment_group_id
+        if gid not in groups:
+            groups[gid] = {
+                "installment_total": e.installment_total or 0,
+                "amount": abs(e.amount),
+                "paid": [],
+                "card_id": e.card_id,
+            }
+        groups[gid]["paid"].append(e.installment_number or 0)
+
+    for gid, g in groups.items():
+        if gid in scheduled_gids:
+            continue  # Already counted via ScheduledExpenses
+        paid = len(g["paid"])
+        remaining = max(0, g["installment_total"] - paid)
+        if remaining == 0:
+            continue
+        total_pasivos += g["amount"] * remaining
+        # Add to detail
+        card_name, card_bank = "", ""
+        if g["card_id"] and g["card_id"] in cards_by_id:
+            c = cards_by_id[g["card_id"]]
+            card_name, card_bank = c.card_name, c.bank or ""
+        elif g["card_id"]:
+            c = db.query(Card).filter(Card.id == g["card_id"]).first()
+            if c:
+                card_name, card_bank = c.card_name, c.bank or ""
+                cards_by_id[c.id] = c
+        pasivos_detail.append(
+            {
+                "id": None,
+                "description": f"Cuotas {paid + 1}-{g['installment_total']}",
+                "amount": g["amount"] * remaining,
+                "currency": "ARS",
+                "scheduled_date": None,
+                "installment_number": paid + 1,
+                "installment_total": g["installment_total"],
+                "card": card_name,
+                "bank": card_bank,
+            }
+        )
 
     return {
         "total_pasivos": total_pasivos,

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -640,7 +640,7 @@ export default function Dashboard() {
         {/* Credit cards */}
         <div className="card p-4">
           <div className="flex items-center justify-between mb-3">
-            <h2 className="text-sm font-semibold text-primary">Tarjetas de Crédito</h2>
+            <h2 className="text-sm font-semibold text-primary">Métodos de Pago</h2>
             <button
               onClick={() => navigate("/accounts")}
               className="text-xs text-secondary hover:text-primary transition-colors"
@@ -651,27 +651,25 @@ export default function Dashboard() {
           {cardData.length === 0 ? (
             <EmptyState
               icon="💳"
-              title="Sin tarjetas registradas"
-              description="Creá una tarjeta para ver el resumen de gastos"
-              action={{ label: "Crear tarjeta", onClick: () => navigate("/accounts") }}
+              title="Sin tarjetas ni cuentas"
+              description="Creá una tarjeta o cuenta para ver el resumen"
+              action={{ label: "Crear cuenta", onClick: () => navigate("/accounts") }}
             />
           ) : (
             <div className="divide-y divide-border-color">
-              {cardData
-                .filter((c) => c.card_type === "credito")
-                .map((card, i) => {
-                  const monthEntry = card.monthly?.find((m) => m.month === month);
-                  return (
-                    <CardRow
-                      key={i}
-                      cardName={card.card_name}
-                      bank={card.bank}
-                      total={monthEntry?.total ?? 0}
-                      cardType={card.card_type}
-                      holder={card.holder}
-                    />
-                  );
-                })}
+              {cardData.map((card, i) => {
+                const monthEntry = card.monthly?.find((m) => m.month === month);
+                return (
+                  <CardRow
+                    key={i}
+                    cardName={card.card_name}
+                    bank={card.bank}
+                    total={monthEntry?.total ?? 0}
+                    cardType={card.card_type}
+                    holder={card.holder}
+                  />
+                );
+              })}
             </div>
           )}
         </div>


### PR DESCRIPTION
## Changes

### Issue #51: Deuda Tarjetas missing future payments
- `credit-card-pasivos` endpoint now projects future installments from Expense records
- Adds amounts where `remaining = installment_total - paid > 0`
- Skips groups that already have ScheduledExpenses (avoids double-counting)

### Issue #52: Dashboard only shows credit cards
- Removed `.filter(card_type === 'credito')` from card summary
- Section now shows all payment methods (credit cards + debit accounts)
- Updated title: 'Tarjetas de Crédito' → 'Métodos de Pago'

**Fixes Issues:** #51, #52