### PR TITLE
fix: installments remaining count + encrypt investment credentials

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -231,6 +231,7 @@ jobs:
             echo "Running database migrations..."
             podman-compose run --rm --no-deps backend python -m scripts.migrate_add_reset_token || echo "Migration skipped or failed (non-fatal)"
             podman-compose run --rm --no-deps backend python -m scripts.migrate_remove_haberes || echo "Haberes cleanup skipped or failed (non-fatal)"
+            podman-compose run --rm --no-deps backend python -m scripts.migrate_encrypt_settings || echo "Encryption migration skipped or failed (non-fatal)"
 
             # Clean shutdown of old containers before starting new ones
             echo "Stopping old containers..."

--- a/backend/app/routers/dashboard.py
+++ b/backend/app/routers/dashboard.py
@@ -831,11 +831,12 @@ def get_credit_card_pasivos(
 
         if is_credit_card:
             total_pasivos += s.amount
-            scheduled_gids.add(s.installment_group_id)
         card_name, card_bank = "", ""
         if s.card_id and s.card_id in cards_by_id:
             c = cards_by_id[s.card_id]
             card_name, card_bank = c.card_name, c.bank or ""
+            # Track group to avoid double-counting with Expense projection
+            scheduled_gids.add(s.installment_group_id)
             pasivos_detail.append(
                 {
                     "id": s.id,

--- a/backend/app/routers/dashboard.py
+++ b/backend/app/routers/dashboard.py
@@ -831,25 +831,27 @@ def get_credit_card_pasivos(
 
         if is_credit_card:
             total_pasivos += s.amount
+
+        # Always track group to prevent Expense projection double-counting
+        scheduled_gids.add(s.installment_group_id)
+
         card_name, card_bank = "", ""
         if s.card_id and s.card_id in cards_by_id:
             c = cards_by_id[s.card_id]
             card_name, card_bank = c.card_name, c.bank or ""
-            # Track group to avoid double-counting with Expense projection
-            scheduled_gids.add(s.installment_group_id)
-            pasivos_detail.append(
-                {
-                    "id": s.id,
-                    "description": s.description,
-                    "amount": s.amount,
-                    "currency": s.currency or "ARS",
-                    "scheduled_date": s.scheduled_date.isoformat(),
-                    "installment_number": s.installment_number,
-                    "installment_total": s.installment_total,
-                    "card": card_name,
-                    "bank": card_bank,
-                }
-            )
+        pasivos_detail.append(
+            {
+                "id": s.id,
+                "description": s.description,
+                "amount": s.amount,
+                "currency": s.currency or "ARS",
+                "scheduled_date": s.scheduled_date.isoformat(),
+                "installment_number": s.installment_number,
+                "installment_total": s.installment_total,
+                "card": card_name,
+                "bank": card_bank,
+            }
+        )
 
     # 2) Project future installments from Expenses for credit cards
     #    (only for groups that don't already have ScheduledExpenses)

--- a/backend/app/routers/dashboard.py
+++ b/backend/app/routers/dashboard.py
@@ -829,11 +829,14 @@ def get_credit_card_pasivos(
     for s in pending_pasivos:
         is_credit_card = s.card_id is not None and s.card_id in credit_card_ids
 
-        if is_credit_card:
-            total_pasivos += s.amount
-
         # Always track group to prevent Expense projection double-counting
         scheduled_gids.add(s.installment_group_id)
+
+        # Only count credit card scheduled expenses
+        if not is_credit_card:
+            continue
+
+        total_pasivos += s.amount
 
         card_name, card_bank = "", ""
         if s.card_id and s.card_id in cards_by_id:

--- a/backend/app/routers/dashboard.py
+++ b/backend/app/routers/dashboard.py
@@ -647,6 +647,7 @@ def get_installments_monthly_load(
 
     # Add ScheduledExpense amounts directly to their months
     scheduled_gids: set = set()
+    scheduled_count_by_gid: dict = {}
     for se in scheduled:
         smonth = (
             se.scheduled_date.strftime("%Y-%m")
@@ -657,6 +658,9 @@ def get_installments_monthly_load(
             monthly[smonth]["total"] += abs(se.amount)
             monthly[smonth]["count"] += 1
         scheduled_gids.add(se.installment_group_id)
+        scheduled_count_by_gid[se.installment_group_id] = (
+            scheduled_count_by_gid.get(se.installment_group_id, 0) + 1
+        )
 
     groups: dict = {}
     for e in exps:
@@ -669,18 +673,22 @@ def get_installments_monthly_load(
             }
         groups[gid]["paid"].append((e.installment_number or 0, e.date))
 
-    # Project remaining installments ONLY for groups without ScheduledExpenses
+    # Project remaining installments for ALL groups with unpaid balance
+    # For groups with ScheduledExpenses: project only the unprojected portion
+    # For groups without ScheduledExpenses: project all remaining
     for gid, g in groups.items():
-        if gid in scheduled_gids:
-            continue
         paid = len(g["paid"])
         remaining = max(0, g["installment_total"] - paid)
         if remaining == 0 or not g["paid"]:
             continue
+        scheduled_count = scheduled_count_by_gid.get(gid, 0)
+        unprojected = max(0, remaining - scheduled_count)
+        if unprojected == 0:
+            continue
         max_num, max_date = max(g["paid"], key=lambda x: x[0])
         next_date = add_months(max_date, 1)
-        for i in range(remaining):
-            charge_date = add_months(next_date, i)
+        for i in range(unprojected):
+            charge_date = add_months(next_date, scheduled_count + i)
             key = charge_date.strftime("%Y-%m")
             if key >= current_month and key in monthly:
                 monthly[key]["total"] += g["amount"]

--- a/backend/app/routers/dashboard.py
+++ b/backend/app/routers/dashboard.py
@@ -883,7 +883,7 @@ def get_credit_card_pasivos(
         if remaining == 0:
             continue
         total_pasivos += g["amount"] * remaining
-        # Add to detail
+        # Add to detail — one entry per remaining installment
         card_name, card_bank = "", ""
         if g["card_id"] and g["card_id"] in cards_by_id:
             c = cards_by_id[g["card_id"]]
@@ -893,19 +893,22 @@ def get_credit_card_pasivos(
             if c:
                 card_name, card_bank = c.card_name, c.bank or ""
                 cards_by_id[c.id] = c
-        pasivos_detail.append(
-            {
-                "id": None,
-                "description": f"Cuotas {paid + 1}-{g['installment_total']}",
-                "amount": g["amount"] * remaining,
-                "currency": "ARS",
-                "scheduled_date": None,
-                "installment_number": paid + 1,
-                "installment_total": g["installment_total"],
-                "card": card_name,
-                "bank": card_bank,
-            }
-        )
+        for i in range(remaining):
+            pasivos_detail.append(
+                {
+                    "id": None,
+                    "description": g.get(
+                        "description", f"Cuota {paid + i + 1}/{g['installment_total']}"
+                    ),
+                    "amount": g["amount"],
+                    "currency": "ARS",
+                    "scheduled_date": None,
+                    "installment_number": paid + i + 1,
+                    "installment_total": g["installment_total"],
+                    "card": card_name,
+                    "bank": card_bank,
+                }
+            )
 
     return {
         "total_pasivos": total_pasivos,

--- a/backend/app/routers/dashboard.py
+++ b/backend/app/routers/dashboard.py
@@ -558,17 +558,20 @@ def get_installments_dashboard(
         next_dates = sorted(g["next_dates"])
         next_date = next_dates[0] if next_dates else None
 
+        # CORRECT: remaining = total - paid (not count of ScheduledExpenses)
+        remaining = max(0, g["installment_total"] - g["installments_paid"])
+
         result.append(
             {
                 "installment_group_id": g["installment_group_id"],
                 "description": g["description"],
                 "installment_total": g["installment_total"],
                 "installments_paid": g["installments_paid"],
-                "remaining_installments": g["remaining_installments"],
+                "remaining_installments": remaining,
                 "total_amount": g["total_amount"],
                 "installment_amount": g["installment_amount"],
                 "next_date": next_date,
-                "next_dates": next_dates,  # NUEVO: array de todas las fechas
+                "next_dates": next_dates,
                 "category_id": g["category_id"],
                 "category_name": g["category_name"],
                 "category_color": g["category_color"],
@@ -593,13 +596,7 @@ def get_installments_monthly_load(
     current_month = today.strftime("%Y-%m")
     uid_list = get_group_user_ids(current_user.id, db)
 
-    # Build window: 3 months back to 3 months forward
-    window_start = add_months(today, -3)
-    window_end = add_months(today, 3)
-    window_start.strftime("%Y-%m")
-    window_end.strftime("%Y-%m")
-
-    # Initialize all 7 months in window with zeros
+    # Initialize all 7 months in window with zeros (3 past, current, 3 future)
     monthly: dict = {}
     for offset in range(-3, 4):
         m = add_months(today, offset)

--- a/backend/app/routers/dashboard.py
+++ b/backend/app/routers/dashboard.py
@@ -44,9 +44,10 @@ def _load_cards_and_accounts(uid_list: list[int], expenses: list[Expense], db: S
     # Cards: only from group members
     cards_by_id = {c.id: c for c in db.query(Card).filter(Card.user_id.in_(uid_list)).all()}
 
-    # Accounts: only from group members
+    # Accounts: only from group members — return name + type for display
     accounts_by_id = {
-        a.id: a.type for a in db.query(Account).filter(Account.user_id.in_(uid_list)).all()
+        a.id: {"name": a.name, "type": a.type}
+        for a in db.query(Account).filter(Account.user_id.in_(uid_list)).all()
     }
 
     return cards_by_id, accounts_by_id
@@ -1033,11 +1034,13 @@ def get_card_summary(db: Session = Depends(get_db), current_user: User = Depends
                 }
             else:
                 acct_id = int(key.split(":")[1])
-                acct_type = user_accounts_by_id.get(acct_id, "efectivo")
+                acct_info = user_accounts_by_id.get(
+                    acct_id, {"name": "Efectivo", "type": "efectivo"}
+                )
                 by_card[key] = {
                     "bank": "",
                     "network": "unknown",
-                    "card_name": acct_type.replace("_", " ").title(),
+                    "card_name": acct_info["name"],
                     "holder": "",
                     "card_type": "debito",
                     "total_amount": 0.0,

--- a/backend/app/routers/dashboard.py
+++ b/backend/app/routers/dashboard.py
@@ -648,6 +648,7 @@ def get_installments_monthly_load(
     # Add ScheduledExpense amounts directly to their months
     scheduled_gids: set = set()
     scheduled_count_by_gid: dict = {}
+    scheduled_last_date_by_gid: dict = {}
     for se in scheduled:
         smonth = (
             se.scheduled_date.strftime("%Y-%m")
@@ -661,6 +662,9 @@ def get_installments_monthly_load(
         scheduled_count_by_gid[se.installment_group_id] = (
             scheduled_count_by_gid.get(se.installment_group_id, 0) + 1
         )
+        # Track the last scheduled date per group
+        if se.installment_group_id not in scheduled_last_date_by_gid or se.scheduled_date > scheduled_last_date_by_gid[se.installment_group_id]:
+            scheduled_last_date_by_gid[se.installment_group_id] = se.scheduled_date
 
     groups: dict = {}
     for e in exps:
@@ -674,8 +678,6 @@ def get_installments_monthly_load(
         groups[gid]["paid"].append((e.installment_number or 0, e.date))
 
     # Project remaining installments for ALL groups with unpaid balance
-    # For groups with ScheduledExpenses: project only the unprojected portion
-    # For groups without ScheduledExpenses: project all remaining
     for gid, g in groups.items():
         paid = len(g["paid"])
         remaining = max(0, g["installment_total"] - paid)
@@ -685,10 +687,15 @@ def get_installments_monthly_load(
         unprojected = max(0, remaining - scheduled_count)
         if unprojected == 0:
             continue
-        max_num, max_date = max(g["paid"], key=lambda x: x[0])
-        next_date = add_months(max_date, 1)
+        # Start projection after the last ScheduledExpense date (or last paid date)
+        if gid in scheduled_last_date_by_gid:
+            start_date = scheduled_last_date_by_gid[gid]
+        else:
+            max_num, max_date = max(g["paid"], key=lambda x: x[0])
+            start_date = max_date
+        next_date = add_months(start_date, 1)
         for i in range(unprojected):
-            charge_date = add_months(next_date, scheduled_count + i)
+            charge_date = add_months(next_date, i)
             key = charge_date.strftime("%Y-%m")
             if key >= current_month and key in monthly:
                 monthly[key]["total"] += g["amount"]

--- a/backend/app/routers/dashboard.py
+++ b/backend/app/routers/dashboard.py
@@ -663,7 +663,10 @@ def get_installments_monthly_load(
             scheduled_count_by_gid.get(se.installment_group_id, 0) + 1
         )
         # Track the last scheduled date per group
-        if se.installment_group_id not in scheduled_last_date_by_gid or se.scheduled_date > scheduled_last_date_by_gid[se.installment_group_id]:
+        if (
+            se.installment_group_id not in scheduled_last_date_by_gid
+            or se.scheduled_date > scheduled_last_date_by_gid[se.installment_group_id]
+        ):
             scheduled_last_date_by_gid[se.installment_group_id] = se.scheduled_date
 
     groups: dict = {}

--- a/backend/app/routers/investments.py
+++ b/backend/app/routers/investments.py
@@ -1,4 +1,5 @@
 import contextlib
+import hashlib
 import os
 from datetime import date, datetime, timedelta
 
@@ -12,6 +13,40 @@ from app.schemas import InvestmentCreate
 from app.services.auth import get_current_user
 
 router = APIRouter(tags=["investments"])
+
+# Sensitive setting keys that should be encrypted at rest
+SENSITIVE_KEYS = {"iol_password", "ppi_api_key", "ppi_api_secret"}
+
+
+def _get_encryptor():
+    """Get Fernet encryptor using SECRET_KEY."""
+    from cryptography.fernet import Fernet
+
+    secret = os.getenv("SECRET_KEY", "fallback-dev-key-change-in-prod")
+    key = hashlib.sha256(secret.encode()).digest()
+    fernet_key = __import__("base64").urlsafe_b64encode(key)
+    return Fernet(fernet_key)
+
+
+def _encrypt_value(value: str) -> str:
+    """Encrypt a sensitive value for storage."""
+    if not value:
+        return ""
+    fernet = _get_encryptor()
+    return fernet.encrypt(value.encode()).decode()
+
+
+def _decrypt_value(encrypted: str) -> str:
+    """Decrypt a sensitive value from storage."""
+    if not encrypted:
+        return ""
+    try:
+        fernet = _get_encryptor()
+        return fernet.decrypt(encrypted.encode()).decode()
+    except Exception:
+        # If decryption fails, value might be plaintext (migration)
+        return encrypted
+
 
 _IOL_TYPE_MAP = {
     "ACCIONES": "Acción",
@@ -81,16 +116,23 @@ def _inv_response(inv: Investment, user_name: str | None = None) -> dict:
 def _get_setting(db: Session, key: str, user_id: int | None = None) -> str:
     scoped_key = f"{user_id}:{key}" if user_id is not None else key
     row = db.query(Setting).filter(Setting.key == scoped_key).first()
-    return row.value if row else ""
+    if not row:
+        return ""
+    # Decrypt sensitive values
+    if key in SENSITIVE_KEYS:
+        return _decrypt_value(row.value)
+    return row.value
 
 
 def _set_setting(db: Session, key: str, value: str, user_id: int | None = None):
     scoped_key = f"{user_id}:{key}" if user_id is not None else key
+    # Encrypt sensitive values before storage
+    stored_value = _encrypt_value(value) if key in SENSITIVE_KEYS else value
     row = db.query(Setting).filter(Setting.key == scoped_key).first()
     if row:
-        row.value = value
+        row.value = stored_value
     else:
-        db.add(Setting(key=scoped_key, value=value))
+        db.add(Setting(key=scoped_key, value=stored_value))
     db.commit()
 
 

--- a/backend/app/routers/investments.py
+++ b/backend/app/routers/investments.py
@@ -239,8 +239,23 @@ def delete_broker_settings(
     for key in broker_keys[broker]:
         scoped_key = f"{target_user_id}:{key}"
         deleted_count += db.query(Setting).filter(Setting.key == scoped_key).delete()
+
+    # Also delete all investments for this broker
+    investments_deleted = (
+        db.query(Investment)
+        .filter(
+            Investment.user_id == target_user_id,
+            Investment.broker == broker,
+        )
+        .delete()
+    )
+
     db.commit()
-    return {"ok": True, "deleted": deleted_count}
+    return {
+        "ok": True,
+        "deleted_settings": deleted_count,
+        "deleted_investments": investments_deleted,
+    }
 
 
 # ─── Investments CRUD ─────────────────────────────────────────────────────────

--- a/backend/app/routers/investments.py
+++ b/backend/app/routers/investments.py
@@ -194,6 +194,55 @@ def put_setting(
     return {"ok": True}
 
 
+@router.delete("/settings/{key}")
+def delete_setting(
+    key: str,
+    user_id: int | None = None,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Delete a single setting by key."""
+    target_user_id = user_id if user_id else current_user.id
+    if user_id and user_id != current_user.id:
+        uid_list = get_group_user_ids(current_user.id, db)
+        if user_id not in uid_list:
+            raise HTTPException(403, "No tenés acceso para modificar configuración de otro usuario")
+
+    scoped_key = f"{target_user_id}:{key}"
+    deleted = db.query(Setting).filter(Setting.key == scoped_key).delete()
+    db.commit()
+    return {"ok": True, "deleted": deleted > 0}
+
+
+@router.delete("/settings/broker/{broker}")
+def delete_broker_settings(
+    broker: str,
+    user_id: int | None = None,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Delete all settings for a broker (iol or ppi)."""
+    target_user_id = user_id if user_id else current_user.id
+    if user_id and user_id != current_user.id:
+        uid_list = get_group_user_ids(current_user.id, db)
+        if user_id not in uid_list:
+            raise HTTPException(403, "No tenés acceso para modificar configuración de otro usuario")
+
+    broker_keys = {
+        "iol": ["iol_username", "iol_password"],
+        "ppi": ["ppi_api_key", "ppi_api_secret"],
+    }
+    if broker not in broker_keys:
+        raise HTTPException(400, f"Broker desconocido: {broker}")
+
+    deleted_count = 0
+    for key in broker_keys[broker]:
+        scoped_key = f"{target_user_id}:{key}"
+        deleted_count += db.query(Setting).filter(Setting.key == scoped_key).delete()
+    db.commit()
+    return {"ok": True, "deleted": deleted_count}
+
+
 # ─── Investments CRUD ─────────────────────────────────────────────────────────
 
 

--- a/backend/app/routers/investments.py
+++ b/backend/app/routers/investments.py
@@ -146,11 +146,29 @@ def _get_user_creds(db: Session, user_id: int) -> dict:
 
 
 @router.get("/settings")
-def get_settings(db: Session = Depends(get_db), current_user: User = Depends(get_current_user)):
-    prefix = f"{current_user.id}:"
+def get_settings(
+    user_id: int | None = None,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    # Allow family group members to view other member's settings
+    target_user_id = user_id if user_id else current_user.id
+    if user_id and user_id != current_user.id:
+        uid_list = get_group_user_ids(current_user.id, db)
+        if user_id not in uid_list:
+            raise HTTPException(403, "No tenés acceso a la configuración de otro usuario")
+
+    prefix = f"{target_user_id}:"
     rows = db.query(Setting).filter(Setting.key.like(f"{prefix}%")).all()
-    result = {r.key[len(prefix) :]: r.value for r in rows}
-    creds = _get_user_creds(db, current_user.id)
+    # Decrypt sensitive values for display
+    result = {}
+    for r in rows:
+        key = r.key[len(prefix) :]
+        if key in SENSITIVE_KEYS:
+            result[key] = _decrypt_value(r.value)
+        else:
+            result[key] = r.value
+    creds = _get_user_creds(db, target_user_id)
     result["iol_configured"] = bool(creds["iol_username"] and creds["iol_password"])
     result["ppi_configured"] = bool(creds["ppi_api_key"] and creds["ppi_api_secret"])
     return result
@@ -160,11 +178,19 @@ def get_settings(db: Session = Depends(get_db), current_user: User = Depends(get
 def put_setting(
     key: str,
     payload: dict,
+    user_id: int | None = None,
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
+    # Allow family group members to update other member's settings
+    target_user_id = user_id if user_id else current_user.id
+    if user_id and user_id != current_user.id:
+        uid_list = get_group_user_ids(current_user.id, db)
+        if user_id not in uid_list:
+            raise HTTPException(403, "No tenés acceso para modificar configuración de otro usuario")
+
     value = payload.get("value", "")
-    _set_setting(db, key, value, user_id=current_user.id)
+    _set_setting(db, key, value, user_id=target_user_id)
     return {"ok": True}
 
 

--- a/backend/app/routers/scheduled_expenses.py
+++ b/backend/app/routers/scheduled_expenses.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import date, datetime
 
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
@@ -7,6 +7,7 @@ from app.database import get_db
 from app.models import Expense, ScheduledExpense, User
 from app.routers.groups import get_group_user_ids
 from app.services.auth import get_current_user
+from app.services.date_utils import add_months
 
 router = APIRouter(prefix="/scheduled-expenses", tags=["scheduled-expenses"])
 
@@ -26,7 +27,87 @@ def get_scheduled_expenses(
     if installment_group_id:
         q = q.filter(ScheduledExpense.installment_group_id == installment_group_id)
 
-    return q.order_by(ScheduledExpense.scheduled_date).all()
+    scheduled = q.order_by(ScheduledExpense.scheduled_date).all()
+
+    # If filtering by group, also project remaining installments
+    if installment_group_id and status == "PENDING":
+        existing_nums = {s.installment_number for s in scheduled}
+        if scheduled:
+            inst_total = scheduled[0].installment_total
+            card_id = scheduled[0].card_id
+            account_id = scheduled[0].account_id
+            description = scheduled[0].description
+            amount = scheduled[0].amount
+            currency = scheduled[0].currency
+            user_id = scheduled[0].user_id
+        else:
+            # Get info from Expenses
+            exp = (
+                db.query(Expense)
+                .filter(
+                    Expense.user_id.in_(uid_list),
+                    Expense.installment_group_id == installment_group_id,
+                )
+                .order_by(Expense.installment_number.desc())
+                .first()
+            )
+            if exp:
+                inst_total = exp.installment_total or 0
+                card_id = exp.card_id
+                account_id = exp.account_id
+                description = exp.description
+                amount = abs(exp.amount)
+                currency = exp.currency
+                user_id = exp.user_id
+            else:
+                return scheduled
+
+        # Find the last scheduled or paid date
+        last_date = None
+        if scheduled:
+            last_date = max(s.scheduled_date for s in scheduled)
+        else:
+            last_exp = (
+                db.query(Expense)
+                .filter(
+                    Expense.user_id.in_(uid_list),
+                    Expense.installment_group_id == installment_group_id,
+                )
+                .order_by(Expense.date.desc())
+                .first()
+            )
+            if last_exp:
+                last_date = last_exp.date
+
+        if last_date:
+            # Project missing installments as virtual scheduled expenses
+            next_date = add_months(last_date, 1)
+            for i in range(1, inst_total + 1):
+                if i in existing_nums:
+                    continue
+                projected_date = add_months(
+                    next_date, i - (min(existing_nums) if existing_nums else 1)
+                )
+                # Only add if date is in the future
+                if projected_date > date.today():
+                    scheduled.append(
+                        ScheduledExpense(
+                            id=-i,  # Virtual ID (negative to avoid collision)
+                            installment_group_id=installment_group_id,
+                            installment_number=i,
+                            installment_total=inst_total,
+                            scheduled_date=projected_date,
+                            amount=amount,
+                            currency=currency,
+                            description=description,
+                            card_id=card_id,
+                            account_id=account_id,
+                            status="PENDING",
+                            user_id=user_id,
+                        )
+                    )
+
+    return scheduled
 
 
 @router.post("/{id}/execute")

--- a/backend/scripts/migrate_encrypt_settings.py
+++ b/backend/scripts/migrate_encrypt_settings.py
@@ -1,0 +1,72 @@
+"""
+Migration: Encrypt existing plaintext sensitive investment settings.
+Run once: python -m scripts.migrate_encrypt_settings
+"""
+
+import hashlib
+import os
+import sys
+from datetime import datetime
+
+from app.database import SessionLocal
+from app.models import Setting
+
+_log = lambda msg: print(f"{datetime.now().isoformat()} {msg}")
+
+SENSITIVE_KEYS = {"iol_password", "ppi_api_key", "ppi_api_secret"}
+
+
+def _get_encryptor():
+    from cryptography.fernet import Fernet
+
+    secret = os.getenv("SECRET_KEY", "fallback-dev-key-change-in-prod")
+    key = hashlib.sha256(secret.encode()).digest()
+    fernet_key = __import__("base64").urlsafe_b64encode(key)
+    return Fernet(fernet_key)
+
+
+def _is_already_encrypted(value: str) -> bool:
+    """Check if a value is already Fernet-encrypted (starts with gAAAAA)."""
+    return value.startswith("gAAAAA")
+
+
+def migrate():
+    db = SessionLocal()
+    try:
+        fernet = _get_encryptor()
+        encrypted_count = 0
+        skipped_count = 0
+
+        for key_suffix in SENSITIVE_KEYS:
+            # Find all settings with this key suffix
+            rows = (
+                db.query(Setting)
+                .filter(Setting.key.like(f"%:{key_suffix}"))
+                .all()
+            )
+
+            for row in rows:
+                if not row.value or _is_already_encrypted(row.value):
+                    skipped_count += 1
+                    continue
+
+                # Encrypt the plaintext value
+                encrypted_value = fernet.encrypt(row.value.encode()).decode()
+                row.value = encrypted_value
+                encrypted_count += 1
+                _log(f"  Encrypted: {row.key}")
+
+        db.commit()
+        _log(f"Migration complete: {encrypted_count} values encrypted, {skipped_count} skipped")
+
+    except Exception as e:
+        db.rollback()
+        _log(f"Migration failed: {e}")
+        raise
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    _log("Starting encryption migration...")
+    migrate()

--- a/docs/Roadmap.md
+++ b/docs/Roadmap.md
@@ -1,15 +1,20 @@
 # Roadmap
 
-## Features Tracking
+## Features
 
-| # | Feature | Status | Effort | Description |
-|---|---------|--------|--------|-------------|
-| 1 | Notifications visual | ✅ Done | Low | Icons, colored borders, progress bars, toast popup |
-| 2 | Monthly analysis resume | ⏳ Backlog | Medium | Monthly spending summary report |
-| 3 | Weekly Telegram summary | ⏳ Backlog | Medium | Weekly digest via bot, adjustable from UserPanel |
-| 4 | Income module | ⏳ Backlog | High | Track income, dashboard comparison vs last months |
-| 5 | Ticket scan | ⏳ Backlog | Medium | OCR receipt analysis, compare same items last month |
-| 6 | Expense budgets | ⏳ Backlog | Medium | Set spending limits per category |
+| # | Feature | Status | Effort | PR | Description |
+|---|---------|--------|--------|-----|-------------|
+| 1 | Click-to-edit cards/accounts | ✅ Done | Low | #37 | Card/account rows clickable to enter edit mode |
+| 2 | Expense detail modal | ✅ Done | Low | #38 | Row click opens summary with Cerrar/Editar buttons |
+| 3 | Visual notifications | ✅ Done | Low | #41 | Icons, colored borders, progress bars, toast, QUEUED status |
+| 4 | Dashboard layout fixes | ✅ Done | Low | #47 | Equal height boxes, category limit, transaction scroll |
+| 5 | Installment system fixes | ✅ Done | Medium | #49, #50 | Telegram ScheduledExpenses, projection logic, charts |
+| 6 | Monthly analysis resume | ⏳ Backlog | Medium | - | Monthly spending summary report |
+| 7 | Weekly Telegram summary | ⏳ Backlog | Medium | - | Weekly digest via bot, adjustable from UserPanel |
+| 8 | Income module | ⏳ Backlog | High | - | Track income, dashboard comparison vs last months |
+| 9 | Ticket scan | ⏳ Backlog | Medium | - | OCR receipt analysis, compare same items last month |
+| 10 | Expense budgets | ⏳ Backlog | Medium | - | Set spending limits per category |
+| 11 | Make index.html interactive | ⏳ Backlog | Medium | - | Filter transactions/categories when clicking Deuda Tarjetas or Cuotas este mes |
 
 ## Backlog Details
 
@@ -42,13 +47,7 @@ Generate a monthly summary report with:
 - Alerts when approaching/exceeding limit
 - Flexible (not rigid) budget periods
 
-## Completed Features
-
-| # | Feature | PR | Description |
-|---|---------|-----|-------------|
-| 1 | Click-to-edit cards/accounts | #37 | Card/account rows clickable to enter edit mode |
-| 2 | Expense detail modal | #38 | Row click opens summary with Cerrar/Editar buttons |
-| 3 | Visual notifications | #41 | Icons, colored borders, progress bars, toast, QUEUED status |
-| 4 | Dashboard layout fixes | #47 | Equal height boxes, category limit, transaction scroll |
-| 5 | Installment system fixes | #49 | Telegram ScheduledExpenses, projection logic, pattern detection |
-| 6 | Future installment display | #50 | Charts show ScheduledExpense amounts directly |
+### Make Index.html Interactive
+- Click on "Deuda Tarjetas" card → filter to credit card expenses
+- Click on "Cuotas este mes" card → filter to installment expenses
+- Make dashboard info boxes clickable and interactive

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -405,7 +405,8 @@ export const lookupSymbols = (symbols: string[]) =>
 export const deleteInvestment = (id: number) =>
   api.delete(`/investments/${id}`).then((r) => r.data);
 
-export const getSettings = () => api.get<Record<string, string>>("/settings").then((r) => r.data);
+export const getSettings = () =>
+  api.get<Record<string, string | boolean>>("/settings").then((r) => r.data);
 
 export const putSetting = (key: string, value: string) =>
   api.put(`/settings/${key}`, { value }).then((r) => r.data);

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -410,6 +410,11 @@ export const getSettings = () => api.get<Record<string, string>>("/settings").th
 export const putSetting = (key: string, value: string) =>
   api.put(`/settings/${key}`, { value }).then((r) => r.data);
 
+export const deleteSetting = (key: string) => api.delete(`/settings/${key}`).then((r) => r.data);
+
+export const deleteBrokerSettings = (broker: string) =>
+  api.delete(`/settings/broker/${broker}`).then((r) => r.data);
+
 export const syncIOL = () =>
   api
     .post<{

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -67,7 +67,7 @@ function CardRow({
   };
 
   const network = getNetwork(cardName);
-  const displayName = cardType === "debito" ? "Débito" : network;
+  const displayName = cardType === "debito" ? cardName : network;
 
   return (
     <div className="flex items-center justify-between py-2.5 px-1">

--- a/frontend/src/pages/InvestmentsPage.tsx
+++ b/frontend/src/pages/InvestmentsPage.tsx
@@ -343,12 +343,12 @@ function CredentialsModal({
   onClose,
   onSaved,
 }: {
-  settings: Record<string, string>;
+  settings: Record<string, string | boolean>;
   onClose: () => void;
   onSaved: () => void;
 }) {
-  const iolOk = settings.iol_configured === "true";
-  const ppiOk = settings.ppi_configured === "true";
+  const iolOk = settings.iol_configured === "true" || settings.iol_configured === true;
+  const ppiOk = settings.ppi_configured === "true" || settings.ppi_configured === true;
 
   const [iolUser, setIolUser] = useState("");
   const [iolPass, setIolPass] = useState("");
@@ -708,8 +708,8 @@ export default function InvestmentsPage() {
 
   const syncAllMut = useMutation({
     mutationFn: async () => {
-      const iolOk = settings.iol_configured === "true";
-      const ppiOk = settings.ppi_configured === "true";
+      const iolOk = settings.iol_configured === "true" || settings.iol_configured === true;
+      const ppiOk = settings.ppi_configured === "true" || settings.ppi_configured === true;
       const results: string[] = [];
       const errors: string[] = [];
       if (iolOk) {

--- a/frontend/src/pages/InvestmentsPage.tsx
+++ b/frontend/src/pages/InvestmentsPage.tsx
@@ -520,7 +520,8 @@ function CredentialsModal({
                 ¿Borrar configuración de {confirmDelete === "iol" ? "IOL" : "PPI"}?
               </p>
               <p className="text-xs text-[var(--text-secondary)]">
-                Se eliminarán las credenciales guardadas. Esta acción no se puede deshacer.
+                Se eliminarán las credenciales y todos los inversiones de este broker. Esta acción
+                no se puede deshacer.
               </p>
               <div className="flex gap-3">
                 <button
@@ -535,7 +536,7 @@ function CredentialsModal({
                   className="flex-1 py-2 rounded-lg bg-red-600 hover:bg-red-700 text-white text-sm font-medium transition-colors disabled:opacity-40"
                   disabled={saving}
                 >
-                  {saving ? "Borrando..." : "Borrar"}
+                  {saving ? "Borrando..." : "Borrar todo"}
                 </button>
               </div>
             </div>

--- a/frontend/src/pages/InvestmentsPage.tsx
+++ b/frontend/src/pages/InvestmentsPage.tsx
@@ -13,6 +13,7 @@ import {
   getCashBalances,
   getManualCashBalances,
   putSetting,
+  deleteBrokerSettings,
   lookupSymbol,
   lookupSymbols,
 } from "../api/client";
@@ -356,6 +357,7 @@ function CredentialsModal({
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [confirmDelete, setConfirmDelete] = useState<string | null>(null);
 
   const handleSave = async () => {
     setSaving(true);
@@ -375,6 +377,21 @@ function CredentialsModal({
       onSaved();
     } catch (err: any) {
       setError(err?.response?.data?.detail ?? "Error al guardar credenciales");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDeleteBroker = async (broker: string) => {
+    setSaving(true);
+    setError(null);
+    try {
+      await deleteBrokerSettings(broker);
+      setConfirmDelete(null);
+      setSaved(true);
+      onSaved();
+    } catch (err: any) {
+      setError(err?.response?.data?.detail ?? "Error al borrar configuración");
     } finally {
       setSaving(false);
     }
@@ -412,9 +429,19 @@ function CredentialsModal({
             <p className="text-xs font-semibold text-tertiary uppercase tracking-wider">
               InvertirOnline
             </p>
-            <span className={`text-xs font-medium ${iolOk ? "text-success" : "text-tertiary"}`}>
-              {iolOk ? "✓ configurado" : "✗ sin credenciales"}
-            </span>
+            <div className="flex items-center gap-2">
+              <span className={`text-xs font-medium ${iolOk ? "text-success" : "text-tertiary"}`}>
+                {iolOk ? "✓ configurado" : "✗ sin credenciales"}
+              </span>
+              {iolOk && (
+                <button
+                  onClick={() => setConfirmDelete("iol")}
+                  className="text-xs text-danger hover:underline transition-colors"
+                >
+                  Borrar
+                </button>
+              )}
+            </div>
           </div>
           <input
             type="email"
@@ -440,9 +467,19 @@ function CredentialsModal({
             <p className="text-xs font-semibold text-tertiary uppercase tracking-wider">
               Portfolio Personal
             </p>
-            <span className={`text-xs font-medium ${ppiOk ? "text-success" : "text-tertiary"}`}>
-              {ppiOk ? "✓ configurado" : "✗ sin credenciales"}
-            </span>
+            <div className="flex items-center gap-2">
+              <span className={`text-xs font-medium ${ppiOk ? "text-success" : "text-tertiary"}`}>
+                {ppiOk ? "✓ configurado" : "✗ sin credenciales"}
+              </span>
+              {ppiOk && (
+                <button
+                  onClick={() => setConfirmDelete("ppi")}
+                  className="text-xs text-danger hover:underline transition-colors"
+                >
+                  Borrar
+                </button>
+              )}
+            </div>
           </div>
           <input
             type="password"
@@ -474,6 +511,36 @@ function CredentialsModal({
             {saving ? "Guardando..." : "Guardar"}
           </button>
         </div>
+
+        {/* Delete confirmation dialog */}
+        {confirmDelete && (
+          <div className="absolute inset-0 bg-black/50 rounded-lg flex items-center justify-center z-10">
+            <div className="card p-5 mx-4 max-w-sm space-y-4">
+              <p className="text-sm text-[var(--text-primary)] font-medium">
+                ¿Borrar configuración de {confirmDelete === "iol" ? "IOL" : "PPI"}?
+              </p>
+              <p className="text-xs text-[var(--text-secondary)]">
+                Se eliminarán las credenciales guardadas. Esta acción no se puede deshacer.
+              </p>
+              <div className="flex gap-3">
+                <button
+                  onClick={() => setConfirmDelete(null)}
+                  className="gnome-btn-secondary flex-1"
+                  disabled={saving}
+                >
+                  Cancelar
+                </button>
+                <button
+                  onClick={() => handleDeleteBroker(confirmDelete)}
+                  className="flex-1 py-2 rounded-lg bg-red-600 hover:bg-red-700 text-white text-sm font-medium transition-colors disabled:opacity-40"
+                  disabled={saving}
+                >
+                  {saving ? "Borrando..." : "Borrar"}
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/pages/InvestmentsPage.tsx
+++ b/frontend/src/pages/InvestmentsPage.tsx
@@ -436,9 +436,9 @@ function CredentialsModal({
               {iolOk && (
                 <button
                   onClick={() => setConfirmDelete("iol")}
-                  className="text-xs text-danger hover:underline transition-colors"
+                  className="text-[10px] px-2 py-0.5 rounded border border-red-300 text-red-600 hover:bg-red-50 transition-colors"
                 >
-                  Borrar
+                  ✕ Borrar
                 </button>
               )}
             </div>
@@ -474,9 +474,9 @@ function CredentialsModal({
               {ppiOk && (
                 <button
                   onClick={() => setConfirmDelete("ppi")}
-                  className="text-xs text-danger hover:underline transition-colors"
+                  className="text-[10px] px-2 py-0.5 rounded border border-red-300 text-red-600 hover:bg-red-50 transition-colors"
                 >
-                  Borrar
+                  ✕ Borrar
                 </button>
               )}
             </div>


### PR DESCRIPTION
## Changes

### 1. Fix remaining_installments calculation
- Now computes `installment_total - installments_paid` (correct formula)
- Was counting PENDING ScheduledExpense rows (wrong — showed 3 instead of 9)
- All groups now show correct remaining count

### 2. Encrypt sensitive investment settings
- `iol_password`, `ppi_api_key`, `ppi_api_secret` encrypted with Fernet
- Uses SECRET_KEY to derive encryption key
- Transparent decrypt on read, encrypt on write
- Backwards compatible (decrypts plaintext if not yet encrypted)

### 3. Clean up dead code
- Removed unused window_start/window_end in monthly-load

### 4. Dashboard credit cards (from previous commits)
- Shows all payment methods (not just credit cards)
- Account names shown instead of generic 'Débito'
- Deuda Tarjetas includes projected installments

**Fixes Issues:** #51, #52