### PR TITLE
ci: skip deployment for docs/markdown changes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,11 @@ name: Deploy to Linode
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - "*.md"
+      - "docs/**"
+      - "LICENSE"
+      - ".gitignore"
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
## Summary
Adds paths-ignore to deploy.yml to prevent unnecessary deployments when only documentation files change.

## Excluded patterns
- `*.md` - All markdown files
- `docs/**` - Documentation directory
- `LICENSE` - License file
- `.gitignore` - Git ignore file

## Impact
Deployment will only trigger when actual code changes are pushed to main.