### PR TITLE
feat: nginx SSL reverse proxy + segmented CI/CD pipeline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -97,7 +97,10 @@ jobs:
           key: ${{ secrets.LINODE_SSH_KEY }}
           port: 43422
           script: |
-            RESOLVED_IP=$(dig +short ${{ vars.DOMAIN_NAME }} | tail -1)
+            RESOLVED_IP=$(nslookup ${{ vars.DOMAIN_NAME }} 2>/dev/null | awk '/^Address: / { print $2 }' | tail -1)
+            if [ -z "$RESOLVED_IP" ]; then
+              RESOLVED_IP=$(host ${{ vars.DOMAIN_NAME }} 2>/dev/null | awk '/has address/ { print $NF }' | head -1)
+            fi
             SERVER_IP=$(curl -s --connect-timeout 5 https://api.ipify.org || curl -s --connect-timeout 5 https://ifconfig.me)
 
             echo "Domain: ${{ vars.DOMAIN_NAME }}"


### PR DESCRIPTION
## Summary

Adds nginx reverse proxy with SSL termination for production, and restructures the deploy pipeline into 9 segmented jobs with comprehensive validations.

## Changes

### Infrastructure
- **nginx/nginx.conf**: New reverse proxy config (SSL termination, HTTP→HTTPS redirect, SPA routing)
- SSL certificates via Let's Encrypt (certbot container, auto-renewal via systemd timer)
- Firewall ports 80/443 opened

### CI/CD Pipeline (9 segmented jobs)

| Job | Purpose | Validation |
|-----|---------|------------|
| `build-and-push` | Build images | GHCR push success |
| `setup-server` | Infrastructure | DNS check, cert expiry (<14d), firewall |
| `write-config` | Config files | Required env vars |
| `validate-config` | Syntax check | `podman-compose config`, `nginx -t` |
| `pull-images` | Get images | `podman image inspect` |
| `backup-db` | Safety net | pg_dump, 12 day retention, non-empty check |
| `migrate` | Schema changes | Abort on failure |
| `restart-and-verify` | Go live | 15×5s retry loop, auto-rollback |
| `cleanup-old-images` | Housekeeping | Prune unused images |

### Security
- Domain moved to `vars.DOMAIN_NAME` (not hardcoded)
- CORS_ORIGINS and FRONTEND_URL updated to use domain variable

### Other
- Frontend container made internal-only (no port mapping)
- README and Wiki Deployment page updated

## Testing

- [x] HTTP → HTTPS redirect working
- [x] HTTPS frontend accessible
- [x] API proxy working
- [x] All containers healthy
- [x] Health check retry loop verified

## Required Setup

Add `DOMAIN_NAME` variable in **Settings → Secrets and variables → Actions → Variables** with your domain (e.g., `okinomonia.freeddns.org`).

Closes #