### PR TITLE
feat: Add nginx reverse proxy with SSL for production

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -100,7 +100,7 @@ jobs:
             mkdir -p /opt/creditcardanalyzer/certbot/{conf,work,logs}
 
             # Get SSL certificate if not already present
-            if [ -f /opt/creditcardanalyzer/certbot/conf/live/okinomonia.freeddns.org/fullchain.pem ]; then
+            if [ -f /opt/creditcardanalyzer/certbot/conf/live/${{ secrets.DOMAIN_NAME }}/fullchain.pem ]; then
                 echo "SSL certificate already exists, skipping"
             else
                 echo "Requesting SSL certificate..."
@@ -110,7 +110,7 @@ jobs:
                   -v /opt/creditcardanalyzer/certbot/logs:/var/log/letsencrypt:Z \
                   -p 80:80 \
                   docker.io/certbot/certbot certonly --standalone \
-                  -d okinomonia.freeddns.org \
+                  -d ${{ secrets.DOMAIN_NAME }} \
                   --email mmendoza0989@gmail.com \
                   --agree-tos --non-interactive
                 echo "SSL certificate obtained"
@@ -118,8 +118,8 @@ jobs:
 
             # Fix cert permissions for nginx container (SELinux + nginx user access)
             chmod 755 /opt/creditcardanalyzer/certbot/conf/archive 2>/dev/null || true
