### PR TITLE
fix: SSE streaming support in production nginx

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -320,6 +320,10 @@ jobs:
                     proxy_set_header X-Real-IP $remote_addr;
                     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
                     proxy_set_header X-Forwarded-Proto $scheme;
+                    proxy_buffering off;
+                    proxy_cache off;
+                    proxy_read_timeout 86400;
+                    chunked_transfer_encoding on;
                 }
             }
             NGINXEOF


### PR DESCRIPTION
## Problem

NotificationsPanel shows 'Conectando...' forever because nginx buffers SSE responses instead of streaming them.

## Root Cause

The deploy.yml generates nginx config without SSE-critical directives:
-  - nginx buffers entire SSE response
-  defaults to 60s - connection closed prematurely
-  - nginx tries to cache streaming responses
-  - needed for streaming through proxy

## Fix

Added all 4 SSE directives to the `location /` block in deploy.yml nginx config.

## Testing

After merge, re-run the deploy pipeline. The notifications panel should connect immediately and show real-time updates.