### PR TITLE
feat: UX improvements (compact modal, mobile fix, deploy fix)

### DIFF
--- a/backend/app/services/budget_helpers.py
+++ b/backend/app/services/budget_helpers.py
@@ -1,0 +1,147 @@
+"""Shared budget spending calculation helpers."""
+
+from calendar import monthrange
+from datetime import date
+
+from sqlalchemy.orm import Session
+
+
+def get_group_user_ids(user_id: int, db: Session) -> list[int]:
+    """Get all user IDs in the same family group."""
+    from app.models import GroupMember
+
+    member = db.query(GroupMember).filter(GroupMember.user_id == user_id).first()
+    if not member:
+        return [user_id]
+    return [
+        m.user_id
+        for m in db.query(GroupMember).filter(GroupMember.group_id == member.group_id).all()
+    ]
+
+
+def get_spending_for_category(
+    category_id: int, year: int, month: int, uid_list: list[int], db: Session
+) -> float:
+    """Get total spending for a category in a given month (including children)."""
+    from app.models import Category, Expense
+
+    cat_ids = [category_id]
+    children = db.query(Category).filter(Category.parent_id == category_id).all()
+    cat_ids.extend([c.id for c in children])
+
+    start = date(year, month, 1)
+    end = date(year, month, monthrange(year, month)[1])
+
+    total = (
+        db.query(Expense)
+        .filter(
+            Expense.user_id.in_(uid_list),
+            Expense.category_id.in_(cat_ids),
+            Expense.date >= start,
+            Expense.date <= end,
+            Expense.is_income == False,
+        )
+        .with_entities(Expense.amount)
+        .all()
+    )
+    return sum(abs(t[0]) for t in total)
+
+
+def get_spending_for_group(
+    group_name: str, year: int, month: int, uid_list: list[int], db: Session
+) -> float:
+    """Get total spending for a macro group in a given month.
+
+    Filters categories by both budget_group AND user_id to prevent cross-user contamination.
+    """
+    from app.models import Category, Expense
+
+    cat_ids = [
+        c.id
+        for c in db.query(Category)
+        .filter(
+            Category.budget_group == group_name,
+            Category.user_id.in_(uid_list),
+        )
+        .all()
+    ]
+
+    start = date(year, month, 1)
+    end = date(year, month, monthrange(year, month)[1])
+
+    total = (
+        db.query(Expense)
+        .filter(
+            Expense.user_id.in_(uid_list),
+            Expense.category_id.in_(cat_ids),
+            Expense.date >= start,
+            Expense.date <= end,
+            Expense.is_income == False,
+        )
+        .with_entities(Expense.amount)
+        .all()
+    )
+    return sum(abs(t[0]) for t in total)
+
+
+def get_spending_for_event(
+    event_categories: list[dict], start_date: date, end_date: date, uid_list: list[int], db: Session
+) -> float:
+    """Get total spending for a budget event's categories within its date range."""
+    from app.models import Expense
+
+    cat_ids = [c["category_id"] for c in event_categories if "category_id" in c]
+    if not cat_ids:
+        return 0.0
+
+    total = (
+        db.query(Expense)
+        .filter(
+            Expense.user_id.in_(uid_list),
+            Expense.category_id.in_(cat_ids),
+            Expense.date >= start_date,
+            Expense.date <= end_date,
+            Expense.is_income == False,
+        )
+        .with_entities(Expense.amount)
+        .all()
+    )
+    return sum(abs(t[0]) for t in total)
+
+
+def get_avg_monthly_spending(category_id: int, uid_list: list[int], db: Session) -> float:
+    """Get average monthly spending for a category over the last 3 months."""
+    from calendar import monthrange
+    from datetime import timedelta
+
+    from sqlalchemy import func
+
+    from app.models import Category, Expense
+
+    today = date.today()
+    cat_ids = [category_id]
+    children = db.query(Category).filter(Category.parent_id == category_id).all()
+    cat_ids.extend([c.id for c in children])
+
+    monthly_totals = []
+    for i in range(3):
+        month_date = today.replace(day=1) - timedelta(days=30 * i)
+        start = month_date.replace(day=1)
+        end = start.replace(day=monthrange(start.year, start.month)[1])
+
+        total = (
+            db.query(Expense)
+            .filter(
+                Expense.user_id.in_(uid_list),
+                Expense.category_id.in_(cat_ids),
+                Expense.date >= start,
+                Expense.date <= end,
+                Expense.is_income == False,
+            )
+            .with_entities(func.sum(Expense.amount))
+            .scalar()
+            or 0
+        )
+        monthly_totals.append(abs(total))
+
+    return sum(monthly_totals) / len(monthly_totals) if monthly_totals else 0

