### PR TITLE
fix: celery beat + current month timezone + disk cleanup

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -749,5 +749,5 @@ jobs:
           port: 43422
           script: |
             echo "Cleaning up old images..."
-            podman image prune -f 2>/dev/null || true
+            podman system prune -af 2>/dev/null || true
             echo "Cleanup complete"


### PR DESCRIPTION
## Celery beat fix

**Root cause**: `PersistentScheduler` with `--schedule=/tmp/celerybeat-schedule` recovered stale state on container restart and never ran the scheduler loop. All tasks had `total_run_count=0`.

**Fix**: Removed `--schedule=/tmp/celerybeat-schedule` from `deploy.yml` and `podman-compose.yml`. Default in-memory Scheduler evaluates crontab schedules correctly.

## Current month validation

**Fix**:
- Backend: `datetime.utcnow()` + `deadline = 23:00 UTC` (= 20:00 UTC-3)
- Frontend: current month hidden from dropdown before 20:00 UTC-3 on last day

## Disk cleanup

Changed `podman image prune -f` → `podman system prune -af` in deploy.yml to remove all unused images (not just dangling), preventing disk fill-up across deploys.