### PR TITLE
fix: run migrations inside container via podman-compose

### DIFF
--- a/backend/scripts/deploy_prod.py
+++ b/backend/scripts/deploy_prod.py
@@ -45,9 +45,9 @@ def main():
     # Step 1: Run migration
     print("\n[Step 1] Running database migration...")
     if args.dry_run:
-        print("  Would run: python -m scripts.migrate_add_reset_token")
+        print("  Would run: podman-compose run --rm --no-deps backend python -m scripts.migrate_add_reset_token")
     else:
-        run_command("cd /home/chelo/creditCardAnalyzer/backend && python -m scripts.migrate_add_reset_token")
+        run_command("cd /home/chelo/creditCardAnalyzer && podman-compose run --rm --no-deps backend python -m scripts.migrate_add_reset_token")
 
     # Step 2: Restart backend
     if not args.skip_restart:

--- a/backend/scripts/deploy_prod.sh
+++ b/backend/scripts/deploy_prod.sh
@@ -25,11 +25,11 @@ done
 echo ""
 echo "[Step 1/3] Running database migration..."
 if [ "$DRY_RUN" = true ]; then
-  echo "  Would run: python -m scripts.migrate_add_reset_token"
-  echo "  Would run: python -m scripts.migrate_remove_haberes"
+  echo "  Would run: podman-compose run --rm --no-deps backend python -m scripts.migrate_add_reset_token"
+  echo "  Would run: podman-compose run --rm --no-deps backend python -m scripts.migrate_remove_haberes"
 else
-  python -m scripts.migrate_add_reset_token
-  python -m scripts.migrate_remove_haberes
+  podman-compose run --rm --no-deps backend python -m scripts.migrate_add_reset_token
+  podman-compose run --rm --no-deps backend python -m scripts.migrate_remove_haberes
 fi
 
 # Step 2: Restart services

--- a/docs/Roadmap.md
+++ b/docs/Roadmap.md
@@ -17,6 +17,7 @@
 | 11 | Make index.html interactive | ✅ Done | Medium | #73 | Click KPI cards to filter expenses, uncategorized warnings |
 | 12 | Billing period tracking | ⏳ In Progress | Medium | #36 | closing_day on Card, billing API, billing view toggle in Dashboard |
 | 13 | Missing categories notification | ✅ Done | Medium | #73 | Real-time notifications for uncategorized expenses on save + login |
+| 14 | FCI, Plazos Fijos y Cauciones | ⏳ Backlog | Medium | - | Support for Fondos Comunes de Inversión, Plazos Fijos, and Cauciones in investments module |
 
 ## Backlog Details
 
@@ -60,3 +61,11 @@ Generate a monthly summary report with:
 - Alert user when expenses are created without a category
 - Notification via Telegram bot or dashboard toast
 - Help ensure all expenses are properly categorized for better analysis
+
+### FCI, Plazos Fijos y Cauciones
+- **FCI (Fondos Comunes de Inversión)**: Track money market, fixed income, and equity funds
+- **Plazos Fijos**: Track fixed-term deposits with maturity dates and rates
+- **Cauciones**: Track overnight lending operations
+- Integration with existing investment portfolio
+- Separate tracking from stocks/ETFs
+- Maturity date alerts and reminders


### PR DESCRIPTION
## Problem

deploy_prod.sh and deploy_prod.py ran migration scripts directly with `python`, which failed with:

```
psycopg2.OperationalError: could not translate host name db to address
```

The hostname db is a Docker Compose service name that only resolves inside the Docker network.

## Fix

Changed both deploy scripts to use `podman-compose run --rm --no-deps backend` which runs the migration inside the backend container where DNS resolution works correctly.

This matches the approach used in the GitHub Actions deploy workflow.