### PR TITLE
fix: block current month report generation before 20:00 on last day

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,8 @@ Add in `Settings → Secrets → Actions`:
   "GOOGLE_CLIENT_ID": "your-google-client-id",
   "GOOGLE_CLIENT_SECRET": "your-google-client-secret",
   "SECRET_KEY": "your-jwt-secret-key",
-  "RESEND_API_KEY": "your-resend-api-key"
+  "RESEND_API_KEY": "your-resend-api-key",
+  "ADMIN_EMAIL": "admin@yourdomain.com"
 }
 ```
 
@@ -228,6 +229,9 @@ source .env
 # Run migrations
 podman-compose run --rm --no-deps backend python -m scripts.migrate_add_reset_token
 podman-compose run --rm --no-deps backend python -m scripts.migrate_remove_haberes
+podman-compose run --rm --no-deps backend python -m scripts.migrate_encrypt_settings
+podman-compose run --rm --no-deps backend python -m scripts.migrate_add_monthly_reports
+podman-compose run --rm --no-deps backend python -m scripts.migrate_add_budgets
 
 # Restart services
 podman-compose down

--- a/backend/app/routers/dashboard.py
+++ b/backend/app/routers/dashboard.py
@@ -2,7 +2,7 @@ import json
 import os
 from calendar import monthrange
 from collections import Counter, defaultdict
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta
 
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import HTMLResponse
@@ -800,6 +800,26 @@ def generate_monthly_report(
         month_str = f"{y}-{m_int:02d}"
     except (ValueError, IndexError):
         raise HTTPException(400, "Invalid month format. Use YYYY-MM.")
+
+    # Validate month range
+    if m_int < 1 or m_int > 12:
+        raise HTTPException(400, "Invalid month. Use a value between 01 and 12.")
+
+    # Validate: cannot generate current month before 20:00 on last day
+    today = date.today()
+    last_day = monthrange(y, m_int)[1]
+    deadline = datetime(y, m_int, last_day, 20, 0, 0)
+
+    if y == today.year and m_int == today.month and datetime.now() < deadline:
+        month_name = MONTHS_ES.get(m_int, str(m_int))
+        raise HTTPException(
+            400,
+            f"El reporte de {month_name} {y} estará disponible después de las 20:00 del {last_day} de {month_name}.",
+        )
+
+    # Reject future months
+    if date(y, m_int, 1) > today.replace(day=1):
+        raise HTTPException(400, "No se pueden generar reportes de meses futuros.")
 
     # Check if already exists and ready
     existing = (

--- a/docs/API-Reference.md
+++ b/docs/API-Reference.md
@@ -73,14 +73,22 @@ Authorization: Bearer {access_token}
 
 ### Dashboard (`/dashboard`)
 
-| Method | Endpoint                 | Description            |
-| ------ | ------------------------ | ---------------------- |
-| `GET`  | `/dashboard`             | Main dashboard summary |
-| `GET`  | `/dashboard/by-category` | Expenses by category   |
-| `GET`  | `/dashboard/by-period`   | Expenses by period     |
-| `GET`  | `/dashboard/by-currency` | Expenses by currency   |
-| `GET`  | `/dashboard/by-card`     | Expenses by card       |
-| `GET`  | `/dashboard/trends`      | AI trend analysis      |
+| Method | Endpoint                                    | Description                                      |
+| ------ | ------------------------------------------- | ------------------------------------------------ |
+| `GET`  | `/dashboard`                                | Main dashboard summary                           |
+| `GET`  | `/dashboard/by-category`                    | Expenses by category                             |
+| `GET`  | `/dashboard/by-period`                      | Expenses by period                               |
+| `GET`  | `/dashboard/by-currency`                    | Expenses by currency                             |
+| `GET`  | `/dashboard/by-card`                        | Expenses by card                                 |
+| `GET`  | `/dashboard/trends`                         | AI trend analysis                                |
+| `GET`  | `/dashboard/monthly-reports`                | List monthly reports                             |
+| `POST` | `/dashboard/monthly-reports/generate`       | Generate monthly report on-demand                |
+| `GET`  | `/dashboard/monthly-reports/{month}/download` | Download monthly report PNG                    |
+
+**Monthly report generation rules:**
+- **Previous months**: always available
+- **Current month**: available only after 20:00 on the last day of the month
+- **Future months**: rejected with 400
 
 ### Import Jobs (`/import-jobs`)
 

--- a/docs/Deployment.md
+++ b/docs/Deployment.md
@@ -118,6 +118,7 @@ The `app-secrets.json` contains:
   "INVESTMENTS_LLM_API_KEY": "...",
   "MESSAGES_BOT_LLM_API_KEY": "...",
   "RESEND_API_KEY": "...",
+  "ADMIN_EMAIL": "...",
   "POSTGRES_PASSWORD_PROD": "...",
   "TELEGRAM_BOT_TOKEN_PROD": "...",
   "TELEGRAM_BOT_TOKEN_DEV": "..."
@@ -143,10 +144,24 @@ GitHub Actions workflow (`.github/workflows/ci.yml`):
 
 ### Celery Beat Schedule
 
-| Schedule      | Task                          | Description                        |
-| ------------- | ----------------------------- | ---------------------------------- |
-| Daily 2:00 AM | `execute_due_installments`    | Execute pending scheduled expenses |
-| Daily 3:30 AM | `cleanup_expired_import_jobs` | Delete import jobs older than 24h  |
+| Schedule               | Task                          | Description                          |
+| ---------------------- | ----------------------------- | ------------------------------------ |
+| Daily 2:00 AM UTC      | `execute_due_installments`    | Execute pending scheduled expenses   |
+| Daily 3:30 AM UTC      | `cleanup_expired_import_jobs` | Delete import jobs older than 24h    |
+| Daily 10:00 UTC        | `check_budget_alerts`         | Send budget warnings via Telegram    |
+| Sunday 23:00 UTC       | `send_weekly_reports`         | Generate weekly spending reports     |
+| 1st of month 23:00 UTC | `generate_monthly_reports`    | Generate previous month reports      |
+
+### Report Failure Handling
+
+Monthly report generation has built-in resilience:
+
+- **Auto-retry**: `generate_single_report` retries up to 3 times with exponential backoff on transient errors (TimeoutError, OSError, ConnectionError)
+- **Failure marking**: Failed reports are marked as `FAILED` in the database with an error message
+- **Admin email alerts**: When all retries fail, an email is sent to `ADMIN_EMAIL` via Resend with error details (user_id, month, error, timestamp)
+- **In-app notifications**: Users receive a `monthly_report_failed` notification
+
+The `celery_worker` and `celery_beat` containers require `RESEND_API_KEY` and `ADMIN_EMAIL` in their environment for email alerts to work.
 
 ### Investment Price Refresh
 
@@ -207,6 +222,7 @@ COPY nginx.conf /etc/nginx/conf.d/default.conf
 | `TELEGRAM_BOT_TOKEN_PROD`  | Production bot token         | -                           |
 | `TELEGRAM_BOT_TOKEN_DEV`   | Development bot token        | -                           |
 | `RESEND_API_KEY`           | Email service key            | -                           |
+| `ADMIN_EMAIL`              | Admin alert email address    | admin@financialplanning.com |
 | `JWT_EXPIRE_DAYS`          | Token expiry                 | 7                           |
 
 ### Frontend


### PR DESCRIPTION
Adds date validation to `POST /dashboard/monthly-reports/generate`:

- **Current month**: blocks generation before 20:00 on the last day of the month. Returns 400 with message like "El reporte de Julio 2026 estará disponible después de las 20:00 del 31 de Julio."
- **Future months**: rejects with 400
- **Invalid month range**: rejects month values outside 1-12 (previously would crash inside Celery)

**Documentation updates:**
- Added `ADMIN_EMAIL` to env vars, APP_SECRETS template, and deployment docs
- Added monthly report endpoints to API Reference with generation rules
- Completed Celery Beat schedule (was missing weekly reports, monthly reports, budget alerts)
- Added report failure handling documentation (retry logic, admin email alerts)
- Updated manual deploy section with all migration scripts