### PR TITLE
fix: celery beat not dispatching tasks + current month timezone

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -416,7 +416,7 @@ jobs:
 
               celery_beat:
                 image: ${BACKEND_IMAGE}:${IMAGE_TAG}
-                command: celery -A app.celery_app beat --loglevel=info --schedule=/tmp/celerybeat-schedule
+                command: celery -A app.celery_app beat --loglevel=info
                 depends_on:
                   - db
                   - redis

--- a/backend/app/routers/dashboard.py
+++ b/backend/app/routers/dashboard.py
@@ -805,12 +805,12 @@ def generate_monthly_report(
     if m_int < 1 or m_int > 12:
         raise HTTPException(400, "Invalid month. Use a value between 01 and 12.")
 
-    # Validate: cannot generate current month before 20:00 on last day
+    # Validate: cannot generate current month before 20:00 on last day (UTC-3)
     today = date.today()
     last_day = monthrange(y, m_int)[1]
-    deadline = datetime(y, m_int, last_day, 20, 0, 0)
+    deadline = datetime(y, m_int, last_day, 23, 0, 0)  # 23:00 UTC = 20:00 UTC-3
 
-    if y == today.year and m_int == today.month and datetime.now() < deadline:
+    if y == today.year and m_int == today.month and datetime.utcnow() < deadline:
         month_name = MONTHS_ES.get(m_int, str(m_int))
         raise HTTPException(
             400,

--- a/docs/Deployment.md
+++ b/docs/Deployment.md
@@ -148,7 +148,6 @@ GitHub Actions workflow (`.github/workflows/ci.yml`):
 | ---------------------- | ----------------------------- | ------------------------------------ |
 | Daily 2:00 AM UTC      | `execute_due_installments`    | Execute pending scheduled expenses   |
 | Daily 3:30 AM UTC      | `cleanup_expired_import_jobs` | Delete import jobs older than 24h    |
-| Daily 10:00 UTC        | `check_budget_alerts`         | Send budget warnings via Telegram    |
 | Sunday 23:00 UTC       | `send_weekly_reports`         | Generate weekly spending reports     |
 | 1st of month 23:00 UTC | `generate_monthly_reports`    | Generate previous month reports      |
 

--- a/frontend/src/components/UserPanel.tsx
+++ b/frontend/src/components/UserPanel.tsx
@@ -78,9 +78,20 @@ function ReportsTab() {
   );
   const monthOptions = [];
   const now = new Date();
+  const currentYear = now.getFullYear();
+  const currentMonth = now.getMonth(); // 0-indexed
+
   for (let i = 0; i < 12; i++) {
     const d = new Date(now.getFullYear(), now.getMonth() - i, 1);
     const monthStr = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}`;
+
+    // Skip current month if before 20:00 UTC-3 on last day
+    if (d.getFullYear() === currentYear && d.getMonth() === currentMonth) {
+      const lastDay = new Date(d.getFullYear(), d.getMonth() + 1, 0).getDate();
+      const deadlineUTC = new Date(Date.UTC(d.getFullYear(), d.getMonth(), lastDay, 23, 0, 0));
+      if (now < deadlineUTC) continue;
+    }
+
     if (!generatedMonths.has(monthStr)) {
       const monthName = MONTHS_ES[d.getMonth()];
       monthOptions.push({

--- a/podman-compose.yml
+++ b/podman-compose.yml
@@ -125,7 +125,7 @@ services:
       context: ./backend
       dockerfile: Dockerfile.dev
     user: "1000:1000"
-    command: celery -A app.celery_app beat --loglevel=info --schedule=/tmp/celerybeat-schedule
+    command: celery -A app.celery_app beat --loglevel=info
     secrets:
       - creditcard_backend_dev_postgres_password
       - creditcard_backend_dev_llm_api_key


### PR DESCRIPTION
## Celery beat fix

**Root cause**: The `PersistentScheduler` with `--schedule=/tmp/celerybeat-schedule` was recovering stale schedule state on container startup and never running the scheduler loop. All tasks had `total_run_count=0` — the weekly report, monthly report, installments, and cleanup never dispatched.

**Fix**: Removed `--schedule=/tmp/celerybeat-schedule` from both `deploy.yml` (prod) and `podman-compose.yml` (dev). Celery's default in-memory `Scheduler` correctly evaluates crontab schedules every cycle.

## Current month report validation

**Root cause**: The fix used `datetime.now()` + `deadline = 20:00`. Inside UTC containers, this means the report is blocked until 20:00 UTC = 17:00 Argentina — 3 hours too early.

**Fix**:
- Backend: `datetime.utcnow()` + `deadline = 23:00 UTC` (= 20:00 UTC-3)
- Frontend: current month hidden from dropdown before 20:00 UTC-3 on last day

## Docs
- Removed `check_budget_alerts` from Celery Beat schedule table (task doesn't exist on main yet)