-            chmod 755 /opt/creditcardanalyzer/certbot/conf/archive/okinomonia.freeddns.org 2>/dev/null || true
-            chmod 644 /opt/creditcardanalyzer/certbot/conf/archive/okinomonia.freeddns.org/*.pem 2>/dev/null || true
+            chmod 755 /opt/creditcardanalyzer/certbot/conf/archive/${{ secrets.DOMAIN_NAME }} 2>/dev/null || true
+            chmod 644 /opt/creditcardanalyzer/certbot/conf/archive/${{ secrets.DOMAIN_NAME }}/*.pem 2>/dev/null || true
             echo "Cert permissions fixed"
 
       - name: Setup certbot renewal timer
@@ -220,15 +220,15 @@ jobs:
             server {
                 listen 80 default_server;
                 server_name _;
-                return 301 https://okinomonia.freeddns.org$request_uri;
+                return 301 https://${{ secrets.DOMAIN_NAME }}$request_uri;
             }
 
             server {
                 listen 443 ssl default_server;
                 server_name _;
 
-                ssl_certificate /etc/letsencrypt/live/okinomonia.freeddns.org/fullchain.pem;
-                ssl_certificate_key /etc/letsencrypt/live/okinomonia.freeddns.org/privkey.pem;
+                ssl_certificate /etc/letsencrypt/live/${{ secrets.DOMAIN_NAME }}/fullchain.pem;
+                ssl_certificate_key /etc/letsencrypt/live/${{ secrets.DOMAIN_NAME }}/privkey.pem;
 
                 ssl_protocols TLSv1.2 TLSv1.3;
                 ssl_ciphers HIGH:!aNULL:!MD5;
@@ -308,8 +308,8 @@ jobs:
                   GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET}
                   SECRET_KEY: ${SECRET_KEY}
                   RESEND_API_KEY: ${RESEND_API_KEY}
-                  FRONTEND_URL: https://okinomonia.freeddns.org
-                  CORS_ORIGINS: https://okinomonia.freeddns.org
+                  FRONTEND_URL: https://${{ secrets.DOMAIN_NAME }}
+                  CORS_ORIGINS: https://${{ secrets.DOMAIN_NAME }}
                 restart: unless-stopped
 
               celery_worker:
@@ -413,6 +413,6 @@ jobs:
             # Verify deployment
             echo "Waiting for services to start..."
             sleep 5
-            curl -sk https://okinomonia.freeddns.org/api/docs -o /dev/null -w "%{http_code}" | grep -q 200 && echo "Deploy OK (domain)" || \
+            curl -sk https://${{ secrets.DOMAIN_NAME }}/api/docs -o /dev/null -w "%{http_code}" | grep -q 200 && echo "Deploy OK (domain)" || \
               (echo "Domain check failed, trying localhost..." && curl -sf http://localhost/api/docs -o /dev/null -w "%{http_code}" | grep -q 200 && echo "Deploy OK (local)") || \
               echo "WARN: health check failed"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: read
+  packages: write
+
 env:
   REGISTRY: ghcr.io
   BACKEND_IMAGE: ghcr.io/${{ github.repository_owner }}/perexp/backend

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,7 +58,7 @@ jobs:
     needs: build-and-push
 
     steps:
-      - name: Install dependencies on server
+      - name: Setup server (podman, podman-compose, dirs)
         uses: appleboy/ssh-action@v1
         with:
           host: ${{ secrets.LINODE_SERVER_IP }}
@@ -68,25 +68,139 @@ jobs:
           script: |
             # Install podman if not exists
             if ! command -v podman &> /dev/null; then
+                echo "Installing podman..."
                 sudo dnf install -y podman podman-docker
                 sudo systemctl enable --now podman.socket
+            else
+                echo "podman already installed, skipping"
             fi
 
             # Install podman-compose if not exists
             if ! command -v podman-compose &> /dev/null; then
+                echo "Installing podman-compose..."
                 sudo dnf install -y python3-pip
                 pip3 install --user podman-compose
+            else
+                echo "podman-compose already installed, skipping"
             fi
 
             # Create app directory
             sudo mkdir -p /opt/creditcardanalyzer
             sudo chown -R $USER:$USER /opt/creditcardanalyzer
 
+      - name: Setup SSL certificates
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.LINODE_SERVER_IP }}
+          username: ${{ secrets.LINODE_SSH_USER }}
+          key: ${{ secrets.LINODE_SSH_KEY }}
+          port: 43422
+          script: |
+            # Create certbot directories
+            mkdir -p /opt/creditcardanalyzer/certbot/{conf,work,logs}
+
+            # Get SSL certificate if not already present
+            if [ -f /opt/creditcardanalyzer/certbot/conf/live/okinomonia.freeddns.org/fullchain.pem ]; then
+                echo "SSL certificate already exists, skipping"
+            else
+                echo "Requesting SSL certificate..."
+                podman run --rm \
+                  -v /opt/creditcardanalyzer/certbot/conf:/etc/letsencrypt:Z \
+                  -v /opt/creditcardanalyzer/certbot/work:/var/lib/letsencrypt:Z \
+                  -v /opt/creditcardanalyzer/certbot/logs:/var/log/letsencrypt:Z \
+                  -p 80:80 \
+                  docker.io/certbot/certbot certonly --standalone \
+                  -d okinomonia.freeddns.org \
+                  --email mmendoza0989@gmail.com \
+                  --agree-tos --non-interactive
+                echo "SSL certificate obtained"
+            fi
+
+            # Fix cert permissions for nginx container (SELinux + nginx user access)
+            chmod 755 /opt/creditcardanalyzer/certbot/conf/archive 2>/dev/null || true
+            chmod 755 /opt/creditcardanalyzer/certbot/conf/archive/okinomonia.freeddns.org 2>/dev/null || true
+            chmod 644 /opt/creditcardanalyzer/certbot/conf/archive/okinomonia.freeddns.org/*.pem 2>/dev/null || true
+            echo "Cert permissions fixed"
+
+      - name: Setup certbot renewal timer
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.LINODE_SERVER_IP }}
+          username: ${{ secrets.LINODE_SSH_USER }}
+          key: ${{ secrets.LINODE_SSH_KEY }}
+          port: 43422
+          script: |
+            # Only create if not already present
+            if [ -f /etc/systemd/system/certbot-renew.timer ]; then
+                echo "Certbot renewal timer already exists, skipping"
+            else
+                echo "Creating certbot renewal timer..."
+                cat > /etc/systemd/system/certbot-renew.service << 'UNIT'
+            [Unit]
+            Description=Certbot SSL Certificate Renewal
+            After=network-online.target
+
+            [Service]
+            Type=oneshot
+            ExecStart=/usr/bin/podman run --rm \
+              -v /opt/creditcardanalyzer/certbot/conf:/etc/letsencrypt:Z \
+              -v /opt/creditcardanalyzer/certbot/work:/var/lib/letsencrypt:Z \
+              -v /opt/creditcardanalyzer/certbot/logs:/var/log/letsencrypt:Z \
+              docker.io/certbot/certbot renew --quiet
+            UNIT
+
+                cat > /etc/systemd/system/certbot-renew.timer << 'UNIT'
+            [Unit]
+            Description=Run certbot renewal twice daily
+
+            [Timer]
+            OnCalendar=daily
+            RandomizedDelaySec=3600
+            Persistent=true
+
+            [Install]
+            WantedBy=timers.target
+            UNIT
+
+                systemctl daemon-reload
+                systemctl enable --now certbot-renew.timer
+                echo "Certbot renewal timer installed"
+            fi
+
+      - name: Open firewall ports
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.LINODE_SERVER_IP }}
+          username: ${{ secrets.LINODE_SSH_USER }}
+          key: ${{ secrets.LINODE_SSH_KEY }}
+          port: 43422
+          script: |
+            # Open ports 80 and 443 if not already open
+            if firewall-cmd --list-ports | grep -q "80/tcp"; then
+                echo "Port 80 already open, skipping"
+            else
+                echo "Opening port 80..."
+                sudo firewall-cmd --permanent --add-port=80/tcp
+            fi
+
+            if firewall-cmd --list-ports | grep -q "443/tcp"; then
+                echo "Port 443 already open, skipping"
+            else
+                echo "Opening port 443..."
+                sudo firewall-cmd --permanent --add-port=443/tcp
+            fi
+
+            sudo firewall-cmd --reload
+            echo "Firewall ports: $(firewall-cmd --list-ports)"
+
   deploy:
     runs-on: ubuntu-latest
     needs: setup-server
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
       - name: Deploy to server via SSH
         uses: appleboy/ssh-action@v1
         with:
@@ -99,6 +213,45 @@ jobs:
             BACKEND_IMAGE="${{ env.BACKEND_IMAGE }}"
             FRONTEND_IMAGE="${{ env.FRONTEND_IMAGE }}"
             IMAGE_TAG="${{ github.sha }}"
+
+            # Write nginx.conf
+            mkdir -p /opt/creditcardanalyzer/nginx
+            cat > /opt/creditcardanalyzer/nginx/nginx.conf << 'NGINXEOF'
+            server {
+                listen 80 default_server;
+                server_name _;
+                return 301 https://okinomonia.freeddns.org$request_uri;
+            }
+
+            server {
+                listen 443 ssl default_server;
+                server_name _;
+
+                ssl_certificate /etc/letsencrypt/live/okinomonia.freeddns.org/fullchain.pem;
+                ssl_certificate_key /etc/letsencrypt/live/okinomonia.freeddns.org/privkey.pem;
+
+                ssl_protocols TLSv1.2 TLSv1.3;
+                ssl_ciphers HIGH:!aNULL:!MD5;
+                ssl_prefer_server_ciphers on;
+                ssl_session_cache shared:SSL:10m;
+                ssl_session_timeout 10m;
+
+                add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+                add_header X-Content-Type-Options nosniff;
+                add_header X-Frame-Options DENY;
+
+                gzip on;
+                gzip_types text/plain text/css application/json application/javascript text/xml;
+
+                location / {
+                    proxy_pass http://frontend:80;
+                    proxy_set_header Host $host;
+                    proxy_set_header X-Real-IP $remote_addr;
+                    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                    proxy_set_header X-Forwarded-Proto $scheme;
+                }
+            }
+            NGINXEOF
 
             # Write docker-compose.yml
             cat > /opt/creditcardanalyzer/docker-compose.yml << 'EOF'
@@ -155,7 +308,8 @@ jobs:
                   GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET}
                   SECRET_KEY: ${SECRET_KEY}
                   RESEND_API_KEY: ${RESEND_API_KEY}
-                  FRONTEND_URL: https://expensas.chelo.ar
+                  FRONTEND_URL: https://okinomonia.freeddns.org
+                  CORS_ORIGINS: https://okinomonia.freeddns.org
                 restart: unless-stopped
 
               celery_worker:
@@ -185,11 +339,27 @@ jobs:
 
               frontend:
                 image: ${FRONTEND_IMAGE}:${IMAGE_TAG}
-                ports:
-                  - "8080:80"
                 depends_on:
                   backend:
                     condition: service_healthy
+                restart: unless-stopped
+
+              nginx:
+                image: docker.io/library/nginx:alpine
+                ports:
+                  - "80:80"
+                  - "443:443"
+                volumes:
+                  - ./nginx/nginx.conf:/etc/nginx/conf.d/default.conf:ro
+                  - ./certbot/conf:/etc/letsencrypt:ro,Z
+                depends_on:
+                  - frontend
+                healthcheck:
+                  test: ["CMD-SHELL", "wget -qO- --no-check-certificate https://127.0.0.1/ || exit 1"]
+                  interval: 30s
+                  timeout: 5s
+                  start_period: 10s
+                  retries: 3
                 restart: unless-stopped
 
             volumes:
@@ -243,4 +413,6 @@ jobs:
             # Verify deployment
             echo "Waiting for services to start..."
             sleep 5
-            curl -sf http://localhost:8080/api/health && echo "Deploy OK" || echo "WARN: health check failed"
+            curl -sk https://okinomonia.freeddns.org/api/docs -o /dev/null -w "%{http_code}" | grep -q 200 && echo "Deploy OK (domain)" || \
+              (echo "Domain check failed, trying localhost..." && curl -sf http://localhost/api/docs -o /dev/null -w "%{http_code}" | grep -q 200 && echo "Deploy OK (local)") || \
+              echo "WARN: health check failed"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,7 +58,7 @@ jobs:
     needs: build-and-push
 
     steps:
-      - name: Setup server (podman, podman-compose, dirs)
+      - name: Install podman and podman-compose
         uses: appleboy/ssh-action@v1
         with:
           host: ${{ secrets.LINODE_SERVER_IP }}
@@ -66,7 +66,6 @@ jobs:
           key: ${{ secrets.LINODE_SSH_KEY }}
           port: 43422
           script: |
-            # Install podman if not exists
             if ! command -v podman &> /dev/null; then
                 echo "Installing podman..."
                 sudo dnf install -y podman podman-docker
@@ -75,7 +74,6 @@ jobs:
                 echo "podman already installed, skipping"
             fi
 
-            # Install podman-compose if not exists
             if ! command -v podman-compose &> /dev/null; then
                 echo "Installing podman-compose..."
                 sudo dnf install -y python3-pip
@@ -84,9 +82,29 @@ jobs:
                 echo "podman-compose already installed, skipping"
             fi
 
-            # Create app directory
-            sudo mkdir -p /opt/creditcardanalyzer
+            sudo mkdir -p /opt/creditcardanalyzer /opt/creditcardanalyzer/backups
             sudo chown -R $USER:$USER /opt/creditcardanalyzer
+
+      - name: Verify DNS resolution
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.LINODE_SERVER_IP }}
+          username: ${{ secrets.LINODE_SSH_USER }}
+          key: ${{ secrets.LINODE_SSH_KEY }}
+          port: 43422
+          script: |
+            RESOLVED_IP=$(dig +short ${{ vars.DOMAIN_NAME }} | tail -1)
+            SERVER_IP=$(curl -s --connect-timeout 5 https://api.ipify.org || curl -s --connect-timeout 5 https://ifconfig.me)
+
+            echo "Domain: ${{ vars.DOMAIN_NAME }}"
+            echo "Resolved IP: $RESOLVED_IP"
+            echo "Server IP: $SERVER_IP"
+
+            if [ "$RESOLVED_IP" != "$SERVER_IP" ]; then
+              echo "ERROR: DNS not pointing to this server ($RESOLVED_IP != $SERVER_IP)"
+              exit 1
+            fi
+            echo "DNS OK: ${{ vars.DOMAIN_NAME }} -> $SERVER_IP"
 
       - name: Setup SSL certificates
         uses: appleboy/ssh-action@v1
@@ -96,27 +114,46 @@ jobs:
           key: ${{ secrets.LINODE_SSH_KEY }}
           port: 43422
           script: |
-            # Create certbot directories
             mkdir -p /opt/creditcardanalyzer/certbot/{conf,work,logs}
 
-            # Get SSL certificate if not already present
-            if [ -f /opt/creditcardanalyzer/certbot/conf/live/${{ vars.DOMAIN_NAME }}/fullchain.pem ]; then
-                echo "SSL certificate already exists, skipping"
-            else
-                echo "Requesting SSL certificate..."
-                podman run --rm \
-                  -v /opt/creditcardanalyzer/certbot/conf:/etc/letsencrypt:Z \
-                  -v /opt/creditcardanalyzer/certbot/work:/var/lib/letsencrypt:Z \
-                  -v /opt/creditcardanalyzer/certbot/logs:/var/log/letsencrypt:Z \
-                  -p 80:80 \
-                  docker.io/certbot/certbot certonly --standalone \
-                  -d ${{ vars.DOMAIN_NAME }} \
-                  --email mmendoza0989@gmail.com \
-                  --agree-tos --non-interactive
-                echo "SSL certificate obtained"
+            CERT_FILE="/opt/creditcardanalyzer/certbot/conf/live/${{ vars.DOMAIN_NAME }}/fullchain.pem"
+
+            if [ -f "$CERT_FILE" ]; then
+                # Check if cert expires within 14 days
+                EXPIRY=$(openssl x509 -in "$CERT_FILE" -noout -enddate | cut -d= -f2)
+                EXPIRY_EPOCH=$(date -d "$EXPIRY" +%s)
+                NOW_EPOCH=$(date +%s)
+                DAYS_LEFT=$(( (EXPIRY_EPOCH - NOW_EPOCH) / 86400 ))
+
+                if [ "$DAYS_LEFT" -lt 14 ]; then
+                    echo "Certificate expires in $DAYS_LEFT days, forcing renewal..."
+                    rm -f "$CERT_FILE"
+                else
+                    echo "SSL certificate OK ($DAYS_LEFT days remaining), skipping"
+                    exit 0
+                fi
             fi
 
-            # Fix cert permissions for nginx container (SELinux + nginx user access)
+            echo "Requesting SSL certificate..."
+            podman run --rm \
+              -v /opt/creditcardanalyzer/certbot/conf:/etc/letsencrypt:Z \
+              -v /opt/creditcardanalyzer/certbot/work:/var/lib/letsencrypt:Z \
+              -v /opt/creditcardanalyzer/certbot/logs:/var/log/letsencrypt:Z \
+              -p 80:80 \
+              docker.io/certbot/certbot certonly --standalone \
+              -d ${{ vars.DOMAIN_NAME }} \
+              --email mmendoza0989@gmail.com \
+              --agree-tos --non-interactive
+            echo "SSL certificate obtained"
+
+      - name: Fix cert permissions
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.LINODE_SERVER_IP }}
+          username: ${{ secrets.LINODE_SSH_USER }}
+          key: ${{ secrets.LINODE_SSH_KEY }}
+          port: 43422
+          script: |
             chmod 755 /opt/creditcardanalyzer/certbot/conf/archive 2>/dev/null || true
             chmod 755 /opt/creditcardanalyzer/certbot/conf/archive/${{ vars.DOMAIN_NAME }} 2>/dev/null || true
             chmod 644 /opt/creditcardanalyzer/certbot/conf/archive/${{ vars.DOMAIN_NAME }}/*.pem 2>/dev/null || true
@@ -130,7 +167,6 @@ jobs:
           key: ${{ secrets.LINODE_SSH_KEY }}
           port: 43422
           script: |
-            # Only create if not already present
             if [ -f /etc/systemd/system/certbot-renew.timer ]; then
                 echo "Certbot renewal timer already exists, skipping"
             else
@@ -175,7 +211,6 @@ jobs:
           key: ${{ secrets.LINODE_SSH_KEY }}
           port: 43422
           script: |
-            # Open ports 80 and 443 if not already open
             if firewall-cmd --list-ports | grep -q "80/tcp"; then
                 echo "Port 80 already open, skipping"
             else
@@ -193,7 +228,7 @@ jobs:
             sudo firewall-cmd --reload
             echo "Firewall ports: $(firewall-cmd --list-ports)"
 
-  deploy:
+  write-config:
     runs-on: ubuntu-latest
     needs: setup-server
 
@@ -201,7 +236,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
-      - name: Deploy to server via SSH
+      - name: Write config files
         uses: appleboy/ssh-action@v1
         with:
           host: ${{ secrets.LINODE_SERVER_IP }}
@@ -209,7 +244,6 @@ jobs:
           key: ${{ secrets.LINODE_SSH_KEY }}
           port: 43422
           script: |
-            # Set image variables
             BACKEND_IMAGE="${{ env.BACKEND_IMAGE }}"
             FRONTEND_IMAGE="${{ env.FRONTEND_IMAGE }}"
             IMAGE_TAG="${{ github.sha }}"
@@ -367,12 +401,11 @@ jobs:
               redis_data:
             EOF
 
-            # Write image variables to .env
+            # Write .env
             echo "BACKEND_IMAGE=${BACKEND_IMAGE}" > /opt/creditcardanalyzer/.env
             echo "FRONTEND_IMAGE=${FRONTEND_IMAGE}" >> /opt/creditcardanalyzer/.env
             echo "IMAGE_TAG=${IMAGE_TAG}" >> /opt/creditcardanalyzer/.env
 
-            # Decode base64 secrets and append to .env
             echo '${{ secrets.APP_SECRETS_B64 }}' | base64 -d | python3 -c "
             import json, sys
             data = json.load(sys.stdin)
@@ -380,39 +413,266 @@ jobs:
                 print(f'{k}={v}')
             " >> /opt/creditcardanalyzer/.env
 
-            # Secure .env
             chmod 600 /opt/creditcardanalyzer/.env
+            echo "Config files written"
 
-            # Deploy
+      - name: Validate required env vars
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.LINODE_SERVER_IP }}
+          username: ${{ secrets.LINODE_SSH_USER }}
+          key: ${{ secrets.LINODE_SSH_KEY }}
+          port: 43422
+          script: |
+            cd /opt/creditcardanalyzer
+            REQUIRED="POSTGRES_PASSWORD LLM_API_KEY SECRET_KEY TELEGRAM_BOT_TOKEN GOOGLE_CLIENT_ID GOOGLE_CLIENT_SECRET RESEND_API_KEY"
+            MISSING=""
+            for var in $REQUIRED; do
+              if ! grep -q "^${var}=" .env; then
+                MISSING="$MISSING $var"
+              fi
+            done
+
+            if [ -n "$MISSING" ]; then
+              echo "ERROR: Missing required env vars:$MISSING"
+              exit 1
+            fi
+            echo "All required env vars present"
+
+  validate-config:
+    runs-on: ubuntu-latest
+    needs: write-config
+
+    steps:
+      - name: Validate docker-compose syntax
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.LINODE_SERVER_IP }}
+          username: ${{ secrets.LINODE_SSH_USER }}
+          key: ${{ secrets.LINODE_SSH_KEY }}
+          port: 43422
+          script: |
             cd /opt/creditcardanalyzer
             export PATH="$HOME/.local/bin:$PATH"
             set -a
             source .env
             set +a
 
-            # Login to GHCR for private repo support
+            echo "Validating docker-compose.yml..."
+            podman-compose config --quiet
+            echo "docker-compose.yml OK"
+
+      - name: Validate nginx config
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.LINODE_SERVER_IP }}
+          username: ${{ secrets.LINODE_SSH_USER }}
+          key: ${{ secrets.LINODE_SSH_KEY }}
+          port: 43422
+          script: |
+            echo "Validating nginx.conf..."
+            podman run --rm \
+              -v /opt/creditcardanalyzer/nginx/nginx.conf:/etc/nginx/conf.d/default.conf:ro \
+              docker.io/library/nginx:alpine nginx -t
+            echo "nginx.conf OK"
+
+  pull-images:
+    runs-on: ubuntu-latest
+    needs: validate-config
+
+    steps:
+      - name: Pull and verify images
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.LINODE_SERVER_IP }}
+          username: ${{ secrets.LINODE_SSH_USER }}
+          key: ${{ secrets.LINODE_SSH_KEY }}
+          port: 43422
+          script: |
+            cd /opt/creditcardanalyzer
+            export PATH="$HOME/.local/bin:$PATH"
+            set -a
+            source .env
+            set +a
+
             echo "Logging in to GHCR..."
             echo "${{ secrets.GHCR_PAT }}" | podman login ghcr.io -u ${{ github.actor }} --password-stdin || echo "WARN: GHCR login failed (may be public repo)"
 
             echo "Pulling new images..."
             podman-compose pull
 
-            # Run database migration before starting new containers
-            echo "Running database migrations..."
-            podman-compose run --rm --no-deps backend python -m scripts.migrate_add_reset_token || echo "Migration skipped or failed (non-fatal)"
-            podman-compose run --rm --no-deps backend python -m scripts.migrate_remove_haberes || echo "Haberes cleanup skipped or failed (non-fatal)"
-            podman-compose run --rm --no-deps backend python -m scripts.migrate_encrypt_settings || echo "Encryption migration skipped or failed (non-fatal)"
+            # Verify images exist
+            echo "Verifying images..."
+            podman image inspect ${BACKEND_IMAGE}:${IMAGE_TAG} > /dev/null 2>&1 || { echo "ERROR: Backend image not found"; exit 1; }
+            podman image inspect ${FRONTEND_IMAGE}:${IMAGE_TAG} > /dev/null 2>&1 || { echo "ERROR: Frontend image not found"; exit 1; }
+            echo "Images verified"
 
-            # Clean shutdown of old containers before starting new ones
+  backup-db:
+    runs-on: ubuntu-latest
+    needs: pull-images
+
+    steps:
+      - name: Backup database
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.LINODE_SERVER_IP }}
+          username: ${{ secrets.LINODE_SSH_USER }}
+          key: ${{ secrets.LINODE_SSH_KEY }}
+          port: 43422
+          script: |
+            BACKUP_DIR="/opt/creditcardanalyzer/backups"
+            mkdir -p $BACKUP_DIR
+
+            TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+            BACKUP_FILE="$BACKUP_DIR/db_${TIMESTAMP}.sql"
+
+            echo "Backing up database..."
+            podman exec creditcardanalyzer_db_1 \
+              pg_dump -U expenses_user expenses > $BACKUP_FILE 2>/dev/null
+
+            # Compress
+            gzip $BACKUP_FILE
+
+            # Verify backup is not empty
+            if [ ! -s "${BACKUP_FILE}.gz" ]; then
+              echo "ERROR: Database backup is empty"
+              exit 1
+            fi
+
+            # Clean up backups older than 12 days
+            find $BACKUP_DIR -name "db_*.sql.gz" -mtime +12 -delete
+
+            BACKUP_SIZE=$(du -h ${BACKUP_FILE}.gz | cut -f1)
+            echo "Backup saved: ${BACKUP_FILE}.gz ($BACKUP_SIZE)"
+
+            # List current backups
+            echo "Current backups:"
+            ls -lh $BACKUP_DIR/db_*.sql.gz 2>/dev/null | tail -5
+
+  migrate:
+    runs-on: ubuntu-latest
+    needs: backup-db
+
+    steps:
+      - name: Run database migrations
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.LINODE_SERVER_IP }}
+          username: ${{ secrets.LINODE_SSH_USER }}
+          key: ${{ secrets.LINODE_SSH_KEY }}
+          port: 43422
+          script: |
+            cd /opt/creditcardanalyzer
+            export PATH="$HOME/.local/bin:$PATH"
+            set -a
+            source .env
+            set +a
+
+            echo "Running database migrations..."
+            podman-compose run --rm --no-deps backend python -m scripts.migrate_add_reset_token
+            podman-compose run --rm --no-deps backend python -m scripts.migrate_remove_haberes
+            podman-compose run --rm --no-deps backend python -m scripts.migrate_encrypt_settings
+            echo "Migrations complete"
+
+  restart-and-verify:
+    runs-on: ubuntu-latest
+    needs: migrate
+
+    steps:
+      - name: Restart services
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.LINODE_SERVER_IP }}
+          username: ${{ secrets.LINODE_SSH_USER }}
+          key: ${{ secrets.LINODE_SSH_KEY }}
+          port: 43422
+          script: |
+            cd /opt/creditcardanalyzer
+            export PATH="$HOME/.local/bin:$PATH"
+            set -a
+            source .env
+            set +a
+
+            # Save current image tag for rollback
+            CURRENT_TAG=$IMAGE_TAG
+            echo "Current tag: $CURRENT_TAG"
+
+            # Stop old containers
             echo "Stopping old containers..."
             podman-compose down --remove-orphans 2>/dev/null || true
 
+            # Start new containers
             echo "Starting new containers..."
             podman-compose up -d --remove-orphans
 
-            # Verify deployment
+      - name: Health check with retry
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.LINODE_SERVER_IP }}
+          username: ${{ secrets.LINODE_SSH_USER }}
+          key: ${{ secrets.LINODE_SSH_KEY }}
+          port: 43422
+          script: |
+            cd /opt/creditcardanalyzer
+            set -a
+            source .env
+            set +a
+
             echo "Waiting for services to start..."
-            sleep 5
-            curl -sk https://${{ vars.DOMAIN_NAME }}/api/docs -o /dev/null -w "%{http_code}" | grep -q 200 && echo "Deploy OK (domain)" || \
-              (echo "Domain check failed, trying localhost..." && curl -sf http://localhost/api/docs -o /dev/null -w "%{http_code}" | grep -q 200 && echo "Deploy OK (local)") || \
-              echo "WARN: health check failed"
+            sleep 10
+
+            RETRIES=15
+            SLEEP=5
+            DEPLOY_OK=false
+
+            for i in $(seq 1 $RETRIES); do
+              STATUS=$(curl -sk -o /dev/null -w "%{http_code}" https://${{ vars.DOMAIN_NAME }}/api/docs 2>/dev/null)
+              if [ "$STATUS" = "200" ]; then
+                echo "Deploy OK after ${i} attempt(s)"
+                DEPLOY_OK=true
+                break
+              fi
+              echo "Attempt $i/$RETRIES: got $STATUS, retrying in ${SLEEP}s..."
+              sleep $SLEEP
+            done
+
+            if [ "$DEPLOY_OK" = "false" ]; then
+              echo "CRITICAL: Health check failed after $((RETRIES * SLEEP))s"
+              echo "Rolling back to previous image tag..."
+
+              # Find previous tag from git log or use latest
+              PREV_TAG=$(podman images --format "{{.Tag}}" | grep -v latest | grep -v $IMAGE_TAG | head -1)
+              if [ -z "$PREV_TAG" ]; then
+                echo "ERROR: No previous image tag found for rollback"
+                exit 1
+              fi
+
+              echo "Rolling back to tag: $PREV_TAG"
+              sed -i "s/^IMAGE_TAG=.*/IMAGE_TAG=${PREV_TAG}/" .env
+              podman-compose down --remove-orphans 2>/dev/null || true
+              podman-compose up -d --remove-orphans
+              exit 1
+            fi
+
+            # Show final status
+            echo ""
+            echo "=== Final Status ==="
+            podman ps --format "table {{.Names}}\t{{.Status}}\t{{.Ports}}"
+
+  cleanup-old-images:
+    runs-on: ubuntu-latest
+    needs: restart-and-verify
+    if: success()
+
+    steps:
+      - name: Cleanup old images
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.LINODE_SERVER_IP }}
+          username: ${{ secrets.LINODE_SSH_USER }}
+          key: ${{ secrets.LINODE_SSH_KEY }}
+          port: 43422
+          script: |
+            echo "Cleaning up old images..."
+            podman image prune -f 2>/dev/null || true
+            echo "Cleanup complete"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -100,7 +100,7 @@ jobs:
             mkdir -p /opt/creditcardanalyzer/certbot/{conf,work,logs}
 
             # Get SSL certificate if not already present
