### PR TITLE
fix: category selector filtering for grouped options

### DIFF
--- a/frontend/src/components/ui/Select.tsx
+++ b/frontend/src/components/ui/Select.tsx
@@ -57,10 +57,7 @@ export function Select({
     }
   }, [isOpen]);
 
-  const allOptions =
-    groups.length > 0
-      ? [...options] // Don't include group options in flat list when groups exist
-      : [...options, ...groups.flatMap((g) => g.options)];
+  const allOptions = [...options, ...groups.flatMap((g) => g.options)];
   const selectedOption = [...options, ...groups.flatMap((g) => g.options)].find(
     (o) => o.value === value,
   );
@@ -233,7 +230,7 @@ export function Select({
 
             {allowCustomValue &&
               search.trim() &&
-              !filteredOptions.some((o) => o.label.toLowerCase() === search.toLowerCase()) && (
+              !allOptions.some((o) => o.label.toLowerCase() === search.toLowerCase()) && (
                 <button
                   type="button"
                   data-option


### PR DESCRIPTION
## Summary
Fixes the category selector in expense edit modal and other places where grouped options are used.

## Problem
- When using grouped category options (parent/child), typing in search showed a misleading 'Usar: ...' button even when matching categories existed
- The 'Categoria Padre' filter appeared to return no results because the search wasn't checking grouped options

## Changes
- `frontend/src/components/ui/Select.tsx`: 
  - Include group options in `allOptions` array for proper search filtering
  - Fix 'Usar:' button condition to check against all available options

## Related
- Closes #64