### PR TITLE
fix: increase Playwright screenshot timeout to prevent report generation failures

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -405,6 +405,8 @@ jobs:
                   GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID}
                   GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET}
                   SECRET_KEY: ${SECRET_KEY}
+                  RESEND_API_KEY: ${RESEND_API_KEY}
+                  ADMIN_EMAIL: ${ADMIN_EMAIL}
                 deploy:
                   resources:
                     limits:
@@ -430,6 +432,8 @@ jobs:
                   GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID}
                   GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET}
                   SECRET_KEY: ${SECRET_KEY}
+                  RESEND_API_KEY: ${RESEND_API_KEY}
+                  ADMIN_EMAIL: ${ADMIN_EMAIL}
                 deploy:
                   resources:
                     limits:
@@ -491,7 +495,7 @@ jobs:
           port: 43422
           script: |
             cd /opt/creditcardanalyzer
-            REQUIRED="POSTGRES_PASSWORD LLM_API_KEY SECRET_KEY TELEGRAM_BOT_TOKEN GOOGLE_CLIENT_ID GOOGLE_CLIENT_SECRET RESEND_API_KEY"
+            REQUIRED="POSTGRES_PASSWORD LLM_API_KEY SECRET_KEY TELEGRAM_BOT_TOKEN GOOGLE_CLIENT_ID GOOGLE_CLIENT_SECRET RESEND_API_KEY ADMIN_EMAIL"
             MISSING=""
             for var in $REQUIRED; do
               if ! grep -q "^${var}=" .env; then

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,3 +1,7 @@
 GOOGLE_API_KEY=AIza...
 GOOGLE_CLIENT_ID=your-client-id.apps.googleusercontent.com
 GOOGLE_CLIENT_SECRET=your-client-secret
+
+# Email notifications (Resend)
+RESEND_API_KEY=re_xxxxx
+ADMIN_EMAIL=admin@yourdomain.com

--- a/backend/app/services/email.py
+++ b/backend/app/services/email.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from datetime import datetime
 
 import resend
 
@@ -10,6 +11,7 @@ if resend_api_key:
     resend.api_key = resend_api_key
 
 FROM_EMAIL = os.getenv("SMTP_FROM", "Financial Planning <onboarding@resend.dev>")
+ADMIN_EMAIL = os.getenv("ADMIN_EMAIL", "admin@financialplanning.com")
 
 
 def send_password_reset_email(to: str, token: str, base_url: str) -> bool:
@@ -49,4 +51,46 @@ def send_password_reset_email(to: str, token: str, base_url: str) -> bool:
         return True
     except Exception as e:
         logger.error(f"Failed to send password reset email to {to}: {e}")
+        return False
+
+
+def send_report_failure_email(user_id: int, month_str: str, error: str) -> bool:
+    if not resend_api_key:
+        logger.warning("RESEND_API_KEY not set — cannot send report failure email")
+        return False
+
+    timestamp = datetime.utcnow().strftime("%d/%m/%Y %H:%M:%S UTC")
+    html = f"""
+    <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; max-width: 480px; margin: 0 auto; padding: 32px;">
+      <div style="text-align: center; margin-bottom: 32px;">
+        <div style="display: inline-block; width: 48px; height: 48px; border-radius: 8px; background: #ef4444; color: white; font-weight: bold; font-size: 20px; line-height: 48px;">!</div>
+      </div>
+      <h1 style="font-size: 20px; font-weight: 600; color: #1a1a1a; margin-bottom: 8px;">Reporte mensual falló</h1>
+      <p style="color: #666; font-size: 14px; line-height: 1.5; margin-bottom: 24px;">
+        La generación del reporte mensual falló después de 3 intentos.
+      </p>
+      <div style="background: #f8f9fa; border-radius: 8px; padding: 16px; margin-bottom: 24px;">
+        <p style="margin: 4px 0; font-size: 13px; color: #333;"><strong>User ID:</strong> {user_id}</p>
+        <p style="margin: 4px 0; font-size: 13px; color: #333;"><strong>Mes:</strong> {month_str}</p>
+        <p style="margin: 4px 0; font-size: 13px; color: #333;"><strong>Error:</strong> {error[:300]}</p>
+        <p style="margin: 4px 0; font-size: 13px; color: #333;"><strong>Timestamp:</strong> {timestamp}</p>
+      </div>
+      <p style="color: #999; font-size: 12px; line-height: 1.5;">
+        Revisá los logs del worker para más detalles.
+      </p>
+    </div>
+    """
+
+    try:
+        params: resend.Emails.SendParams = {
+            "from": FROM_EMAIL,
+            "to": [ADMIN_EMAIL],
+            "subject": f"[ALERTA] Reporte mensual falló — {month_str} — User {user_id}",
+            "html": html,
+        }
+        result = resend.Emails.send(params)
+        logger.info(f"Report failure email sent for user {user_id}, month {month_str}: {result}")
+        return True
+    except Exception as e:
+        logger.error(f"Failed to send report failure email for user {user_id}: {e}")
         return False

--- a/backend/app/services/pdf_report.py
+++ b/backend/app/services/pdf_report.py
@@ -367,16 +367,17 @@ def generate_report_image(report_data: dict, user_name: str) -> bytes:
 
     # Generate PNG image with Playwright
     with sync_playwright() as p:
