### PR TITLE
fix: weekly report duplicate dispatch + celery beat + month validation

### DIFF
--- a/backend/app/tasks/weekly_summary.py
+++ b/backend/app/tasks/weekly_summary.py
@@ -236,6 +236,17 @@ def send_weekly_reports():
     db = SessionLocal()
     try:
         start, end = _get_week_range()
+        week_key = start.isoformat()
+
+        # Global dedup: check if weekly report was already sent for this week
+        global_setting = (
+            db.query(Setting)
+            .filter(Setting.key == "weekly_report_last_sent")
+            .first()
+        )
+        if global_setting and global_setting.value == week_key:
+            print(f"[WEEKLY REPORT] Already sent for week {week_key}, skipping")
+            return
 
         # Get all users with Telegram connected
         users = db.query(User).filter(User.telegram_chat_id.isnot(None)).all()
@@ -291,6 +302,14 @@ def send_weekly_reports():
                 continue
 
         print(f"[WEEKLY REPORT] Sent {sent_count} weekly reports")
+
+        # Mark week as sent to prevent duplicate dispatches on restart
+        if sent_count > 0:
+            if global_setting:
+                global_setting.value = week_key
+            else:
+                db.add(Setting(key="weekly_report_last_sent", value=week_key))
+            db.commit()
     except Exception as e:
         print(f"[WEEKLY REPORT] Error: {e}")
         db.rollback()

--- a/backend/app/tasks/weekly_summary.py
+++ b/backend/app/tasks/weekly_summary.py
@@ -239,11 +239,7 @@ def send_weekly_reports():
         week_key = start.isoformat()
 
         # Global dedup: check if weekly report was already sent for this week
-        global_setting = (
-            db.query(Setting)
-            .filter(Setting.key == "weekly_report_last_sent")
-            .first()
-        )
+        global_setting = db.query(Setting).filter(Setting.key == "weekly_report_last_sent").first()
         if global_setting and global_setting.value == week_key:
             print(f"[WEEKLY REPORT] Already sent for week {week_key}, skipping")
             return


### PR DESCRIPTION
## Weekly report sent on every deploy

**Root cause**: In-memory celery beat scheduler re-evaluates all crontab tasks on restart. Every deploy restarts the beat container, which dispatches the weekly report again if it's Sunday after 23:00 UTC.

**Fix**: Added global dedup via `Setting` model — stores `weekly_report_last_sent` with the week's start date. Before sending, checks if already sent for current week. Survives container restarts since it's in PostgreSQL.

## Celery beat fix

Removed `--schedule=/tmp/celerybeat-schedule` from `deploy.yml` and `podman-compose.yml`. The PersistentScheduler was recovering stale state and never dispatching tasks (`total_run_count=0` for all entries).

## Current month validation

- Backend: `datetime.utcnow()` + `deadline = 23:00 UTC` (= 20:00 UTC-3)
- Frontend: current month hidden from dropdown before 20:00 UTC-3 on last day

## Disk cleanup

Changed `podman image prune -f` → `podman system prune -af` in deploy.yml to remove all unused images.