### PR TITLE
fix: category selector filtering for grouped options

### DIFF
--- a/frontend/src/components/ui/Select.tsx
+++ b/frontend/src/components/ui/Select.tsx
@@ -99,7 +99,8 @@ export function Select({
     // Add group options (only when groups exist, since they're not in filteredOptions)
     if (groups.length > 0) {
       groups.forEach((group) => {
-        const groupMatches = !search || group.label.toLowerCase().includes(search.toLowerCase());
+        const groupMatches =
+          !search || group.label.toLowerCase().includes(search.toLowerCase());
         const groupFiltered = group.options.filter(
           (o) =>
             groupMatches ||
@@ -268,7 +269,8 @@ export function Select({
             {/* Render grouped options with headers */}
             {groups.length > 0 &&
               groups.map((group) => {
-                const groupMatches = !search || group.label.toLowerCase().includes(search.toLowerCase());
+                const groupMatches =
+                  !search || group.label.toLowerCase().includes(search.toLowerCase());
                 const groupFiltered = group.options.filter(
                   (o) =>
                     groupMatches ||

--- a/frontend/src/components/ui/Select.tsx
+++ b/frontend/src/components/ui/Select.tsx
@@ -99,9 +99,10 @@ export function Select({
     // Add group options (only when groups exist, since they're not in filteredOptions)
     if (groups.length > 0) {
       groups.forEach((group) => {
+        const groupMatches = !search || group.label.toLowerCase().includes(search.toLowerCase());
         const groupFiltered = group.options.filter(
           (o) =>
-            !search ||
+            groupMatches ||
             o.label.toLowerCase().includes(search.toLowerCase()) ||
             o.value.toLowerCase().includes(search.toLowerCase()),
         );
@@ -267,9 +268,10 @@ export function Select({
             {/* Render grouped options with headers */}
             {groups.length > 0 &&
               groups.map((group) => {
+                const groupMatches = !search || group.label.toLowerCase().includes(search.toLowerCase());
                 const groupFiltered = group.options.filter(
                   (o) =>
-                    !search ||
+                    groupMatches ||
                     o.label.toLowerCase().includes(search.toLowerCase()) ||
                     o.value.toLowerCase().includes(search.toLowerCase()),
                 );

--- a/frontend/src/components/ui/Select.tsx
+++ b/frontend/src/components/ui/Select.tsx
@@ -99,8 +99,7 @@ export function Select({
     // Add group options (only when groups exist, since they're not in filteredOptions)
     if (groups.length > 0) {
       groups.forEach((group) => {
-        const groupMatches =
-          !search || group.label.toLowerCase().includes(search.toLowerCase());
+        const groupMatches = !search || group.label.toLowerCase().includes(search.toLowerCase());
         const groupFiltered = group.options.filter(
           (o) =>
             groupMatches ||


### PR DESCRIPTION
## Summary
Fixes the category selector search behavior when using grouped options (parent/child categories).

## Problem
- Typing a parent category name (e.g. 'Alimentacion') showed no results because the filter only checked child names
- 'Usar:' custom value button appeared incorrectly when groups were provided

## Changes
- `Select.tsx`: Include group options in allOptions for proper search filtering
- `Select.tsx`: Fix 'Usar:' button condition to check against all available options
- `Select.tsx`: Show all children when parent category name matches search

## Related
- Closes #64