### PR TITLE
feat: Integración caja de ahorro ↔ tarjeta débito (Item#16)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -666,7 +666,7 @@ jobs:
             set +a
 
             echo "Running database migrations..."
-            for script in migrate_add_reset_token migrate_remove_haberes migrate_encrypt_settings migrate_add_monthly_reports migrate_db_structure migrate_security_columns; do
+            for script in migrate_add_reset_token migrate_remove_haberes migrate_encrypt_settings migrate_add_monthly_reports migrate_db_structure migrate_security_columns migrate_add_card_account_link; do
               if ! podman-compose run --rm backend python -m scripts.$script; then
                 echo "::warning::Migration $script had issues (may already be applied)"
               fi

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -128,6 +128,7 @@ class Card(Base):
     __table_args__ = (
         Index("ix_cards_user_id", "user_id"),
         Index("ix_cards_card_type", "card_type"),
+        Index("ix_cards_linked_account_id", "linked_account_id"),
     )
     id = Column(Integer, primary_key=True, index=True)
     card_name = Column(String, nullable=False)  # Visa, Mastercard, etc
@@ -136,8 +137,12 @@ class Card(Base):
         String, default=""
     )  # Primer nombre del usuario (para agrupar en grupo familiar)
     card_type = Column(String, default="credito")  # credito, debito
