### PR TITLE
feat: dashboard interactive cards + notifications + fixes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,6 +18,7 @@ env:
   REGISTRY: ghcr.io
   BACKEND_IMAGE: ghcr.io/${{ github.repository_owner }}/perexp/backend
   FRONTEND_IMAGE: ghcr.io/${{ github.repository_owner }}/perexp/frontend
+  DOMAIN_NAME: okinomonia.freeddns.org
 
 jobs:
   build-and-push:
@@ -498,6 +499,10 @@ jobs:
           key: ${{ secrets.LINODE_SSH_KEY }}
           port: 43422
           script: |
+            # Substitute domain in nginx.conf
+            DOMAIN_NAME="${{ env.DOMAIN_NAME }}"
+            sed -i "s/\${DOMAIN_NAME}/${DOMAIN_NAME}/g" /opt/creditcardanalyzer/nginx/nginx.conf
+
             cd /opt/creditcardanalyzer
             export PATH="$HOME/.local/bin:$PATH"
             set -a

--- a/docs/Roadmap.md
+++ b/docs/Roadmap.md
@@ -14,9 +14,9 @@
 | 8 | Income module | ⏳ Backlog | High | - | Track income, dashboard comparison vs last months |
 | 9 | Ticket scan | ⏳ Backlog | Medium | - | OCR receipt analysis, compare same items last month |
 | 10 | Expense budgets | ⏳ Backlog | Medium | - | Set spending limits per category |
-| 11 | Make index.html interactive | ⏳ Backlog | Medium | - | Filter transactions/categories when clicking Deuda Tarjetas or Cuotas este mes |
+| 11 | Make index.html interactive | ✅ Done | Medium | #73 | Click KPI cards to filter expenses, uncategorized warnings |
 | 12 | Billing period tracking | ⏳ In Progress | Medium | #36 | closing_day on Card, billing API, billing view toggle in Dashboard |
-| 13 | Missing categories notification | ⏳ Backlog | Medium | - | Notify when expenses lack category assignment |
+| 13 | Missing categories notification | ✅ Done | Medium | #73 | Real-time notifications for uncategorized expenses on save + login |
 
 ## Backlog Details
 