--- a/backend/main.py
+++ b/backend/main.py
@@ -71,19 +71,6 @@ async def lifespan(application: FastAPI):
         db.commit()
         logging.getLogger(__name__).info(f"Auto-verified {len(unverified)} existing users")
 
-    # Flag existing users for forced password change (new security policy)
-    from sqlalchemy import text as _sql
-
-    needs_flag = db.execute(
-        _sql("SELECT id FROM users WHERE force_password_change = false AND hashed_password IS NOT NULL")
-    ).fetchall()
-    if needs_flag:
-        db.execute(
-            _sql("UPDATE users SET force_password_change = true WHERE hashed_password IS NOT NULL AND force_password_change = false")
-        )
-        db.commit()
-        logging.getLogger(__name__).info(f"Flagged {len(needs_flag)} users for forced password change")
-
     db.close()
 
     task = asyncio.create_task(price_refresh_loop())

--- a/frontend/src/components/ExpenseModals.tsx
+++ b/frontend/src/components/ExpenseModals.tsx
@@ -1,7 +1,5 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { DayPicker } from "react-day-picker";
-import { es } from "date-fns/locale";
 import { getCategories, getAccounts, getCards, createCategory } from "../api/client";
 import type { Expense, ExpenseCreate, Card } from "../types";
 import { Select } from "./ui/Select";
@@ -52,75 +50,6 @@ export const EMPTY_FORM: ExpenseCreate = {
 };
 
 // DatePicker component with calendar