+    linked_account_id = Column(
+        Integer, ForeignKey("accounts.id", ondelete="SET NULL"), nullable=True
+    )
     user_id = Column(Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
     created_at = Column(DateTime, default=datetime.utcnow)
+    linked_account = relationship("Account")
 
 
 class Expense(Base):

--- a/backend/app/routers/accounts.py
+++ b/backend/app/routers/accounts.py
@@ -26,6 +26,8 @@ class AccountResponse(BaseModel):
     id: int
     name: str
     type: str
+    linked_card_id: int | None = None
+    linked_card_name: str | None = None
     user_id: int
     created_at: datetime
 
@@ -39,8 +41,23 @@ def list_accounts(
     current_user: User = Depends(get_current_user),
 ):
     """List all accounts for the current user"""
+    from app.models import Card
+
     accounts = db.query(Account).filter(Account.user_id == current_user.id).all()
-    return accounts
+    result = []
+    for account in accounts:
+        account_dict = AccountResponse.model_validate(account)
+        # Find linked card (if any debit card references this account)
+        linked_card = (
+            db.query(Card)
+            .filter(Card.linked_account_id == account.id)
+            .first()
+        )
+        if linked_card:
+            account_dict.linked_card_id = linked_card.id
+            account_dict.linked_card_name = f"{linked_card.card_name} ({linked_card.bank})"
+        result.append(account_dict)
+    return result
 
 
 @router.post("", response_model=AccountResponse, status_code=201)

--- a/backend/app/routers/accounts.py
+++ b/backend/app/routers/accounts.py
@@ -48,11 +48,7 @@ def list_accounts(
     for account in accounts:
         account_dict = AccountResponse.model_validate(account)
         # Find linked card (if any debit card references this account)
-        linked_card = (
-            db.query(Card)
-            .filter(Card.linked_account_id == account.id)
-            .first()
-        )
+        linked_card = db.query(Card).filter(Card.linked_account_id == account.id).first()
         if linked_card:
             account_dict.linked_card_id = linked_card.id
             account_dict.linked_card_name = f"{linked_card.card_name} ({linked_card.bank})"

--- a/backend/app/routers/cards.py
+++ b/backend/app/routers/cards.py
@@ -116,9 +116,7 @@ def create_card(
             )
         # Check if account is already linked to another card
         existing_link = (
-            db.query(Card)
-            .filter(Card.linked_account_id == card.linked_account_id)
-            .first()
+            db.query(Card).filter(Card.linked_account_id == card.linked_account_id).first()
         )
         if existing_link:
             raise HTTPException(

--- a/backend/app/routers/cards.py
+++ b/backend/app/routers/cards.py
@@ -27,6 +27,7 @@ class CardCreate(BaseModel):
     bank: str = ""
     holder: str = ""
     card_type: str = "credito"  # credito, debito
+    linked_account_id: int | None = None
 
 
 class CardUpdate(BaseModel):
@@ -34,6 +35,7 @@ class CardUpdate(BaseModel):
     bank: str | None = None
     holder: str | None = None
     card_type: str | None = None
+    linked_account_id: int | None = None
 
 
 class CardResponse(BaseModel):
@@ -42,6 +44,8 @@ class CardResponse(BaseModel):
     bank: str
     holder: str
     card_type: str
+    linked_account_id: int | None = None
+    linked_account_name: str | None = None
     user_id: int
     created_at: datetime
 
@@ -55,9 +59,21 @@ def list_cards(
     current_user: User = Depends(get_current_user),
 ):
     """List all cards for the current user and group"""
+    from sqlalchemy.orm import joinedload
+
     uid_list = get_group_user_ids(current_user.id, db)
-    cards = db.query(Card).filter(Card.user_id.in_(uid_list)).all()
-    return cards
+    cards = (
+        db.query(Card)
+        .options(joinedload(Card.linked_account))
+        .filter(Card.user_id.in_(uid_list))
+        .all()
+    )
+    result = []
+    for card in cards:
+        card_dict = CardResponse.model_validate(card)
+        card_dict.linked_account_name = card.linked_account.name if card.linked_account else None
+        result.append(card_dict)
+    return result
 
 
 @router.post("", response_model=CardResponse, status_code=201)
@@ -67,11 +83,49 @@ def create_card(
     current_user: User = Depends(get_current_user),
 ):
     """Create a new card"""
+    from app.models import Account
+
     card_name = card.card_name.strip()
     bank = card.bank.strip() if card.bank else ""
 
     if not card_name or not bank:
         raise HTTPException(status_code=400, detail="Nombre y banco son obligatorios")
+
+    # Validate linked_account_id if provided
+    linked_account_id = None
+    if card.linked_account_id is not None:
+        account = (
+            db.query(Account)
+            .filter(
+                Account.id == card.linked_account_id,
+                Account.user_id == current_user.id,
+            )
+            .first()
+        )
+        if not account:
+            raise HTTPException(status_code=404, detail="Cuenta no encontrada")
+        if account.type != "caja_ahorro":
+            raise HTTPException(
+                status_code=400,
+                detail="Solo se pueden vincular cuentas de tipo Caja de Ahorro",
+            )
+        if card.card_type != "debito":
+            raise HTTPException(
+                status_code=400,
+                detail="Solo las tarjetas de débito se pueden vincular a una cuenta",
+            )
+        # Check if account is already linked to another card
+        existing_link = (
+            db.query(Card)
+            .filter(Card.linked_account_id == card.linked_account_id)
+            .first()
+        )
+        if existing_link:
+            raise HTTPException(
+                status_code=409,
+                detail="Esta cuenta ya está vinculada a otra tarjeta",
+            )
+        linked_account_id = card.linked_account_id
 
     existing_by_fields = (
         db.query(Card)
@@ -105,6 +159,7 @@ def create_card(
         bank=bank,
         holder=holder,
         card_type=card.card_type,
+        linked_account_id=linked_account_id,
         user_id=current_user.id,
     )
     db.add(db_card)
@@ -121,6 +176,8 @@ def update_card(
     current_user: User = Depends(get_current_user),
 ):
     """Update a card"""
+    from app.models import Account
+
     db_card = (
         db.query(Card)
         .filter(
@@ -134,6 +191,43 @@ def update_card(
         raise HTTPException(status_code=404, detail="Card not found")
 
     update_data = card.model_dump(exclude_none=True)
+
+    # Validate linked_account_id if being updated
+    if "linked_account_id" in update_data:
+        linked_id = update_data["linked_account_id"]
+        if linked_id is not None:
+            account = (
+                db.query(Account)
+                .filter(
+                    Account.id == linked_id,
+                    Account.user_id == current_user.id,
+                )
+                .first()
+            )
+            if not account:
+                raise HTTPException(status_code=404, detail="Cuenta no encontrada")
+            if account.type != "caja_ahorro":
+                raise HTTPException(
+                    status_code=400,
+                    detail="Solo se pueden vincular cuentas de tipo Caja de Ahorro",
+                )
+            card_type = update_data.get("card_type", db_card.card_type)
+            if card_type != "debito":
+                raise HTTPException(
+                    status_code=400,
+                    detail="Solo las tarjetas de débito se pueden vincular a una cuenta",
+                )
+            # Check if account is already linked to another card
+            existing_link = (
+                db.query(Card)
+                .filter(Card.linked_account_id == linked_id, Card.id != card_id)
+                .first()
+            )
+            if existing_link:
+                raise HTTPException(
+                    status_code=409,
+                    detail="Esta cuenta ya está vinculada a otra tarjeta",
+                )
 
     for key, value in update_data.items():
         if isinstance(value, str):

--- a/backend/app/routers/expenses.py
+++ b/backend/app/routers/expenses.py
@@ -324,6 +324,10 @@ def create_expense(
         if not card:
             raise HTTPException(404, "Tarjeta no encontrada")
 
+        # Auto-asign account_id if card has linked account
+        if card.linked_account_id and not data.get("account_id"):
+            data["account_id"] = card.linked_account_id
+
     # Validate account belongs to user
     if data.get("account_id"):
         from app.models import Account

--- a/backend/scripts/migrate_add_card_account_link.py
+++ b/backend/scripts/migrate_add_card_account_link.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""
+Migration: Add linked_account_id to cards table.
+
+Links debit cards to savings accounts (caja_ahorro).
+
+Run with: python -m scripts.migrate_add_card_account_link
+"""
+
+import os
+import sys
+
+from sqlalchemy import create_engine, text
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+def get_engine():
+    db_url = os.getenv("DATABASE_URL")
+    if not db_url:
+        raise RuntimeError("DATABASE_URL env var not set. Aborting.")
+    if db_url.startswith("postgres://"):
+        db_url = db_url.replace("postgres://", "postgresql://", 1)
+    print(f"Connecting to: {db_url.split('@')[1] if '@' in db_url else db_url}")
+    return create_engine(db_url)
+
+
+def main():
+    engine = get_engine()
+
+    print("=" * 60)
+    print("Migration: Add linked_account_id to cards table")
+    print("=" * 60)
+
+    with engine.begin() as conn:
+        dialect = engine.dialect.name
+
+        if dialect == "postgresql":
+            conn.execute(text("SET search_path TO public"))
+
+            # Check if column already exists
+            has_column = conn.execute(text("""
+                SELECT EXISTS (
+                    SELECT 1 FROM information_schema.columns
+                    WHERE table_name = 'cards' AND column_name = 'linked_account_id'
+                )
+            """)).scalar()
+
+            if has_column:
+                print("Column linked_account_id already exists. Skipping.")
+            else:
+                print("Adding linked_account_id column to cards...")
+                conn.execute(text("""
+                    ALTER TABLE cards ADD COLUMN linked_account_id INTEGER
+                    REFERENCES accounts(id) ON DELETE SET NULL
+                """))
+                print("  ✓ Column added")
+
+            # Ensure index exists
+            has_index = conn.execute(text("""
+                SELECT EXISTS (
+                    SELECT 1 FROM pg_indexes
+                    WHERE tablename = 'cards' AND indexname = 'ix_cards_linked_account_id'
+                )
+            """)).scalar()
+
+            if not has_index:
+                print("Creating index ix_cards_linked_account_id...")
+                conn.execute(text("""
+                    CREATE INDEX ix_cards_linked_account_id ON cards (linked_account_id)
+                """))
+                print("  ✓ Index created")
+            else:
+                print("Index ix_cards_linked_account_id already exists. Skipping.")
+
+            # Verify
+            verify = conn.execute(text("""
+                SELECT column_name, is_nullable, foreign_key_name
+                FROM information_schema.columns c
+                LEFT JOIN (
+                    SELECT tc.table_name, kcu.column_name, tc.constraint_name as foreign_key_name
+                    FROM information_schema.table_constraints tc
+                    JOIN information_schema.key_column_usage kcu
+                        ON tc.constraint_name = kcu.constraint_name
+                    WHERE tc.constraint_type = 'FOREIGN KEY' AND tc.table_name = 'cards'
+                ) fk ON c.table_name = fk.table_name AND c.column_name = fk.column_name
+                WHERE c.table_name = 'cards' AND c.column_name = 'linked_account_id'
+            """)).fetchone()
+
+            if verify:
+                print(f"\nVerification passed:")
+                print(f"  Column: {verify[0]}")
+                print(f"  Nullable: {verify[1]}")
+                print(f"  FK constraint: {verify[2] or 'inherited from model'}")
+            else:
+                raise RuntimeError("Verification failed: column not found")
+
+        else:
+            print(f"Dialect '{dialect}' not PostgreSQL. Skipping schema changes.")
+            print("SQLite/Alembic will handle this via models.")
+
+    print("\n" + "=" * 60)
+    print("Migration complete!")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/scripts/migrate_add_card_account_link.py
+++ b/backend/scripts/migrate_add_card_account_link.py
@@ -75,15 +75,8 @@ def main():
 
             # Verify
             verify = conn.execute(text("""
-                SELECT column_name, is_nullable, foreign_key_name
+                SELECT c.column_name, c.is_nullable
                 FROM information_schema.columns c
-                LEFT JOIN (
-                    SELECT tc.table_name, kcu.column_name, tc.constraint_name as foreign_key_name
-                    FROM information_schema.table_constraints tc
-                    JOIN information_schema.key_column_usage kcu
-                        ON tc.constraint_name = kcu.constraint_name
-                    WHERE tc.constraint_type = 'FOREIGN KEY' AND tc.table_name = 'cards'
-                ) fk ON c.table_name = fk.table_name AND c.column_name = fk.column_name
                 WHERE c.table_name = 'cards' AND c.column_name = 'linked_account_id'
             """)).fetchone()
 
@@ -91,7 +84,6 @@ def main():
                 print(f"\nVerification passed:")
                 print(f"  Column: {verify[0]}")
                 print(f"  Nullable: {verify[1]}")
-                print(f"  FK constraint: {verify[2] or 'inherited from model'}")
             else:
                 raise RuntimeError("Verification failed: column not found")
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -594,10 +594,17 @@ export const createCard = (data: {
   bank?: string;
   holder?: string;
   card_type?: string;
+  linked_account_id?: number | null;
 }) => api.post<Card>("/cards", data).then((r) => r.data);
 export const updateCard = (
   id: number,
-  data: { card_name?: string; bank?: string; holder?: string; card_type?: string },
+  data: {
+    card_name?: string;
+    bank?: string;
+    holder?: string;
+    card_type?: string;
+    linked_account_id?: number | null;
+  },
 ) => api.put<Card>(`/cards/${id}`, data).then((r) => r.data);
 export const deleteCard = (id: number) => api.delete(`/cards/${id}`).then((r) => r.data);
 

--- a/frontend/src/components/AccountsManager.tsx
+++ b/frontend/src/components/AccountsManager.tsx
@@ -12,7 +12,6 @@ import {
 import type { Account } from "../types";
 import { Select } from "./ui/Select";
 import { Skeleton, SkeletonList } from "./ui/Skeleton";
-import CardAccountModal from "./CardAccountModal";
 
 const ACCOUNT_TYPES = [
   { value: "efectivo", label: "Efectivo", color: "badge-success" },
@@ -48,7 +47,6 @@ export default function AccountsManager() {
   const [bank, setBank] = useState("");
   const [cardType, setCardType] = useState("credito");
   const [linkedCardId, setLinkedCardId] = useState<number | null>(null);
-  const [showCreateModal, setShowCreateModal] = useState(false);
 
   const { data: accounts = [], isLoading } = useQuery({
     queryKey: ["accounts"],
@@ -435,15 +433,6 @@ export default function AccountsManager() {
           </div>
         );
       })}
-
-      <button
-        onClick={() => setShowCreateModal(true)}
-        className="w-full py-2.5 border-2 border-dashed border-border-color rounded-lg text-sm text-secondary hover:border-primary hover:text-primary transition-colors"
-      >
-        + Agregar cuenta
-      </button>
-
-      {showCreateModal && <CardAccountModal onClose={() => setShowCreateModal(false)} />}
 
       {deleteConfirm && (
         <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/60">

--- a/frontend/src/components/AccountsManager.tsx
+++ b/frontend/src/components/AccountsManager.tsx
@@ -325,6 +325,11 @@ export default function AccountsManager() {
                 <div className="flex-1 min-w-0">
                   <div className="text-sm font-semibold text-primary truncate">{account.name}</div>
                   <div className="text-xs text-secondary">{typeInfo.label}</div>
+                  {account.linked_card_name && (
+                    <div className="text-xs text-[var(--color-success)] mt-0.5">
+                      Vinculada a: {account.linked_card_name}
+                    </div>
+                  )}
                 </div>
                 <div className="relative">
                   <button

--- a/frontend/src/components/AccountsManager.tsx
+++ b/frontend/src/components/AccountsManager.tsx
@@ -12,6 +12,7 @@ import {
 import type { Account } from "../types";
 import { Select } from "./ui/Select";
 import { Skeleton, SkeletonList } from "./ui/Skeleton";
+import CardAccountModal from "./CardAccountModal";
 
 const ACCOUNT_TYPES = [
   { value: "efectivo", label: "Efectivo", color: "badge-success" },
@@ -47,6 +48,7 @@ export default function AccountsManager() {
   const [bank, setBank] = useState("");
   const [cardType, setCardType] = useState("credito");
   const [linkedCardId, setLinkedCardId] = useState<number | null>(null);
+  const [showCreateModal, setShowCreateModal] = useState(false);
 
   const { data: accounts = [], isLoading } = useQuery({
     queryKey: ["accounts"],
@@ -65,11 +67,17 @@ export default function AccountsManager() {
 
   const createMut = useMutation({
     mutationFn: createAccount,
-    onSuccess: () => {
+    onSuccess: (created: Account) => {
       queryClient.invalidateQueries({ queryKey: ["accounts"] });
+      // Link debit card if one was selected during creation
+      if (type === "caja_ahorro" && linkedCardId) {
+        updateCardLinkMut.mutate({ cardId: linkedCardId, accountId: created.id });
+      }
       setEditId(null);
+      setCardName("");
       setName("");
       setType("efectivo");
+      setLinkedCardId(null);
     },
     onError: (error: {
       response?: {
@@ -427,6 +435,15 @@ export default function AccountsManager() {
           </div>
         );
       })}
+
+      <button
+        onClick={() => setShowCreateModal(true)}
+        className="w-full py-2.5 border-2 border-dashed border-border-color rounded-lg text-sm text-secondary hover:border-primary hover:text-primary transition-colors"
+      >
+        + Agregar cuenta
+      </button>
+
+      {showCreateModal && <CardAccountModal onClose={() => setShowCreateModal(false)} />}
 
       {deleteConfirm && (
         <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/60">

--- a/frontend/src/components/AccountsManager.tsx
+++ b/frontend/src/components/AccountsManager.tsx
@@ -6,6 +6,8 @@ import {
   updateAccount,
   deleteAccount,
   createCard,
+  getCards,
+  updateCard,
 } from "../api/client";
 import type { Account } from "../types";
 import { Select } from "./ui/Select";
@@ -44,11 +46,22 @@ export default function AccountsManager() {
   const [type, setType] = useState("efectivo");
   const [bank, setBank] = useState("");
   const [cardType, setCardType] = useState("credito");
+  const [linkedCardId, setLinkedCardId] = useState<number | null>(null);
 
   const { data: accounts = [], isLoading } = useQuery({
     queryKey: ["accounts"],
     queryFn: getAccounts,
   });
+
+  const { data: cards = [] } = useQuery({
+    queryKey: ["cards"],
+    queryFn: getCards,
+  });
+
+  // Debit cards not already linked to another account
+  const availableDebitCards = cards.filter(
+    (c) => c.card_type === "debito" && (!c.linked_account_id || c.linked_account_id === editId),
+  );
 
   const createMut = useMutation({
     mutationFn: createAccount,
@@ -112,10 +125,20 @@ export default function AccountsManager() {
     },
   });
 
+  const updateCardLinkMut = useMutation({
+    mutationFn: ({ cardId, accountId }: { cardId: number; accountId: number | null }) =>
+      updateCard(cardId, { linked_account_id: accountId }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["cards"] });
+      queryClient.invalidateQueries({ queryKey: ["accounts"] });
+    },
+  });
+
   const handleEdit = (account: Account) => {
     setEditId(account.id);
     setName(account.name);
     setType(account.type);
+    setLinkedCardId(account.linked_card_id || null);
     setMenuOpen(null);
   };
 
@@ -126,6 +149,7 @@ export default function AccountsManager() {
     setType("efectivo");
     setBank("");
     setCardType("credito");
+    setLinkedCardId(null);
   };
 
   const handleSubmit = (e: React.FormEvent) => {
@@ -158,6 +182,21 @@ export default function AccountsManager() {
     } else {
       if (editId && editId > 0) {
         updateMut.mutate({ id: editId, data: { name: name.trim(), type } });
+
+        // Handle card linking for caja_ahorro accounts
+        if (type === "caja_ahorro") {
+          // Find the currently linked card (if any)
+          const currentlyLinkedCard = cards.find((c) => c.linked_account_id === editId);
+          const currentlyLinkedId = currentlyLinkedCard?.id || null;
+
+          if (linkedCardId && linkedCardId !== currentlyLinkedId) {
+            // Link new card
+            updateCardLinkMut.mutate({ cardId: linkedCardId, accountId: editId });
+          } else if (!linkedCardId && currentlyLinkedId) {
+            // Unlink
+            updateCardLinkMut.mutate({ cardId: currentlyLinkedId, accountId: null });
+          }
+        }
       } else {
         createMut.mutate({ name: name.trim(), type });
       }
@@ -283,6 +322,26 @@ export default function AccountsManager() {
                         placeholder="Ej: Galicia"
                       />
                     </div>
+                  </div>
+                )}
+
+                {/* Vincular tarjeta débito (solo caja_ahorro) */}
+                {type === "caja_ahorro" && editId && editId > 0 && (
+                  <div className="space-y-1.5 pt-2 border-t border-[var(--border-color)]">
+                    <label className="text-xs font-medium text-[var(--text-secondary)]">
+                      Vincular tarjeta débito
+                    </label>
+                    <Select
+                      value={String(linkedCardId || "")}
+                      onChange={(v) => setLinkedCardId(v ? Number(v) : null)}
+                      options={[
+                        { value: "", label: "Sin vinculación" },
+                        ...availableDebitCards.map((c) => ({
+                          value: String(c.id),
+                          label: `${c.card_name} (${c.bank})`,
+                        })),
+                      ]}
+                    />
                   </div>
                 )}
 

--- a/frontend/src/components/CardAccountModal.tsx
+++ b/frontend/src/components/CardAccountModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { createCard, createAccount, getAccounts, getCards, updateCard } from "../api/client";
 import type { Account } from "../types";
@@ -18,6 +18,7 @@ interface CardAccountModalProps {
 
 export default function CardAccountModal({ onClose }: CardAccountModalProps) {
   const queryClient = useQueryClient();
+  const nameInputRef = useRef<HTMLInputElement>(null);
 
   const [accountType, setAccountType] = useState("tarjeta");
   const [cardName, setCardName] = useState("");
@@ -32,7 +33,12 @@ export default function CardAccountModal({ onClose }: CardAccountModalProps) {
       if (e.key === "Escape") onClose();
     };
     document.addEventListener("keydown", handleEscape);
-    return () => document.removeEventListener("keydown", handleEscape);
+    // Focus the name input after a short delay to ensure modal is rendered
+    const timer = setTimeout(() => nameInputRef.current?.focus(), 100);
+    return () => {
+      document.removeEventListener("keydown", handleEscape);
+      clearTimeout(timer);
+    };
   }, [onClose]);
 
   const { data: accounts = [] } = useQuery({
@@ -45,11 +51,8 @@ export default function CardAccountModal({ onClose }: CardAccountModalProps) {
     queryFn: getCards,
   });
 
-  // Available caja_ahorro accounts for linking to a new debit card
-  const availableAccounts = accounts.filter((a) => a.type === "caja_ahorro" && !a.linked_card_id);
-
-  // Available debit cards for linking to a new caja_ahorro account
-  const availableDebitCards = cards.filter((c) => c.card_type === "debito" && !c.linked_account_id);
+  const availableAccounts = accounts.filter((a) => a.type === "caja_ahorro");
+  const availableDebitCards = cards.filter((c) => c.card_type === "debito");
 
   const updateCardLinkMut = useMutation({
     mutationFn: ({ cardId, accountId }: { cardId: number; accountId: number | null }) =>
@@ -73,7 +76,6 @@ export default function CardAccountModal({ onClose }: CardAccountModalProps) {
     mutationFn: (data: { name: string; type: string }) => createAccount(data),
     onSuccess: (created: Account) => {
       queryClient.invalidateQueries({ queryKey: ["accounts"] });
-      // Link debit card if one was selected
       if (linkedCardId) {
         updateCardLinkMut.mutate({ cardId: linkedCardId, accountId: created.id });
       }
@@ -113,11 +115,11 @@ export default function CardAccountModal({ onClose }: CardAccountModalProps) {
 
   return (
     <div
-      className="fixed inset-0 z-[60] flex items-center justify-center p-4 animate-modal-backdrop bg-black/60"
+      className="fixed inset-0 z-[60] flex items-start justify-center pt-[10vh] p-4 animate-modal-backdrop bg-black/60 overflow-y-auto"
       onClick={onClose}
     >
       <div
-        className="relative card w-full max-w-sm max-h-[90vh] overflow-auto p-6 space-y-4 animate-modal-content"
+        className="relative card w-full max-w-sm p-6 space-y-4 animate-modal-content"
         onClick={(e) => e.stopPropagation()}
       >
         <div className="flex items-center justify-between">
@@ -162,7 +164,7 @@ export default function CardAccountModal({ onClose }: CardAccountModalProps) {
                   ]}
                 />
               </div>
-              {cardType === "debito" && availableAccounts.length > 0 && (
+              {cardType === "debito" && (
                 <div className="space-y-1.5">
                   <label className="text-xs font-medium text-[var(--text-secondary)]">
                     Vincular a cuenta
@@ -178,6 +180,11 @@ export default function CardAccountModal({ onClose }: CardAccountModalProps) {
                       })),
                     ]}
                   />
+                  {availableAccounts.length === 0 && (
+                    <p className="text-[10px] text-[var(--text-tertiary)]">
+                      Creá una Caja de Ahorro primero para poder vincular
+                    </p>
+                  )}
                 </div>
               )}
               <div className="space-y-1.5">
@@ -201,7 +208,7 @@ export default function CardAccountModal({ onClose }: CardAccountModalProps) {
             </div>
           )}
 
-          {accountType === "caja_ahorro" && availableDebitCards.length > 0 && (
+          {accountType === "caja_ahorro" && (
             <div className="space-y-1.5 pt-2 border-t border-[var(--border-color)]">
               <label className="text-xs font-medium text-[var(--text-secondary)]">
                 Vincular tarjeta débito
@@ -217,12 +224,20 @@ export default function CardAccountModal({ onClose }: CardAccountModalProps) {
                   })),
                 ]}
               />
+              {availableDebitCards.length === 0 && (
+                <p className="text-[10px] text-[var(--text-tertiary)]">
+                  Creá una Tarjeta Débito primero para poder vincular
+                </p>
+              )}
             </div>
           )}
 
           <div className="space-y-1.5">
-            <label className="text-xs font-medium text-[var(--text-secondary)]">Tarjeta</label>
+            <label className="text-xs font-medium text-[var(--text-secondary)]">
+              {accountType === "tarjeta" ? "Tarjeta" : "Nombre"}
+            </label>
             <input
+              ref={nameInputRef}
               type="text"
               value={cardName}
               onChange={(e) => {
@@ -235,7 +250,6 @@ export default function CardAccountModal({ onClose }: CardAccountModalProps) {
                   : "border-[var(--border-color)] focus:border-primary"
               }`}
               placeholder={accountType === "tarjeta" ? "Ej: Visa Galicia" : "Ej: Mi Cuenta"}
-              autoFocus
             />
             {errors.card_name && <p className="text-xs text-red-500">{errors.card_name}</p>}
           </div>

--- a/frontend/src/components/CardAccountModal.tsx
+++ b/frontend/src/components/CardAccountModal.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from "react";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { createCard, createAccount } from "../api/client";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { createCard, createAccount, getAccounts, getCards, updateCard } from "../api/client";
+import type { Account } from "../types";
 import { Select } from "./ui/Select";
 
 const ACCOUNT_TYPES = [
@@ -23,6 +24,8 @@ export default function CardAccountModal({ onClose }: CardAccountModalProps) {
   const [bank, setBank] = useState("");
   const [cardType, setCardType] = useState("credito");
   const [errors, setErrors] = useState<{ card_name?: string; bank?: string }>({});
+  const [linkedAccountId, setLinkedAccountId] = useState<number | null>(null);
+  const [linkedCardId, setLinkedCardId] = useState<number | null>(null);
 
   useEffect(() => {
     const handleEscape = (e: KeyboardEvent) => {
@@ -32,18 +35,48 @@ export default function CardAccountModal({ onClose }: CardAccountModalProps) {
     return () => document.removeEventListener("keydown", handleEscape);
   }, [onClose]);
 
+  const { data: accounts = [] } = useQuery({
+    queryKey: ["accounts"],
+    queryFn: getAccounts,
+  });
+
+  const { data: cards = [] } = useQuery({
+    queryKey: ["cards"],
+    queryFn: getCards,
+  });
+
+  // Available caja_ahorro accounts for linking to a new debit card
+  const availableAccounts = accounts.filter((a) => a.type === "caja_ahorro" && !a.linked_card_id);
+
+  // Available debit cards for linking to a new caja_ahorro account
+  const availableDebitCards = cards.filter((c) => c.card_type === "debito" && !c.linked_account_id);
+
+  const updateCardLinkMut = useMutation({
+    mutationFn: ({ cardId, accountId }: { cardId: number; accountId: number | null }) =>
+      updateCard(cardId, { linked_account_id: accountId }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["cards"] });
+      queryClient.invalidateQueries({ queryKey: ["accounts"] });
+    },
+  });
+
   const createCardMut = useMutation({
     mutationFn: createCard,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["cards"] });
+      queryClient.invalidateQueries({ queryKey: ["accounts"] });
       onClose();
     },
   });
 
   const createAccountMut = useMutation({
     mutationFn: (data: { name: string; type: string }) => createAccount(data),
-    onSuccess: () => {
+    onSuccess: (created: Account) => {
       queryClient.invalidateQueries({ queryKey: ["accounts"] });
+      // Link debit card if one was selected
+      if (linkedCardId) {
+        updateCardLinkMut.mutate({ cardId: linkedCardId, accountId: created.id });
+      }
       onClose();
     },
   });
@@ -69,6 +102,7 @@ export default function CardAccountModal({ onClose }: CardAccountModalProps) {
         card_name: cardName.trim(),
         bank: bank.trim(),
         card_type: cardType,
+        linked_account_id: cardType === "debito" ? linkedAccountId : null,
       });
     } else {
       createAccountMut.mutate({ name: cardName.trim(), type: accountType });
@@ -118,13 +152,34 @@ export default function CardAccountModal({ onClose }: CardAccountModalProps) {
                 </label>
                 <Select
                   value={cardType}
-                  onChange={setCardType}
+                  onChange={(v) => {
+                    setCardType(v);
+                    if (v !== "debito") setLinkedAccountId(null);
+                  }}
                   options={[
                     { value: "credito", label: "Crédito" },
                     { value: "debito", label: "Débito" },
                   ]}
                 />
               </div>
+              {cardType === "debito" && availableAccounts.length > 0 && (
+                <div className="space-y-1.5">
+                  <label className="text-xs font-medium text-[var(--text-secondary)]">
+                    Vincular a cuenta
+                  </label>
+                  <Select
+                    value={String(linkedAccountId || "")}
+                    onChange={(v) => setLinkedAccountId(v ? Number(v) : null)}
+                    options={[
+                      { value: "", label: "Sin vinculación" },
+                      ...availableAccounts.map((a) => ({
+                        value: String(a.id),
+                        label: a.name,
+                      })),
+                    ]}
+                  />
+                </div>
+              )}
               <div className="space-y-1.5">
                 <label className="text-xs font-medium text-[var(--text-secondary)]">Banco</label>
                 <input
@@ -143,6 +198,25 @@ export default function CardAccountModal({ onClose }: CardAccountModalProps) {
                 />
                 {errors.bank && <p className="text-xs text-red-500">{errors.bank}</p>}
               </div>
+            </div>
+          )}
+
+          {accountType === "caja_ahorro" && availableDebitCards.length > 0 && (
+            <div className="space-y-1.5 pt-2 border-t border-[var(--border-color)]">
+              <label className="text-xs font-medium text-[var(--text-secondary)]">
+                Vincular tarjeta débito
+              </label>
+              <Select
+                value={String(linkedCardId || "")}
+                onChange={(v) => setLinkedCardId(v ? Number(v) : null)}
+                options={[
+                  { value: "", label: "Sin vinculación" },
+                  ...availableDebitCards.map((c) => ({
+                    value: String(c.id),
+                    label: `${c.card_name} (${c.bank})`,
+                  })),
+                ]}
+              />
             </div>
           )}
 

--- a/frontend/src/components/CardsManager.tsx
+++ b/frontend/src/components/CardsManager.tsx
@@ -8,6 +8,7 @@ import {
   createAccount,
   getCardSummary,
   getMe,
+  getAccounts,
 } from "../api/client";
 import { useQuery as useCardDataQuery } from "@tanstack/react-query";
 import type { Card } from "../types";
@@ -50,11 +51,24 @@ export default function CardsManager() {
   const [holder, setHolder] = useState("");
   const [cardType, setCardType] = useState("credito");
   const [accountType, setAccountType] = useState("efectivo");
+  const [linkedAccountId, setLinkedAccountId] = useState<number | null>(null);
 
   const { data: cards = [], isLoading } = useQuery({
     queryKey: ["cards"],
     queryFn: getCards,
   });
+
+  const { data: accounts = [] } = useQuery({
+    queryKey: ["accounts"],
+    queryFn: getAccounts,
+  });
+
+  // Filter accounts that are caja_ahorro and not already linked to another card
+  const availableLinkedAccounts = accounts.filter(
+    (a) =>
+      a.type === "caja_ahorro" &&
+      (!a.linked_card_id || (editId && editId > 0 && a.linked_card_id === editId)),
+  );
 
   const { data: currentUser } = useQuery({
     queryKey: ["me"],
@@ -69,14 +83,22 @@ export default function CardsManager() {
   });
 
   const createMut = useMutation({
-    mutationFn: createCard,
+    mutationFn: (data: {
+      card_name: string;
+      bank: string;
+      holder?: string;
+      card_type?: string;
+      linked_account_id?: number | null;
+    }) => createCard(data),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["cards"] });
+      queryClient.invalidateQueries({ queryKey: ["accounts"] });
       setEditId(null);
       setCardName("");
       setBank("");
       setHolder("");
       setCardType("credito");
+      setLinkedAccountId(null);
     },
     onError: (error: { response?: { status?: number; data?: { detail?: string } } }) => {
       if (error.response?.status === 409) {
@@ -99,15 +121,22 @@ export default function CardsManager() {
       data,
     }: {
       id: number;
-      data: { card_name?: string; bank?: string; card_type?: string; closing_day?: number | null };
+      data: {
+        card_name?: string;
+        bank?: string;
+        card_type?: string;
+        linked_account_id?: number | null;
+      };
     }) => updateCard(id, data),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["cards"] });
+      queryClient.invalidateQueries({ queryKey: ["accounts"] });
       setEditId(null);
       setCardName("");
       setBank("");
       setHolder("");
       setCardType("credito");
+      setLinkedAccountId(null);
     },
   });
 
@@ -137,6 +166,7 @@ export default function CardsManager() {
     setBank(card.bank || "");
     setHolder(card.holder || "");
     setCardType(card.card_type);
+    setLinkedAccountId(card.linked_account_id || null);
     setAccountType("tarjeta");
     setMenuOpen(null);
   };
@@ -147,6 +177,7 @@ export default function CardsManager() {
     setBank("");
     setHolder("");
     setCardType("credito");
+    setLinkedAccountId(null);
     setAccountType("tarjeta");
   };
 
@@ -156,6 +187,7 @@ export default function CardsManager() {
     setBank("");
     setHolder(currentUser ? getFirstName(currentUser.full_name) : "");
     setCardType("credito");
+    setLinkedAccountId(null);
     setAccountType("efectivo");
     setMenuOpen(null);
   };
@@ -178,10 +210,17 @@ export default function CardsManager() {
     setErrors({});
 
     if (accountType === "tarjeta") {
-      const data: { card_name: string; bank?: string; holder?: string; card_type?: string } = {
+      const data: {
+        card_name: string;
+        bank: string;
+        holder?: string;
+        card_type?: string;
+        linked_account_id?: number | null;
+      } = {
         card_name: cardName.trim(),
         bank: bank.trim(),
         card_type: cardType,
+        linked_account_id: cardType === "debito" ? linkedAccountId : null,
       };
       if (editId && editId > 0) {
         updateMut.mutate({ id: editId, data });
@@ -270,13 +309,34 @@ export default function CardsManager() {
                   <label className="text-xs font-medium text-[var(--text-secondary)]">Tipo</label>
                   <Select
                     value={cardType}
-                    onChange={(v) => setCardType(v)}
+                    onChange={(v) => {
+                      setCardType(v);
+                      if (v !== "debito") setLinkedAccountId(null);
+                    }}
                     options={[
                       { value: "credito", label: "Crédito" },
                       { value: "debito", label: "Débito" },
                     ]}
                   />
                 </div>
+                {cardType === "debito" && availableLinkedAccounts.length > 0 && (
+                  <div className="space-y-1.5">
+                    <label className="text-xs font-medium text-[var(--text-secondary)]">
+                      Vincular a cuenta
+                    </label>
+                    <Select
+                      value={String(linkedAccountId || "")}
+                      onChange={(v) => setLinkedAccountId(v ? Number(v) : null)}
+                      options={[
+                        { value: "", label: "Sin vinculación" },
+                        ...availableLinkedAccounts.map((a) => ({
+                          value: String(a.id),
+                          label: a.name,
+                        })),
+                      ]}
+                    />
+                  </div>
+                )}
                 <div className="flex gap-2 pt-2">
                   <button
                     type="submit"
@@ -318,6 +378,11 @@ export default function CardsManager() {
                     — {card.bank}
                   </div>
                   <div className="text-xs text-tertiary mt-0.5">Titular: {card.holder || "—"}</div>
+                  {card.linked_account_name && (
+                    <div className="text-xs text-[var(--color-success)] mt-0.5">
+                      Vinculada a: {card.linked_account_name}
+                    </div>
+                  )}
                 </div>
                 <div className="relative">
                   <button
@@ -401,13 +466,34 @@ export default function CardsManager() {
                 </label>
                 <Select
                   value={cardType}
-                  onChange={(v) => setCardType(v)}
+                  onChange={(v) => {
+                    setCardType(v);
+                    if (v !== "debito") setLinkedAccountId(null);
+                  }}
                   options={[
                     { value: "credito", label: "Crédito" },
                     { value: "debito", label: "Débito" },
                   ]}
                 />
               </div>
+              {cardType === "debito" && availableLinkedAccounts.length > 0 && (
+                <div className="space-y-1.5">
+                  <label className="text-xs font-medium text-[var(--text-secondary)]">
+                    Vincular a cuenta
+                  </label>
+                  <Select
+                    value={String(linkedAccountId || "")}
+                    onChange={(v) => setLinkedAccountId(v ? Number(v) : null)}
+                    options={[
+                      { value: "", label: "Sin vinculación" },
+                      ...availableLinkedAccounts.map((a) => ({
+                        value: String(a.id),
+                        label: a.name,
+                      })),
+                    ]}
+                  />
+                </div>
+              )}
               <div className="space-y-1.5">
                 <label className="text-xs font-medium text-[var(--text-secondary)]">Banco</label>
                 <input

--- a/frontend/src/components/CardsManager.tsx
+++ b/frontend/src/components/CardsManager.tsx
@@ -476,7 +476,7 @@ export default function CardsManager() {
                   ]}
                 />
               </div>
-              {cardType === "debito" && availableLinkedAccounts.length > 0 && (
+              {cardType === "debito" && (
                 <div className="space-y-1.5">
                   <label className="text-xs font-medium text-[var(--text-secondary)]">
                     Vincular a cuenta
@@ -492,6 +492,11 @@ export default function CardsManager() {
                       })),
                     ]}
                   />
+                  {availableLinkedAccounts.length === 0 && (
+                    <p className="text-[10px] text-[var(--text-tertiary)]">
+                      Creá una Caja de Ahorro primero para poder vincular
+                    </p>
+                  )}
                 </div>
               )}
               <div className="space-y-1.5">

--- a/frontend/src/components/CardsManager.tsx
+++ b/frontend/src/components/CardsManager.tsx
@@ -7,20 +7,12 @@ import {
   deleteCard,
   createAccount,
   getCardSummary,
-  getMe,
   getAccounts,
 } from "../api/client";
 import { useQuery as useCardDataQuery } from "@tanstack/react-query";
 import type { Card } from "../types";
 import { Select } from "./ui/Select";
 import { Skeleton, SkeletonList } from "./ui/Skeleton";
-
-const getFirstName = (fullName: string): string => {
-  if (fullName.includes(",")) {
-    return fullName.split(",")[1].trim().split(" ")[0];
-  }
-  return fullName.split(" ")[0];
-};
 
 const ACCOUNT_TYPES = [
   { value: "efectivo", label: "Efectivo" },
@@ -69,11 +61,6 @@ export default function CardsManager() {
       a.type === "caja_ahorro" &&
       (!a.linked_card_id || (editId && editId > 0 && a.linked_card_id === editId)),
   );
-
-  const { data: currentUser } = useQuery({
-    queryKey: ["me"],
-    queryFn: getMe,
-  });
 
   // Card data from expenses (for future extension - show spending by card)
   useCardDataQuery({
@@ -179,17 +166,6 @@ export default function CardsManager() {
     setCardType("credito");
     setLinkedAccountId(null);
     setAccountType("tarjeta");
-  };
-
-  const handleAdd = () => {
-    setEditId(-1);
-    setCardName("");
-    setBank("");
-    setHolder(currentUser ? getFirstName(currentUser.full_name) : "");
-    setCardType("credito");
-    setLinkedAccountId(null);
-    setAccountType("efectivo");
-    setMenuOpen(null);
   };
 
   const handleSubmit = (e: React.FormEvent) => {
@@ -553,15 +529,6 @@ export default function CardsManager() {
             </button>
           </div>
         </form>
-      )}
-
-      {editId === null && (
-        <button
-          onClick={handleAdd}
-          className="w-full py-2.5 border-2 border-dashed border-border-color rounded-lg text-sm text-secondary hover:border-primary hover:text-primary transition-colors"
-        >
-          + Agregar
-        </button>
       )}
 
       {deleteConfirm && (

--- a/frontend/src/components/UserPanel.tsx
+++ b/frontend/src/components/UserPanel.tsx
@@ -27,6 +27,7 @@ import { ConfirmDialog } from "./ConfirmDialog";
 import { useTheme } from "../context/ThemeContext";
 import AccountsManager from "./AccountsManager";
 import CardsManager from "./CardsManager";
+import CardAccountModal from "./CardAccountModal";
 
 const MONTHS_ES = [
   "Enero",
@@ -266,6 +267,7 @@ export default function UserPanel({ open, onClose }: Props) {
   const [showRegenInviteConfirm, setShowRegenInviteConfirm] = useState(false);
   const [showRegenTelegramConfirm, setShowRegenTelegramConfirm] = useState(false);
   const [showLogoutConfirm, setShowLogoutConfirm] = useState(false);
+  const [showCardAccountModal, setShowCardAccountModal] = useState(false);
 
   // MFA state
   const [mfaQrCode, setMfaQrCode] = useState<string | null>(null);
@@ -1200,6 +1202,14 @@ export default function UserPanel({ open, onClose }: Props) {
             <div className="space-y-0">
               <AccountsManager />
               <CardsManager />
+              <div className="px-4 py-2">
+                <button
+                  onClick={() => setShowCardAccountModal(true)}
+                  className="w-full py-2.5 border-2 border-dashed border-border-color rounded-lg text-sm text-secondary hover:border-primary hover:text-primary transition-colors"
+                >
+                  + Crear tarjeta o cuenta
+                </button>
+              </div>
             </div>
           )}
 
@@ -1286,6 +1296,8 @@ export default function UserPanel({ open, onClose }: Props) {
         }}
         onCancel={() => setShowLogoutConfirm(false)}
       />
+
+      {showCardAccountModal && <CardAccountModal onClose={() => setShowCardAccountModal(false)} />}
     </>
   );
 }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -83,6 +83,8 @@ export interface Account {
   id: number;
   name: string;
   type: string;
+  linked_card_id?: number | null;
+  linked_card_name?: string | null;
   user_id: number;
   created_at: string;
 }
@@ -93,6 +95,8 @@ export interface Card {
   bank: string;
   holder: string;
   card_type: string;
+  linked_account_id?: number | null;
+  linked_account_name?: string | null;
   user_id: number;
   created_at: string;
 }


### PR DESCRIPTION
## Summary

Bidirectional linking between savings accounts (caja_ahorro) and debit cards. When a debit card is linked to a savings account, expenses paid with that card are automatically reflected in the account.

## Changes

### Backend
- **Model**: Added  FK to  model with relationship to 
- **Migration**: Idempotent migration script ()
- **Cards Router**: 
  - / schemas include 
  -  includes  and 
  - Validations: only caja_ahorro accounts, only debit cards, one account per card
  -  eager loads linked account with name
- **Accounts Router**: 
  -  includes  and 
  -  does inverse lookup to find linked card
- **Expenses Router**: Auto-assigns  when creating expense with linked debit card

### Frontend
- **Types**:  interface has /,  has /
- **CardsManager**: Dropdown for linked account appears when cardType=debito, shows linked account info on card display
- **AccountsManager**: Shows linked card badge for caja_ahorro accounts
- **API Client**: / accept 

## Validation Rules
- Only  accounts can be linked to debit cards
- Only  cards can be linked to accounts
- One account can only be linked to one card (and vice versa)
- Linking is bidirectional: can link from card or from account

## Testing
- [x] TypeScript type check passes
- [x] Python lint passes (ruff)
- [x] Frontend formatting passes (prettier)

Closes #16