--- a/frontend/src/components/CardAccountModal.tsx
+++ b/frontend/src/components/CardAccountModal.tsx
@@ -78,9 +78,8 @@ export default function CardAccountModal({ onClose }: CardAccountModalProps) {
   const pending = createCardMut.isPending || createAccountMut.isPending;
 
   return (
-    <div className="fixed inset-0 z-[60] flex items-center justify-center p-4 animate-modal-backdrop">
-      <div className="fixed inset-0 bg-black/60" onClick={onClose} />
-      <div className="relative card w-full max-w-sm max-h-[90vh] overflow-auto p-6 space-y-4 animate-modal-content">
+    <div className="fixed inset-0 z-[60] flex items-center justify-center p-4 animate-modal-backdrop bg-black/60" onClick={onClose}>
+      <div className="relative card w-full max-w-sm max-h-[90vh] overflow-auto p-6 space-y-4 animate-modal-content" onClick={(e) => e.stopPropagation()}>
         <div className="flex items-center justify-between">
           <h2 className="text-lg font-semibold text-[var(--text-primary)]">
             Crear tarjeta o cuenta

--- a/frontend/src/components/CardAccountModal.tsx
+++ b/frontend/src/components/CardAccountModal.tsx
@@ -78,8 +78,14 @@ export default function CardAccountModal({ onClose }: CardAccountModalProps) {
   const pending = createCardMut.isPending || createAccountMut.isPending;
 
   return (
-    <div className="fixed inset-0 z-[60] flex items-center justify-center p-4 animate-modal-backdrop bg-black/60" onClick={onClose}>
-      <div className="relative card w-full max-w-sm max-h-[90vh] overflow-auto p-6 space-y-4 animate-modal-content" onClick={(e) => e.stopPropagation()}>
+    <div
+      className="fixed inset-0 z-[60] flex items-center justify-center p-4 animate-modal-backdrop bg-black/60"
+      onClick={onClose}
+    >
+      <div
+        className="relative card w-full max-w-sm max-h-[90vh] overflow-auto p-6 space-y-4 animate-modal-content"
+        onClick={(e) => e.stopPropagation()}
+      >
         <div className="flex items-center justify-between">
           <h2 className="text-lg font-semibold text-[var(--text-primary)]">
             Crear tarjeta o cuenta

--- a/frontend/src/components/ConfirmDialog.tsx
+++ b/frontend/src/components/ConfirmDialog.tsx
@@ -25,14 +25,14 @@ export function ConfirmDialog({
   if (!isOpen) return null;
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center p-4 animate-modal-backdrop">
-      <div className="absolute inset-0 bg-black/60" onClick={onCancel} />
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4 animate-modal-backdrop bg-black/60" onClick={onCancel}>
       <div
         ref={trapRef}
         role="dialog"
         aria-modal="true"
         aria-label={title}
         className="relative bg-[var(--color-surface)] border border-[var(--border-color)] rounded-md shadow-xl w-full max-w-sm p-4 space-y-4 animate-modal-content"
+        onClick={(e) => e.stopPropagation()}
       >
         <div className="space-y-1">
           <h3 className="text-sm font-semibold text-[var(--text-primary)]">{title}</h3>

--- a/frontend/src/components/ConfirmDialog.tsx
+++ b/frontend/src/components/ConfirmDialog.tsx
@@ -25,7 +25,10 @@ export function ConfirmDialog({
   if (!isOpen) return null;
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center p-4 animate-modal-backdrop bg-black/60" onClick={onCancel}>
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4 animate-modal-backdrop bg-black/60"
+      onClick={onCancel}
+    >
       <div
         ref={trapRef}
         role="dialog"

--- a/frontend/src/components/DetailModal.tsx
+++ b/frontend/src/components/DetailModal.tsx
@@ -24,7 +24,10 @@ export function DetailModal({ isOpen, onClose, title, subtitle, children }: Deta
   if (!isOpen) return null;
 
   return (
-    <div className="fixed inset-0 z-50 flex items-end sm:items-center justify-center p-0 sm:p-4 animate-modal-backdrop bg-black/60" onClick={onClose}>
+    <div
+      className="fixed inset-0 z-50 flex items-end sm:items-center justify-center p-0 sm:p-4 animate-modal-backdrop bg-black/60"
+      onClick={onClose}
+    >
       <div
         ref={trapRef}
         role="dialog"

--- a/frontend/src/components/DetailModal.tsx
+++ b/frontend/src/components/DetailModal.tsx
@@ -24,14 +24,14 @@ export function DetailModal({ isOpen, onClose, title, subtitle, children }: Deta
   if (!isOpen) return null;
 
   return (
-    <div className="fixed inset-0 z-50 flex items-end sm:items-center justify-center p-0 sm:p-4 animate-modal-backdrop">
-      <div className="fixed inset-0 bg-black/60" onClick={onClose} />
+    <div className="fixed inset-0 z-50 flex items-end sm:items-center justify-center p-0 sm:p-4 animate-modal-backdrop bg-black/60" onClick={onClose}>
       <div
         ref={trapRef}
         role="dialog"
         aria-modal="true"
         aria-label={title}
         className="relative bg-[var(--color-surface)] border border-[var(--border-color)] rounded-t-lg sm:rounded-lg shadow-xl w-full sm:max-w-lg max-h-[90vh] overflow-hidden flex flex-col animate-modal-content"
+        onClick={(e) => e.stopPropagation()}
       >
         <div className="flex items-center justify-between px-5 py-4 border-b border-[var(--border-color)]">
           <div className="min-w-0 flex-1">

--- a/frontend/src/components/ExpenseModals.tsx
+++ b/frontend/src/components/ExpenseModals.tsx
@@ -261,7 +261,10 @@ export function ExpenseModal({
   const trapRef = useFocusTrap(true);
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center p-4 animate-modal-backdrop bg-black/60" onClick={onClose}>
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4 animate-modal-backdrop bg-black/60"
+      onClick={onClose}
+    >
       <div
         ref={trapRef}
         role="dialog"

--- a/frontend/src/components/ExpenseModals.tsx
+++ b/frontend/src/components/ExpenseModals.tsx
@@ -261,14 +261,14 @@ export function ExpenseModal({
   const trapRef = useFocusTrap(true);
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center p-4 animate-modal-backdrop">
-      <div className="fixed inset-0 bg-black/60" onClick={onClose} />
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4 animate-modal-backdrop bg-black/60" onClick={onClose}>
       <div
         ref={trapRef}
         role="dialog"
         aria-modal="true"
         aria-label={initial ? "Editar gasto" : "Nuevo gasto"}
         className="relative card w-full max-w-lg max-h-[90vh] overflow-auto p-6 space-y-4 animate-modal-content"
+        onClick={(e) => e.stopPropagation()}
       >
         <div className="flex items-center justify-between">
           <h2 className="text-lg font-semibold text-[var(--text-primary)]">

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,15 +1,15 @@
 server {
     listen 80 default_server;
     server_name _;
-    return 301 https://YOUR_DOMAIN$request_uri;
+    return 301 https://${DOMAIN_NAME}$request_uri;
 }
 
 server {
     listen 443 ssl default_server;
     server_name _;
 
-    ssl_certificate /etc/letsencrypt/live/YOUR_DOMAIN/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/YOUR_DOMAIN/privkey.pem;
+    ssl_certificate /etc/letsencrypt/live/${DOMAIN_NAME}/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/${DOMAIN_NAME}/privkey.pem;
 
     ssl_protocols TLSv1.2 TLSv1.3;
     ssl_ciphers HIGH:!aNULL:!MD5;
@@ -30,5 +30,9 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_buffering off;
+        proxy_cache off;
+        proxy_read_timeout 86400;
+        chunked_transfer_encoding on;
     }
 }


### PR DESCRIPTION
## Summary
Implements features #11 and #13 from the roadmap, plus bug fixes.

## Feature #11 — Make dashboard info boxes interactive
- 'Total gastado' card → navigates to /expenses
- 'Deuda tarjetas' card → navigates to /expenses?card_type=credito
- 'Cuotas este mes' card → navigates to /expenses?installment=1
- Added card_type and installment filters to backend + frontend

## Feature #13 — Missing categories notification
- Backend creates Notification when expense saved without category
- Real-time notification via SSE (like import-job notifications)
- /expenses/uncategorized-count endpoint creates notification on login
- Toast + bell panel entry with click → /expenses?uncategorized=1

## Bug fixes
- Fixed Gnome Web (Epiphany) modal backdrop — removed nested fixed overlays
- Fixed nginx SSE support — added proxy_buffering off, proxy_read_timeout
- Added nginx/nginx.conf to repo for future deploys

## Files changed
- backend/app/routers/expenses.py — card_type/installment filters + uncategorized notifications
- frontend/src/api/client.ts — new filter params + getUncategorizedCount
- frontend/src/hooks/useExpenseFilters.ts — cardType + installment filters
- frontend/src/pages/Dashboard.tsx — clickable KPI cards + uncategorized query
- frontend/src/pages/ExpensesPage.tsx — wired new filters
- frontend/src/context/NotificationsContext.tsx — uncategorized_expense toast
- frontend/src/components/NotificationsPanel.tsx — click nav + icon
- frontend/src/components/ExpenseModals.tsx — modal backdrop fix
- frontend/src/components/DetailModal.tsx — modal backdrop fix
- frontend/src/components/CardAccountModal.tsx — modal backdrop fix
- frontend/src/components/ConfirmDialog.tsx — modal backdrop fix
- nginx/nginx.conf — SSE support added to repo

## Related
- Closes #11
- Closes #13