-export function DatePickerInput({
-  value,
-  onChange,
-}: {
-  value: string;
-  onChange: (d: string) => void;
-}) {
-  const [isOpen, setIsOpen] = useState(false);
-  const ref = useRef<HTMLDivElement>(null);
-
-  const getValidDate = (val: string): Date => {
-    if (!val || typeof val !== "string") return new Date();
-    const parts = val.split("-");
-    if (parts.length !== 3) return new Date();
-    const d = parseInt(parts[0]);
-    const m = parseInt(parts[1]);
-    const y = parseInt(parts[2]);
-    if (isNaN(d) || isNaN(m) || isNaN(y)) return new Date();
-    if (d < 1 || d > 31 || m < 1 || m > 12 || y < 2000 || y > 2100) return new Date();
-    return new Date(y, m - 1, d);
-  };
-
-  const selectedDate = getValidDate(value);
-
-  useEffect(() => {
-    function handleClickOutside(e: MouseEvent) {
-      if (ref.current && !ref.current.contains(e.target as Node)) {
-        setIsOpen(false);
-      }
-    }
-    document.addEventListener("mousedown", handleClickOutside);
-    return () => document.removeEventListener("mousedown", handleClickOutside);
-  }, []);
-
-  return (
-    <div ref={ref} className="relative">
-      <input
-        type="text"
-        value={value}
-        onChange={(e) => {
-          const raw = e.target.value.replace(/[^\d-]/g, "").slice(0, 10);
-          onChange(raw);
-        }}
-        onClick={() => setIsOpen(!isOpen)}
-        className="w-full px-3 py-2 rounded-md border border-[var(--border-color)] text-sm text-[var(--text-primary)] bg-[var(--color-base-container)] focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary transition cursor-pointer"
-        placeholder="DD-MM-YYYY"
-      />
-      {isOpen && (
-        <div className="absolute z-50 mt-2 p-3 bg-[var(--color-surface)] border border-[var(--border-color)] rounded-xl shadow-gnome-lg">
-          <DayPicker
-            mode="single"
-            selected={selectedDate}
-            onSelect={(d) => {
-              if (d) {
-                const nd = String(d.getDate()).padStart(2, "0");
-                const nm = String(d.getMonth() + 1).padStart(2, "0");
-                const ny = d.getFullYear();
-                onChange(`${nd}-${nm}-${ny}`);
-                setIsOpen(false);
-              }
-            }}
-            locale={es}
-            className=""
-          />
-        </div>
-      )}
-    </div>
-  );
-}
 
 // ExpenseModal - Full modal for expense transactions with payment method selector
 interface ExpenseModalProps {
@@ -260,6 +189,10 @@ export function ExpenseModal({
 
   const trapRef = useFocusTrap(true);
 
+  const [showAdvanced, setShowAdvanced] = useState(
+    !!initial?.notes || !!(initial?.installment_total && initial.installment_total > 1),
+  );
+
   return (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center p-4 animate-modal-backdrop bg-black/60"
@@ -270,7 +203,7 @@ export function ExpenseModal({
         role="dialog"
         aria-modal="true"
         aria-label={initial ? "Editar gasto" : "Nuevo gasto"}
-        className="relative card w-full max-w-lg max-h-[90vh] overflow-auto p-6 space-y-4 animate-modal-content"
+        className="relative card w-full max-w-md max-h-[90vh] overflow-auto p-5 space-y-2.5 animate-modal-content"
         onClick={(e) => e.stopPropagation()}
       >
         <div className="flex items-center justify-between">
@@ -311,14 +244,14 @@ export function ExpenseModal({
         {/* Payment method toggle */}
         {!isInstallmentsOnly && (
           <div>
-            <label className="block text-sm font-medium text-[var(--text-secondary)] mb-2">
+            <label className="block text-sm font-medium text-[var(--text-secondary)] mb-1.5">
               Medio de pago
             </label>
             <div className="flex rounded-md border border-[var(--border-color)] overflow-hidden">
               <button
                 type="button"
                 onClick={() => switchPayMethod("card")}
-                className={`flex-1 px-3 py-2 text-sm font-medium transition ${
+                className={`flex-1 px-3 py-1.5 text-sm font-medium transition ${
                   payMethod === "card"
                     ? "bg-[var(--color-primary)] text-[var(--color-on-primary)]"
                     : "bg-[var(--color-base-container)] text-[var(--text-secondary)] hover:bg-[var(--color-base-alt)]"
@@ -329,7 +262,7 @@ export function ExpenseModal({
               <button
                 type="button"
                 onClick={() => switchPayMethod("cash")}
-                className={`flex-1 px-3 py-2 text-sm font-medium transition ${
+                className={`flex-1 px-3 py-1.5 text-sm font-medium transition ${
                   payMethod === "cash"
                     ? "bg-[var(--color-primary)] text-[var(--color-on-primary)]"
                     : "bg-[var(--color-base-container)] text-[var(--text-secondary)] hover:bg-[var(--color-base-alt)]"
@@ -341,27 +274,31 @@ export function ExpenseModal({
           </div>
         )}
 
+        {/* Fecha */}
         <div>
           <label className="text-xs font-medium text-[var(--text-secondary)]">
             Fecha <span className="text-danger">*</span>
           </label>
-          <DatePickerInput value={form.date} onChange={(d) => set("date", d)} />
-        </div>
-
-        <div>
-          <label className="text-xs font-medium text-[var(--text-secondary)]">
-            Descripción <span className="text-danger">*</span>
-          </label>
           <input
-            type="text"
-            value={form.description}
-            onChange={(e) => set("description", e.target.value)}
-            placeholder="Ej: Supermercado Coto"
-            className="w-full px-3 py-2 rounded-md border border-[var(--border-color)] text-sm text-[var(--text-primary)] bg-[var(--color-base-container)] focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary transition"
+            type="date"
+            value={(() => {
+              // Convert DD-MM-YYYY to YYYY-MM-DD for native date input
+              const parts = form.date.split("-");
+              if (parts.length === 3) return `${parts[2]}-${parts[1]}-${parts[0]}`;
+              return form.date;
+            })()}
+            onChange={(e) => {
+              // Convert YYYY-MM-DD back to DD-MM-YYYY
+              const parts = e.target.value.split("-");
+              if (parts.length === 3) set("date", `${parts[2]}-${parts[1]}-${parts[0]}`);
+              else set("date", e.target.value);
+            }}
+            className="w-full px-3 py-1.5 rounded-md border border-[var(--border-color)] text-sm text-[var(--text-primary)] bg-[var(--color-base-container)] focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary transition"
           />
         </div>
 
-        <div className="grid grid-cols-3 gap-3">
+        {/* Monto + Moneda */}
+        <div className="grid grid-cols-3 gap-2">
           <div className="col-span-2">
             <label className="text-xs font-medium text-[var(--text-secondary)]">
               Monto <span className="text-danger">*</span>
@@ -370,7 +307,7 @@ export function ExpenseModal({
               type="number"
               value={form.amount}
               onChange={(e) => set("amount", parseFloat(e.target.value) || 0)}
-              className="w-full px-3 py-2 rounded-md border border-[var(--border-color)] text-sm text-[var(--text-primary)] bg-[var(--color-base-container)] focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary transition"
+              className="w-full px-3 py-1.5 rounded-md border border-[var(--border-color)] text-sm text-[var(--text-primary)] bg-[var(--color-base-container)] focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary transition"
             />
           </div>
           <div>
@@ -386,68 +323,82 @@ export function ExpenseModal({
           </div>
         </div>
 
-        <div>
-          <label className="text-xs font-medium text-[var(--text-secondary)]">Categoría</label>
-          <Select
-            value={form.category_id ? String(form.category_id) : ""}
-            onChange={async (v) => {
-              if (!v) {
-                set("category_id", null);
-                return;
-              }
-              const parsed = parseInt(v);
-              if (!isNaN(parsed)) {
-                set("category_id", parsed);
-              } else {
-                // Create new category
-                try {
-                  const newCat = await createCategory({
-                    name: v,
-                    color: "#6366f1",
-                    keywords: "",
-                    parent_id: null,
-                  });
-                  queryClient.invalidateQueries({ queryKey: ["categories"] });
-                  set("category_id", newCat.id);
-                } catch {
-                  // Duplicate name or other error - leave category_id as null
+        {/* Descripción + Categoría */}
+        <div className="grid grid-cols-2 gap-2">
+          <div>
+            <label className="text-xs font-medium text-[var(--text-secondary)]">
+              Descripción <span className="text-danger">*</span>
+            </label>
+            <input
+              type="text"
+              value={form.description}
+              onChange={(e) => set("description", e.target.value)}
+              placeholder="Ej: Supermercado Coto"
+              className="w-full px-3 py-1.5 rounded-md border border-[var(--border-color)] text-sm text-[var(--text-primary)] bg-[var(--color-base-container)] focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary transition"
+            />
+          </div>
+          <div>
+            <label className="text-xs font-medium text-[var(--text-secondary)]">Categoría</label>
+            <Select
+              value={form.category_id ? String(form.category_id) : ""}
+              onChange={async (v) => {
+                if (!v) {
+                  set("category_id", null);
+                  return;
                 }
-              }
-            }}
-            groups={(() => {
-              const parentIds = new Set(
-                categories.filter((c) => c.parent_id).map((c) => c.parent_id!),
-              );
-              const parents = categories.filter((c) => !c.parent_id && parentIds.has(c.id));
-              const orphans = categories.filter((c) => !c.parent_id && !parentIds.has(c.id));
-              return [
-                ...parents.map((parent) => ({
-                  label: parent.name,
-                  options: categories
-                    .filter((c) => c.parent_id === parent.id)
-                    .map((c) => ({ value: String(c.id), label: c.name })),
-                })),
-                ...(orphans.length > 0
-                  ? [
-                      {
-                        label: "—",
-                        options: orphans.map((c) => ({ value: String(c.id), label: c.name })),
-                      },
-                    ]
-                  : []),
-              ];
-            })()}
-            placeholder="Sin categoría"
-          />
+                const parsed = parseInt(v);
+                if (!isNaN(parsed)) {
+                  set("category_id", parsed);
+                } else {
+                  try {
+                    const newCat = await createCategory({
+                      name: v,
+                      color: "#6366f1",
+                      keywords: "",
+                      parent_id: null,
+                    });
+                    queryClient.invalidateQueries({ queryKey: ["categories"] });
+                    set("category_id", newCat.id);
+                  } catch {
+                    // Duplicate name or other error
+                  }
+                }
+              }}
+              groups={(() => {
+                const parentIds = new Set(
+                  categories.filter((c) => c.parent_id).map((c) => c.parent_id!),
+                );
+                const parents = categories.filter((c) => !c.parent_id && parentIds.has(c.id));
+                const orphans = categories.filter((c) => !c.parent_id && !parentIds.has(c.id));
+                return [
+                  ...parents.map((parent) => ({
+                    label: parent.name,
+                    options: categories
+                      .filter((c) => c.parent_id === parent.id)
+                      .map((c) => ({ value: String(c.id), label: c.name })),
+                  })),
+                  ...(orphans.length > 0
+                    ? [
+                        {
+                          label: "—",
+                          options: orphans.map((c) => ({ value: String(c.id), label: c.name })),
+                        },
+                      ]
+                    : []),
+                ];
+              })()}
+              placeholder="Sin categoría"
+            />
+          </div>
         </div>
 
-        {/* Cascading: Banco → Tarjeta */}
+        {/* Banco → Tarjeta */}
         <div
-          className={`space-y-3 transition-opacity ${
+          className={`transition-opacity ${
             payMethod === "cash" ? "opacity-40 pointer-events-none" : ""
           }`}
         >
-          <div className="grid grid-cols-2 gap-3">
+          <div className="grid grid-cols-2 gap-2">
             <div>
               <label className="text-xs font-medium text-[var(--text-secondary)]">Banco</label>
               <Select
@@ -474,13 +425,10 @@ export function ExpenseModal({
           </div>
         </div>
 
-        {/* Account selector for cash/transfer payments */}
-        <div
-          className={`space-y-3 ${payMethod === "card" ? "opacity-40 pointer-events-none" : ""}`}
-        >
-          {/* Warning when no accounts for cash/transfer */}
+        {/* Account selector for cash/transfer */}
+        <div className={`${payMethod === "card" ? "opacity-40 pointer-events-none" : ""}`}>
           {payMethod === "cash" && accounts.filter((a) => a.type !== "credito").length === 0 && (
-            <div className="flex items-start gap-2 bg-amber-50 border border-amber-200 rounded-lg px-3 py-2 text-xs text-amber-700">
+            <div className="flex items-start gap-2 bg-amber-50 border border-amber-200 rounded-lg px-3 py-2 text-xs text-amber-700 mb-2">
               <span className="mt-0.5">⚠️</span>
               <div className="flex-1">
                 <p>No tenés cuentas creadas para efectivo/transferencia.</p>
@@ -509,70 +457,83 @@ export function ExpenseModal({
               placeholder="Seleccionar cuenta"
               disabled={payMethod === "card"}
             />
-            <p className="text-xs text-[var(--text-tertiary)] mt-1">
-              Caja de ahorro, cuenta corriente, MercadoPago, efectivo
-            </p>
           </div>
         </div>
 
-        {payMethod === "card" && (
-          <div className="border border-[var(--border-color)] rounded-md p-3 space-y-3">
-            {!isInstallmentsOnly && (
-              <label className="flex items-center gap-2 cursor-pointer select-none">
-                <input
-                  type="checkbox"
-                  checked={cuotasEnabled}
-                  onChange={(e) => toggleCuotas(e.target.checked)}
-                  className="accent-[var(--color-primary)]"
-                />
-                <span className="text-sm font-medium text-[var(--text-secondary)]">
-                  Compra en cuotas
-                </span>
-              </label>
-            )}
-            {(cuotasEnabled || isInstallmentsOnly) && (
-              <div className="flex items-center gap-3">
-                <div className="flex-1">
-                  <label className="text-xs font-medium text-[var(--text-secondary)]">
-                    Cuota N°
+        {/* Advanced toggle */}
+        <button
+          type="button"
+          onClick={() => setShowAdvanced(!showAdvanced)}
+          className="text-xs font-medium text-[var(--text-tertiary)] hover:text-[var(--color-primary)] transition flex items-center gap-1"
+        >
+          <span>{showAdvanced ? "▾" : "▸"}</span>
+          Más opciones
+        </button>
+
+        {/* Advanced section: Cuotas + Notas */}
+        {showAdvanced && (
+          <div className="space-y-2.5 pt-1 border-t border-[var(--border-color)]">
+            {payMethod === "card" && (
+              <div className="border border-[var(--border-color)] rounded-md p-2.5 space-y-2">
+                {!isInstallmentsOnly && (
+                  <label className="flex items-center gap-2 cursor-pointer select-none">
+                    <input
+                      type="checkbox"
+                      checked={cuotasEnabled}
+                      onChange={(e) => toggleCuotas(e.target.checked)}
+                      className="accent-[var(--color-primary)]"
+                    />
+                    <span className="text-sm font-medium text-[var(--text-secondary)]">
+                      Compra en cuotas
+                    </span>
                   </label>
-                  <input
-                    type="number"
-                    min={1}
-                    value={form.installment_number ?? 1}
-                    onChange={(e) => set("installment_number", parseInt(e.target.value) || 1)}
-                    className="w-full px-3 py-2 rounded-md border border-[var(--border-color)] text-sm text-[var(--text-primary)] bg-[var(--color-base-container)] focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary transition text-center"
-                  />
-                </div>
-                <span className="text-[var(--text-tertiary)] mt-4">de</span>
-                <div className="flex-1">
-                  <label className="text-xs font-medium text-[var(--text-secondary)]">
-                    Total cuotas
-                  </label>
-                  <input
-                    type="number"
-                    min={1}
-                    value={form.installment_total ?? 1}
-                    onChange={(e) => set("installment_total", parseInt(e.target.value) || 1)}
-                    className="w-full px-3 py-2 rounded-md border border-[var(--border-color)] text-sm text-[var(--text-primary)] bg-[var(--color-base-container)] focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary transition text-center"
-                  />
-                </div>
+                )}
+                {(cuotasEnabled || isInstallmentsOnly) && (
+                  <div className="flex items-center gap-3">
+                    <div className="flex-1">
+                      <label className="text-xs font-medium text-[var(--text-secondary)]">
+                        Cuota N°
+                      </label>
+                      <input
+                        type="number"
+                        min={1}
+                        value={form.installment_number ?? 1}
+                        onChange={(e) => set("installment_number", parseInt(e.target.value) || 1)}
+                        className="w-full px-3 py-1.5 rounded-md border border-[var(--border-color)] text-sm text-[var(--text-primary)] bg-[var(--color-base-container)] focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary transition text-center"
+                      />
+                    </div>
+                    <span className="text-[var(--text-tertiary)] mt-4">de</span>
+                    <div className="flex-1">
+                      <label className="text-xs font-medium text-[var(--text-secondary)]">
+                        Total cuotas
+                      </label>
+                      <input
+                        type="number"
+                        min={1}
+                        value={form.installment_total ?? 1}
+                        onChange={(e) => set("installment_total", parseInt(e.target.value) || 1)}
+                        className="w-full px-3 py-1.5 rounded-md border border-[var(--border-color)] text-sm text-[var(--text-primary)] bg-[var(--color-base-container)] focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary transition text-center"
+                      />
+                    </div>
+                  </div>
+                )}
               </div>
             )}
+
+            <div>
+              <label className="text-xs font-medium text-[var(--text-secondary)]">Notas</label>
+              <textarea
+                value={form.notes ?? ""}
+                onChange={(e) => set("notes", e.target.value)}
+                className="w-full px-3 py-1.5 rounded-md border border-[var(--border-color)] text-sm text-[var(--text-primary)] bg-[var(--color-base-container)] focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary transition resize-none"
+                rows={1}
+              />
+            </div>
           </div>
         )}
 
-        <div>
-          <label className="text-xs font-medium text-[var(--text-secondary)]">Notas</label>
-          <textarea
-            value={form.notes ?? ""}
-            onChange={(e) => set("notes", e.target.value)}
-            className="w-full px-3 py-2 rounded-md border border-[var(--border-color)] text-sm text-[var(--text-primary)] bg-[var(--color-base-container)] focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary transition resize-none"
-            rows={2}
-          />
-        </div>
-
-        <div className="flex gap-2 pt-2">
+        {/* Buttons */}
+        <div className="flex gap-2 pt-1">
           <button
             onClick={onClose}
             className="flex-1 px-4 py-2 rounded-md border border-[var(--border-color)] text-sm font-medium text-[var(--text-secondary)] hover:bg-[var(--color-base-alt)] transition"

--- a/frontend/src/pages/ExpensesPage.tsx
+++ b/frontend/src/pages/ExpensesPage.tsx
@@ -473,7 +473,7 @@ export default function ExpensesPage() {
   };
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-6 pb-20 md:pb-0">
       {/* Header */}
       <div className="flex items-center justify-between">
         <h1 className="text-2xl font-semibold text-[var(--text-primary)]">Gastos</h1>


### PR DESCRIPTION
## Summary

Collection of UX/UI improvements and fixes.

## Changes

### Compact Expense Modal
- Replaced DayPicker with native date input (YYYY-MM-DD ↔ DD-MM-YYYY)
- Description + Category in side-by-side grid
- 'Más opciones' collapsible toggle for Notas + Cuotas
- Reduced width (max-w-lg → max-w-md), spacing (space-y-4 → space-y-2.5)
- Removed DatePickerInput component and react-day-picker dependency

### Mobile Fix
- Added bottom padding on expenses page to avoid overlap with fixed bottom nav bar

### Backend Fixes
- Removed redundant force_password_change flag from startup (was re-flagging users on every restart)
- Added migrate_add_card_account_link to deploy.yml migration loop
- Ruff formatted accounts.py and cards.py