### PR TITLE
fix: current month report timezone (UTC-3) + frontend filter

### DIFF
--- a/backend/app/routers/dashboard.py
+++ b/backend/app/routers/dashboard.py
@@ -805,12 +805,12 @@ def generate_monthly_report(
     if m_int < 1 or m_int > 12:
         raise HTTPException(400, "Invalid month. Use a value between 01 and 12.")
 
-    # Validate: cannot generate current month before 20:00 on last day
+    # Validate: cannot generate current month before 20:00 on last day (UTC-3)
     today = date.today()
     last_day = monthrange(y, m_int)[1]
-    deadline = datetime(y, m_int, last_day, 20, 0, 0)
+    deadline = datetime(y, m_int, last_day, 23, 0, 0)  # 23:00 UTC = 20:00 UTC-3
 
-    if y == today.year and m_int == today.month and datetime.now() < deadline:
+    if y == today.year and m_int == today.month and datetime.utcnow() < deadline:
         month_name = MONTHS_ES.get(m_int, str(m_int))
         raise HTTPException(
             400,

--- a/frontend/src/components/UserPanel.tsx
+++ b/frontend/src/components/UserPanel.tsx
@@ -78,9 +78,20 @@ function ReportsTab() {
   );
   const monthOptions = [];
   const now = new Date();
+  const currentYear = now.getFullYear();
+  const currentMonth = now.getMonth(); // 0-indexed
+
   for (let i = 0; i < 12; i++) {
     const d = new Date(now.getFullYear(), now.getMonth() - i, 1);
     const monthStr = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}`;
+
+    // Skip current month if before 20:00 UTC-3 on last day
+    if (d.getFullYear() === currentYear && d.getMonth() === currentMonth) {
+      const lastDay = new Date(d.getFullYear(), d.getMonth() + 1, 0).getDate();
+      const deadlineUTC = new Date(Date.UTC(d.getFullYear(), d.getMonth(), lastDay, 23, 0, 0));
+      if (now < deadlineUTC) continue;
+    }
+
     if (!generatedMonths.has(monthStr)) {
       const monthName = MONTHS_ES[d.getMonth()];
       monthOptions.push({


### PR DESCRIPTION
Fixes the current month report generation validation:

**Backend:**
- Deadline changed from `20:00 UTC` to `23:00 UTC` (= 20:00 Argentina / UTC-3)
- Uses `datetime.utcnow()` instead of `datetime.now()` for correct comparison

**Frontend:**
- Current month is now hidden from the report generation dropdown until 20:00 UTC-3 on the last day of the month