-        browser = p.chromium.launch(args=["--no-sandbox", "--disable-dev-shm-usage"])
+        browser = p.chromium.launch(args=["--no-sandbox", "--disable-dev-shm-usage", "--disable-gpu"])
         page = browser.new_page(
             viewport={"width": 1080, "height": 1600},
             device_scale_factor=2,  # Retina quality
         )
         page.set_content(html_content, wait_until="networkidle")
         page.emulate_media(media="screen")
+        page.wait_for_timeout(2000)
 
         # Take screenshot of the full page
-        png_bytes = page.screenshot(full_page=True, type="png")
+        png_bytes = page.screenshot(full_page=True, type="png", timeout=60000)
         browser.close()
 
     return png_bytes

--- a/backend/app/services/weekly_report.py
+++ b/backend/app/services/weekly_report.py
@@ -127,7 +127,7 @@ def generate_weekly_report_image(report_data: dict) -> bytes:
 
     # Generate PNG image with Playwright
     with sync_playwright() as p:
-        browser = p.chromium.launch(args=["--no-sandbox", "--disable-dev-shm-usage"])
+        browser = p.chromium.launch(args=["--no-sandbox", "--disable-dev-shm-usage", "--disable-gpu"])
         page = browser.new_page(
             viewport={"width": 800, "height": 600},
             device_scale_factor=2,  # Retina quality
@@ -140,7 +140,7 @@ def generate_weekly_report_image(report_data: dict) -> bytes:
         page.set_viewport_size({"width": 800, "height": content_height})
 
         # Take screenshot of the full page
-        png_bytes = page.screenshot(full_page=True, type="png")
+        png_bytes = page.screenshot(full_page=True, type="png", timeout=60000)
         browser.close()
 
     return png_bytes

--- a/backend/app/tasks/monthly_report.py
+++ b/backend/app/tasks/monthly_report.py
@@ -664,11 +664,19 @@ Usa flags para tendencias preocupantes a monitorear."""
     }
 
 
-@celery_app.task(name="app.tasks.monthly_report.generate_single_report")
-def generate_single_report(user_id: int, month_str: str):
+@celery_app.task(
+    name="app.tasks.monthly_report.generate_single_report",
+    bind=True,
+    max_retries=3,
+    retry_backoff=True,
+    retry_backoff_max=60,
+    autoretry_for=(TimeoutError, OSError, ConnectionError),
+)
+def generate_single_report(self, user_id: int, month_str: str):
     """
     Generate a single monthly report for a user.
     Called on-demand from the API. Creates notification when done.
+    Retries up to 3 times on transient errors (timeout, OS, connection).
     """
     db = SessionLocal()
     try:
@@ -696,7 +704,17 @@ def generate_single_report(user_id: int, month_str: str):
         user_name = (
             user.full_name if user and user.full_name else (user.email if user else "Usuario")
         )
-        png_bytes = generate_report_image(report_data, user_name)
+        try:
+            png_bytes = generate_report_image(report_data, user_name)
+        except Exception as e:
+            # Mark as failed on final attempt
+            if self.request.retries >= self.max_retries:
+                raise
+            # Retry on transient errors
+            if isinstance(e, (TimeoutError, OSError, ConnectionError)):
+                raise
+            # Non-retryable error — fail immediately
+            raise
 
         # Update report
         report.report_data = json.dumps(report_data)
@@ -753,6 +771,12 @@ def generate_single_report(user_id: int, month_str: str):
             )
             db.add(notification)
             db.commit()
+
+            # Send email alert to admin
+            from app.services.email import send_report_failure_email
+
+            send_report_failure_email(user_id, month_str, str(e))
+
         except Exception:
             db.rollback()
 
@@ -822,6 +846,25 @@ def generate_monthly_reports():
 
             except Exception as e:
                 print(f"[MONTHLY REPORT] Error generating for user {user.id}: {e}")
+
+                # Mark as failed
+                try:
+                    failed_report = MonthlyReport(
+                        user_id=user.id,
+                        month=month_str,
+                        status="FAILED",
+                        error_message=str(e)[:500],
+                    )
+                    db.add(failed_report)
+                    db.commit()
+
+                    # Send email alert to admin
+                    from app.services.email import send_report_failure_email
+
+                    send_report_failure_email(user.id, month_str, str(e))
+                except Exception:
+                    db.rollback()
+
                 continue
 
         db.commit()


### PR DESCRIPTION
Fixes Playwright `Page.screenshot: Timeout 30000ms exceeded` error and adds report failure notifications.

**Playwright timeout fix:**
- Added `--disable-gpu` to Chromium launch args to reduce resource contention
- Added `page.wait_for_timeout(2000)` in `pdf_report.py` to ensure Chart.js canvas rendering completes
- Increased screenshot timeout from 30s to 60s in both `pdf_report.py` and `weekly_report.py`

**Report failure handling:**
- Added Celery retry logic (3x with exponential backoff) for `generate_single_report` on transient errors (TimeoutError, OSError, ConnectionError)
- Added `send_report_failure_email()` via Resend — sends styled HTML email to admin when report generation fails after all retries
- Both on-demand and batch report tasks now mark failed reports as `FAILED` in DB and email admin
- Injected `RESEND_API_KEY` + `ADMIN_EMAIL` into celery_worker and celery_beat containers in `deploy.yml`

**Root cause:** The report template has ~10 Chart.js canvases and loads Google Fonts. At `device_scale_factor=2`, PNG encoding of the full page exceeds the default 30s timeout, especially when GPU acceleration causes contention in the container.

**Env var required:** Set `ADMIN_EMAIL` in GitHub secrets `APP_SECRETS_B64`.