### PR TITLE
fix: DetailModal mobile positioning (centered, no bottom overlap)

### DIFF
--- a/frontend/src/components/DetailModal.tsx
+++ b/frontend/src/components/DetailModal.tsx
@@ -25,7 +25,7 @@ export function DetailModal({ isOpen, onClose, title, subtitle, children }: Deta
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-end sm:items-center justify-center p-0 sm:p-4 animate-modal-backdrop bg-black/60"
+      className="fixed inset-0 z-50 flex items-center justify-center p-4 animate-modal-backdrop bg-black/60"
       onClick={onClose}
     >
       <div
@@ -33,7 +33,7 @@ export function DetailModal({ isOpen, onClose, title, subtitle, children }: Deta
         role="dialog"
         aria-modal="true"
         aria-label={title}
-        className="relative bg-[var(--color-surface)] border border-[var(--border-color)] rounded-t-lg sm:rounded-lg shadow-xl w-full sm:max-w-lg max-h-[90vh] overflow-hidden flex flex-col animate-modal-content"
+        className="relative bg-[var(--color-surface)] border border-[var(--border-color)] rounded-lg shadow-xl w-full max-w-lg max-h-[90vh] overflow-hidden flex flex-col animate-modal-content"
         onClick={(e) => e.stopPropagation()}
       >
         <div className="flex items-center justify-between px-5 py-4 border-b border-[var(--border-color)]">


### PR DESCRIPTION
## Summary

Align DetailModal (expense preview) position with ExpenseModal (edit) on mobile.

## Problem

DetailModal used `items-end` on mobile (bottom sheet style), which overlapped with the fixed bottom nav bar. ExpenseModal used `items-center` (centered). Users saw different modal positions depending on which action they took.

## Fix

- Changed DetailModal from `items-end sm:items-center` to `items-center` (centered on all screens)
- Changed padding from `p-0 sm:p-4` to `p-4` (consistent on all screens)
- Removed `rounded-t-lg` (no longer a bottom sheet)

Both modals now appear centered vertically on mobile and desktop.