-            if [ -f /opt/creditcardanalyzer/certbot/conf/live/${{ secrets.DOMAIN_NAME }}/fullchain.pem ]; then
+            if [ -f /opt/creditcardanalyzer/certbot/conf/live/${{ vars.DOMAIN_NAME }}/fullchain.pem ]; then
                 echo "SSL certificate already exists, skipping"
             else
                 echo "Requesting SSL certificate..."
@@ -110,7 +110,7 @@ jobs:
                   -v /opt/creditcardanalyzer/certbot/logs:/var/log/letsencrypt:Z \
                   -p 80:80 \
                   docker.io/certbot/certbot certonly --standalone \
-                  -d ${{ secrets.DOMAIN_NAME }} \
+                  -d ${{ vars.DOMAIN_NAME }} \
                   --email mmendoza0989@gmail.com \
                   --agree-tos --non-interactive
                 echo "SSL certificate obtained"
@@ -118,8 +118,8 @@ jobs:
 
             # Fix cert permissions for nginx container (SELinux + nginx user access)
             chmod 755 /opt/creditcardanalyzer/certbot/conf/archive 2>/dev/null || true
-            chmod 755 /opt/creditcardanalyzer/certbot/conf/archive/${{ secrets.DOMAIN_NAME }} 2>/dev/null || true
-            chmod 644 /opt/creditcardanalyzer/certbot/conf/archive/${{ secrets.DOMAIN_NAME }}/*.pem 2>/dev/null || true
+            chmod 755 /opt/creditcardanalyzer/certbot/conf/archive/${{ vars.DOMAIN_NAME }} 2>/dev/null || true
+            chmod 644 /opt/creditcardanalyzer/certbot/conf/archive/${{ vars.DOMAIN_NAME }}/*.pem 2>/dev/null || true
             echo "Cert permissions fixed"
 
       - name: Setup certbot renewal timer
@@ -220,15 +220,15 @@ jobs:
             server {
                 listen 80 default_server;
                 server_name _;
-                return 301 https://${{ secrets.DOMAIN_NAME }}$request_uri;
+                return 301 https://${{ vars.DOMAIN_NAME }}$request_uri;
             }
 
             server {
                 listen 443 ssl default_server;
                 server_name _;
 
-                ssl_certificate /etc/letsencrypt/live/${{ secrets.DOMAIN_NAME }}/fullchain.pem;
-                ssl_certificate_key /etc/letsencrypt/live/${{ secrets.DOMAIN_NAME }}/privkey.pem;
+                ssl_certificate /etc/letsencrypt/live/${{ vars.DOMAIN_NAME }}/fullchain.pem;
+                ssl_certificate_key /etc/letsencrypt/live/${{ vars.DOMAIN_NAME }}/privkey.pem;
 
                 ssl_protocols TLSv1.2 TLSv1.3;
                 ssl_ciphers HIGH:!aNULL:!MD5;
@@ -308,8 +308,8 @@ jobs:
                   GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET}
                   SECRET_KEY: ${SECRET_KEY}
                   RESEND_API_KEY: ${RESEND_API_KEY}
-                  FRONTEND_URL: https://${{ secrets.DOMAIN_NAME }}
-                  CORS_ORIGINS: https://${{ secrets.DOMAIN_NAME }}
+                  FRONTEND_URL: https://${{ vars.DOMAIN_NAME }}
+                  CORS_ORIGINS: https://${{ vars.DOMAIN_NAME }}
                 restart: unless-stopped
 
               celery_worker:
@@ -413,6 +413,6 @@ jobs:
             # Verify deployment
             echo "Waiting for services to start..."
             sleep 5
-            curl -sk https://${{ secrets.DOMAIN_NAME }}/api/docs -o /dev/null -w "%{http_code}" | grep -q 200 && echo "Deploy OK (domain)" || \
+            curl -sk https://${{ vars.DOMAIN_NAME }}/api/docs -o /dev/null -w "%{http_code}" | grep -q 200 && echo "Deploy OK (domain)" || \
               (echo "Domain check failed, trying localhost..." && curl -sf http://localhost/api/docs -o /dev/null -w "%{http_code}" | grep -q 200 && echo "Deploy OK (local)") || \
               echo "WARN: health check failed"

--- a/README.md
+++ b/README.md
@@ -139,13 +139,50 @@ podman-compose run --rm backend_dev python -c "from app.database import SessionL
 
 ## Production Deployment
 
+### Architecture
+
+```
+Internet → :80 (redirect) → :443 (nginx SSL) → :80 (frontend nginx) → backend:8000
+```
+
+Production runs on a Linode server with the following services:
+
+| Service | Description |
+|---------|-------------|
+| `nginx` | Reverse proxy with SSL termination (ports 80/443) |
+| `frontend` | React SPA served by nginx (internal only) |
+| `backend` | FastAPI backend (internal only) |
+| `celery_worker` | Background task processor |
+| `db` | PostgreSQL 16 |
+| `redis` | Redis 7 |
+
 ### GitHub Actions
 
 Push to `main` branch triggers automatic deployment:
 
 1. Build Docker images → push to GHCR
-2. SSH into server → pull images
-3. Run migrations → restart services
+2. Setup server (podman, SSL certs, firewall)
+3. Deploy containers → run migrations → verify health
+
+### SSL Certificates
+
+SSL is handled by Let's Encrypt via certbot:
+
+- Certs stored at `/opt/creditcardanalyzer/certbot/conf/`
+- Auto-renewal via systemd timer (`certbot-renew.timer`)
+- Nginx mounts certs as read-only with SELinux `:Z` flag
+
+### Idempotent Setup Steps
+
+Each setup step validates before acting:
+
+| Step | Validation | Action |
+|------|------------|--------|
+| Podman | `command -v podman` | Install via dnf |
+| podman-compose | `command -v podman-compose` | Install via pip |
+| SSL cert | `ls certbot/conf/live/.../fullchain.pem` | Run certbot container |
+| Certbot timer | `ls /etc/systemd/system/certbot-renew.timer` | Create systemd timer |
+| Firewall | `firewall-cmd --list-ports` | Open 80/443 |
 
 ### Required Secrets
 
@@ -156,6 +193,7 @@ Add in `Settings → Secrets → Actions`:
 | `LINODE_SERVER_IP` | Server IP address |
 | `LINODE_SSH_USER` | SSH username |
 | `LINODE_SSH_KEY` | SSH private key |
+| `GHCR_PAT` | GitHub PAT for GHCR login |
 | `APP_SECRETS_B64` | Base64-encoded JSON with app secrets |
 
 ### APP_SECRETS Template
@@ -194,6 +232,21 @@ podman-compose run --rm --no-deps backend python -m scripts.migrate_remove_haber
 # Restart services
 podman-compose down
 podman-compose up -d
+
+# Verify
+curl -sk https://okinomonia.freeddns.org/api/docs
+```
+
+### Health Checks
+
+Deployment verifies the full stack:
+
+```bash
+# Primary: domain-based (validates DNS + SSL + nginx + backend)
+curl -sk https://okinomonia.freeddns.org/api/docs
+
+# Fallback: localhost (validates nginx container only)
+curl -sf http://localhost/api/docs
 ```
 
 ## Telegram Bot

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ podman-compose down
 podman-compose up -d
 
 # Verify
-curl -sk https://okinomonia.freeddns.org/api/docs
+curl -sk https://yourdomain.com/api/docs
 ```
 
 ### Health Checks
@@ -243,7 +243,7 @@ Deployment verifies the full stack:
 
 ```bash
 # Primary: domain-based (validates DNS + SSL + nginx + backend)
-curl -sk https://okinomonia.freeddns.org/api/docs
+curl -sk https://yourdomain.com/api/docs
 
 # Fallback: localhost (validates nginx container only)
 curl -sf http://localhost/api/docs

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,34 @@
+server {
+    listen 80 default_server;
+    server_name _;
+    return 301 https://okinomonia.freeddns.org$request_uri;
+}
+
+server {
+    listen 443 ssl default_server;
+    server_name _;
+
+    ssl_certificate /etc/letsencrypt/live/okinomonia.freeddns.org/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/okinomonia.freeddns.org/privkey.pem;
+
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers HIGH:!aNULL:!MD5;
+    ssl_prefer_server_ciphers on;
+    ssl_session_cache shared:SSL:10m;
+    ssl_session_timeout 10m;
+
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+    add_header X-Content-Type-Options nosniff;
+    add_header X-Frame-Options DENY;
+
+    gzip on;
+    gzip_types text/plain text/css application/json application/javascript text/xml;
+
+    location / {
+        proxy_pass http://frontend:80;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,15 +1,15 @@
 server {
     listen 80 default_server;
     server_name _;
-    return 301 https://okinomonia.freeddns.org$request_uri;
+    return 301 https://YOUR_DOMAIN$request_uri;
 }
 
 server {
     listen 443 ssl default_server;
     server_name _;
 
-    ssl_certificate /etc/letsencrypt/live/okinomonia.freeddns.org/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/okinomonia.freeddns.org/privkey.pem;
+    ssl_certificate /etc/letsencrypt/live/YOUR_DOMAIN/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/YOUR_DOMAIN/privkey.pem;
 
     ssl_protocols TLSv1.2 TLSv1.3;
     ssl_ciphers HIGH:!aNULL:!MD5;


### PR DESCRIPTION
## Summary

Adds nginx reverse proxy with SSL termination for production deployment at okinomonia.freeddns.org.

## Changes

- **nginx/nginx.conf**: New reverse proxy config for SSL termination and SPA routing
- **deploy.yml**: Updated with nginx service, SSL cert setup, firewall config, and validation steps

## Architecture

```
Internet → :80 (redirect) → :443 (nginx SSL) → :80 (frontend nginx) → backend:8000
```

## Validation Steps (idempotent)

Each setup step checks before acting:
- Installs podman/podman-compose only if missing
- Creates SSL cert only if not present
- Sets up certbot timer only if missing
- Opens firewall ports only if closed
- Health check uses domain with localhost fallback

## Other Changes

-  and  updated to 
- Frontend container made internal-only (no port mapping)
- SSL auto-renewal via systemd timer

## Testing

- [x] HTTP → HTTPS redirect working
- [x] HTTPS frontend accessible
- [x] API proxy working
- [x] All containers healthy

Closes #