### PR TITLE
feat: AI auto-categorization + async bot + nightly suggestions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,15 @@ on:
       - "LICENSE"
       - ".gitignore"
   workflow_dispatch:
+    inputs:
+      action:
+        description: "What to run"
+        required: true
+        default: "full"
+        type: choice
+        options:
+          - full
+          - migrate-only
 
 permissions:
   contents: read
@@ -21,6 +30,7 @@ env:
 
 jobs:
   build-and-push:
+    if: github.event_name == 'push' || inputs.action == 'full'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -67,6 +77,7 @@ jobs:
   setup-server:
     runs-on: ubuntu-latest
     needs: build-and-push
+    if: always() && !cancelled() && (github.event_name == 'push' || inputs.action == 'full')
 
     steps:
       - name: Install podman and podman-compose
@@ -270,6 +281,7 @@ jobs:
   write-config:
     runs-on: ubuntu-latest
     needs: setup-server
+    if: always() && !cancelled() && (github.event_name == 'push' || inputs.action == 'full')
 
     steps:
       - name: Checkout
@@ -535,6 +547,7 @@ jobs:
   validate-config:
     runs-on: ubuntu-latest
     needs: write-config
+    if: always() && !cancelled() && (github.event_name == 'push' || inputs.action == 'full')
 
     steps:
       - name: Validate docker-compose syntax
@@ -572,6 +585,7 @@ jobs:
   pull-images:
     runs-on: ubuntu-latest
     needs: validate-config
+    if: always() && !cancelled() && (github.event_name == 'push' || inputs.action == 'full')
 
     steps:
       - name: Pull and verify images
@@ -607,6 +621,7 @@ jobs:
   backup-db:
     runs-on: ubuntu-latest
     needs: pull-images
+    if: always() && !cancelled()
 
     steps:
       - name: Backup database

--- a/backend/app/celery_schedule.py
+++ b/backend/app/celery_schedule.py
@@ -23,4 +23,8 @@ celery_app.conf.beat_schedule = {
         "task": "app.tasks.monthly_report.generate_monthly_reports",
         "schedule": crontab(hour=23, minute=0, day_of_month="1"),  # 20:00 UTC-3 = 23:00 UTC
     },
+    "suggest-uncategorized-categories-daily": {
+        "task": "app.tasks.suggest_uncategorized.suggest_uncategorized_categories",
+        "schedule": crontab(hour=2, minute=0),  # 23:00 UTC-3 = 02:00 UTC
+    },
 }

--- a/backend/app/prompts.py
+++ b/backend/app/prompts.py
@@ -137,3 +137,21 @@ Ejemplos:
 - Input: "Mastercard HSBC" → {{"card_name": "Mastercard", "bank": "HSBC"}}
 - Input: "Naranja" → {{"card_name": "Naranja", "bank": ""}}
 - Input: "Mi Visa" → {{"card_name": "Visa", "bank": ""}}"""
+
+
+CATEGORY_SUGGEST_PROMPT = """Sos un asistente que sugiere categorías de gastos personales.
+
+Categorías disponibles (formato: ID:N Padre > Hijo [palabras clave]):
+{formatted_categories}
+
+Transacción:
+- Descripción: {description}
+- Monto: {amount}
+
+Reglas:
+- Elegí la subcategoría más específica que aplique
+- Usá el NUMERO de ID (ej: ID:15), NO el nombre
+- Si ninguna categoría encaja, devolvé category_id: null
+- Respondé SOLO con JSON: {{"category_id": N, "confidence": 0.0-1.0}}
+
+Si no estás seguro (confidence < 0.5), devolvé {{"category_id": null, "confidence": 0.0}}"""

--- a/backend/app/routers/categories.py
+++ b/backend/app/routers/categories.py
@@ -1,11 +1,13 @@
 from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
 from app.database import get_db
 from app.models import Category, Expense, User
-from app.schemas import CategoryCreate, CategoryResponse
+from app.schemas import CategoryCreate, CategoryResponse, CategorySuggestRequest
 from app.seed import _apply_base_hierarchy_for_user
 from app.services.auth import get_current_user
+from app.services.categorization import llm_categorize
 
 router = APIRouter(prefix="/categories", tags=["categories"])
 
@@ -105,3 +107,21 @@ def seed_default_categories(
     db: Session = Depends(get_db), current_user: User = Depends(get_current_user)
 ):
     return _apply_base_hierarchy_for_user(db, current_user.id)
+
+
+class CategorySuggestResponse(BaseModel):
+    category_id: int
+    category_name: str
+    parent_name: str | None = None
+    confidence: float
+
+
+@router.post("/suggest", response_model=CategorySuggestResponse | None)
+def suggest_category(
+    body: CategorySuggestRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    cats = db.query(Category).filter(Category.user_id == current_user.id).all()
+    result = llm_categorize(body.description, body.amount, cats, current_user.id, db)
+    return result

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -150,6 +150,11 @@ class CategoryResponse(CategoryBase):
     model_config = {"from_attributes": True}
 
 
+class CategorySuggestRequest(BaseModel):
+    description: str
+    amount: float | None = None
+
+
 class AccountSimple(BaseModel):
     id: int
     name: str

--- a/backend/app/services/categorization.py
+++ b/backend/app/services/categorization.py
@@ -1,6 +1,13 @@
+import json
+import logging
+import os
+
+from google import genai
 from sqlalchemy.orm import Session
 
-from app.models import Category
+from app.models import Category, Setting
+
+logger = logging.getLogger(__name__)
 
 PAYMENT_SKIP_KEYWORDS = [
     "su pago en pesos",
@@ -95,3 +102,151 @@ def _resolve_category(db: Session, amount: float, description: str, cats: list) 
                 return cat.id
 
     return auto_categorize(description, cats)
+
+
+def _get_setting(db: Session, key: str, user_id: int) -> str | None:
+    row = db.query(Setting).filter(Setting.key == f"{user_id}:{key}").first()
+    return row.value if row else None
+
+
+def _build_formatted_categories(cats: list) -> str:
+    """Build formatted category list for the LLM prompt."""
+    children_map: dict[int | None, list[Category]] = {}
+    for cat in cats:
+        children_map.setdefault(cat.parent_id, []).append(cat)
+
+    lines = []
+    for parent in children_map.get(None, []):
+        children = children_map.get(parent.id, [])
+        for child in children:
+            kw = f" [{child.keywords}]" if child.keywords else ""
+            lines.append(f"- ID:{child.id} {parent.name} > {child.name}{kw}")
+    return "\n".join(lines)
+
+
+def _llm_client() -> genai.Client:
+    return genai.Client(api_key=os.getenv("LLM_API_KEY", ""))
+
+
+def _get_parent_name(cat: Category, categories: list) -> str:
+    """Get parent category name for a child category."""
+    if not cat.parent_id:
+        return ""
+    parent = next((c for c in categories if c.id == cat.parent_id), None)
+    return parent.name if parent else ""
+
+
+def llm_categorize(
+    description: str, amount: float | None, categories: list, user_id: int, db: Session,
+    temperature: float = 0.3,
+) -> dict | None:
+    """Use Gemini Flash to suggest a category. Falls back to keyword matching on failure."""
+    from app.prompts import CATEGORY_SUGGEST_PROMPT
+
+    _app_env = os.getenv("APP_ENV", "development")
+    debug = _app_env != "production" or os.getenv("DEBUG_CATEGORIZATION") == "1"
+
+    try:
+        enabled = _get_setting(db, "ai_suggestions_enabled", user_id)
+        if enabled == "false":
+            if debug:
+                logger.info("[AI-CAT] Disabled for user %s", user_id)
+            return None
+
+        min_confidence = float(_get_setting(db, "ai_suggestions_min_confidence", user_id) or "0.5")
+
+        formatted = _build_formatted_categories(categories)
+        if not formatted.strip():
+            if debug:
+                logger.info("[AI-CAT] No leaf categories found")
+            return None
+
+        amount_str = f"${amount:,.2f}" if amount is not None else "no especificado"
+        prompt = CATEGORY_SUGGEST_PROMPT.format(
+            formatted_categories=formatted,
+            description=description,
+            amount=amount_str,
+        )
+
+        if debug:
+            logger.info("[AI-CAT] Calling LLM: desc=%s, amount=%s", description, amount_str)
+
+        client = _llm_client()
+        response = client.models.generate_content(
+            model="gemini-flash-latest", contents=prompt,
+            config={"temperature": temperature},
+        )
+        text = response.text.strip()
+
+        # Extract JSON from response (handle markdown code blocks)
+        if "```" in text:
+            text = text.split("```")[1]
+            if text.startswith("json"):
+                text = text[4:]
+            text = text.strip()
+
+        data = json.loads(text)
+        category_id = data.get("category_id")
+        confidence = float(data.get("confidence", 0))
+
+        if debug:
+            logger.info("[AI-CAT] LLM response: id=%s, confidence=%.2f, min=%.2f", category_id, confidence, min_confidence)
+
+        if category_id is None or confidence < min_confidence:
+            if debug:
+                logger.info("[AI-CAT] Rejected: id=%s, confidence below threshold", category_id)
+            return None
+
+        # Validate category exists — try numeric ID first, then name fallback
+        cat = None
+        if isinstance(category_id, (int, float)):
+            cat = next((c for c in categories if c.id == int(category_id)), None)
+        elif isinstance(category_id, str):
+            # LLM sometimes returns the name instead of ID — try matching by name
+            cat = next((c for c in categories if c.name.lower() == category_id.lower()), None)
+            if not cat:
+                # Try "Parent > Child" format
+                cat = next(
+                    (c for c in categories if f"{_get_parent_name(c, categories)} > {c.name}".lower() == category_id.lower()),
+                    None,
+                )
+        if not cat:
+            if debug:
+                logger.info("[AI-CAT] Category id=%s not found in user categories", category_id)
+            return None
+
+        # Build hierarchy
+        parent_name = None
+        if cat.parent_id:
+            parent = next((c for c in categories if c.id == cat.parent_id), None)
+            parent_name = parent.name if parent else None
+
+        if debug:
+            logger.info("[AI-CAT] Accepted: %s > %s (%.2f)", parent_name or "?", cat.name, confidence)
+
+        return {
+            "category_id": cat.id,
+            "category_name": cat.name,
+            "parent_name": parent_name,
+            "confidence": confidence,
+        }
+    except Exception as e:
+        if debug:
+            logger.warning("[AI-CAT] LLM failed: %s — falling back to keywords", e)
+        else:
+            logger.debug("LLM categorization failed, falling back to keywords")
+        cat_id = auto_categorize(description, categories)
+        if cat_id:
+            cat = next((c for c in categories if c.id == cat_id), None)
+            if cat:
+                parent_name = None
+                if cat.parent_id:
+                    parent = next((c for c in categories if c.id == cat.parent_id), None)
+                    parent_name = parent.name if parent else None
+                return {
+                    "category_id": cat.id,
+                    "category_name": cat.name,
+                    "parent_name": parent_name,
+                    "confidence": 1.0,
+                }
+        return None

--- a/backend/app/services/categorization.py
+++ b/backend/app/services/categorization.py
@@ -137,7 +137,11 @@ def _get_parent_name(cat: Category, categories: list) -> str:
 
 
 def llm_categorize(
-    description: str, amount: float | None, categories: list, user_id: int, db: Session,
+    description: str,
+    amount: float | None,
+    categories: list,
+    user_id: int,
+    db: Session,
     temperature: float = 0.3,
 ) -> dict | None:
     """Use Gemini Flash to suggest a category. Falls back to keyword matching on failure."""
@@ -173,7 +177,8 @@ def llm_categorize(
 
         client = _llm_client()
         response = client.models.generate_content(
-            model="gemini-flash-latest", contents=prompt,
+            model="gemini-flash-latest",
+            contents=prompt,
             config={"temperature": temperature},
         )
         text = response.text.strip()
@@ -190,7 +195,12 @@ def llm_categorize(
         confidence = float(data.get("confidence", 0))
 
         if debug:
-            logger.info("[AI-CAT] LLM response: id=%s, confidence=%.2f, min=%.2f", category_id, confidence, min_confidence)
+            logger.info(
+                "[AI-CAT] LLM response: id=%s, confidence=%.2f, min=%.2f",
+                category_id,
+                confidence,
+                min_confidence,
+            )
 
         if category_id is None or confidence < min_confidence:
             if debug:
@@ -207,7 +217,12 @@ def llm_categorize(
             if not cat:
                 # Try "Parent > Child" format
                 cat = next(
-                    (c for c in categories if f"{_get_parent_name(c, categories)} > {c.name}".lower() == category_id.lower()),
+                    (
+                        c
+                        for c in categories
+                        if f"{_get_parent_name(c, categories)} > {c.name}".lower()
+                        == category_id.lower()
+                    ),
                     None,
                 )
         if not cat:
@@ -222,7 +237,9 @@ def llm_categorize(
             parent_name = parent.name if parent else None
 
         if debug:
-            logger.info("[AI-CAT] Accepted: %s > %s (%.2f)", parent_name or "?", cat.name, confidence)
+            logger.info(
+                "[AI-CAT] Accepted: %s > %s (%.2f)", parent_name or "?", cat.name, confidence
+            )
 
         return {
             "category_id": cat.id,

--- a/backend/app/tasks/__init__.py
+++ b/backend/app/tasks/__init__.py
@@ -1,1 +1,8 @@
-# Tasks package
+# Tasks package — import all task modules so celery autodiscovers them
+import app.tasks.cleanup_import_jobs  # noqa: F401
+import app.tasks.daily_uncategorized  # noqa: F401
+import app.tasks.import_processor  # noqa: F401
+import app.tasks.monthly_report  # noqa: F401
+import app.tasks.scheduled_expenses  # noqa: F401
+import app.tasks.suggest_uncategorized  # noqa: F401
+import app.tasks.weekly_summary  # noqa: F401

--- a/backend/app/tasks/suggest_uncategorized.py
+++ b/backend/app/tasks/suggest_uncategorized.py
@@ -25,6 +25,7 @@ def suggest_uncategorized_categories():
         for user in users:
             # Skip if AI suggestions are disabled for this user
             from app.services.categorization import _get_setting
+
             enabled = _get_setting(db, "ai_suggestions_enabled", user.id)
             if enabled == "false":
                 continue
@@ -44,6 +45,7 @@ def suggest_uncategorized_categories():
 
             # Get uncategorized expenses from last 30 days
             from datetime import date, timedelta
+
             cutoff = date.today() - timedelta(days=30)
             expenses = (
                 db.query(Expense)
@@ -59,6 +61,7 @@ def suggest_uncategorized_categories():
 
             # Get user categories
             from app.models import Category
+
             cats = db.query(Category).filter(Category.user_id == user.id).all()
             if not cats:
                 continue
@@ -67,20 +70,26 @@ def suggest_uncategorized_categories():
             suggestions = []
             for exp in expenses:
                 result = llm_categorize(
-                    exp.description, exp.amount, cats, user.id, db,
+                    exp.description,
+                    exp.amount,
+                    cats,
+                    user.id,
+                    db,
                     temperature=0.7,
                 )
                 if result and result["confidence"] >= 0.4:
-                    suggestions.append({
-                        "expense_id": exp.id,
-                        "description": exp.description,
-                        "amount": exp.amount,
-                        "date": exp.date.isoformat(),
-                        "suggested_category_id": result["category_id"],
-                        "category_name": result["category_name"],
-                        "parent_name": result.get("parent_name"),
-                        "confidence": round(result["confidence"], 2),
-                    })
+                    suggestions.append(
+                        {
+                            "expense_id": exp.id,
+                            "description": exp.description,
+                            "amount": exp.amount,
+                            "date": exp.date.isoformat(),
+                            "suggested_category_id": result["category_id"],
+                            "category_name": result["category_name"],
+                            "parent_name": result.get("parent_name"),
+                            "confidence": round(result["confidence"], 2),
+                        }
+                    )
 
             if not suggestions:
                 continue

--- a/backend/app/tasks/suggest_uncategorized.py
+++ b/backend/app/tasks/suggest_uncategorized.py
@@ -1,0 +1,107 @@
+"""Daily task to suggest categories for uncategorized expenses using AI."""
+
+import json
+import logging
+
+from app.celery_app import celery_app
+from app.database import SessionLocal
+from app.models import Expense, Notification, User
+from app.services.categorization import llm_categorize
+
+logger = logging.getLogger(__name__)
+
+
+@celery_app.task(name="app.tasks.suggest_uncategorized.suggest_uncategorized_categories")
+def suggest_uncategorized_categories():
+    """Find uncategorized expenses and suggest categories via LLM (high temperature).
+
+    Creates in-app notifications with suggestions — does NOT modify expenses.
+    """
+    db = SessionLocal()
+    try:
+        users = db.query(User).filter(User.is_active == True).all()  # noqa: E712
+        total_users_notified = 0
+
+        for user in users:
+            # Skip if AI suggestions are disabled for this user
+            from app.services.categorization import _get_setting
+            enabled = _get_setting(db, "ai_suggestions_enabled", user.id)
+            if enabled == "false":
+                continue
+
+            # Skip if unread suggestion notification already exists
+            existing = (
+                db.query(Notification)
+                .filter(
+                    Notification.user_id == user.id,
+                    Notification.type == "category_suggestions",
+                    Notification.read == False,  # noqa: E712
+                )
+                .first()
+            )
+            if existing:
+                continue
+
+            # Get uncategorized expenses from last 30 days
+            from datetime import date, timedelta
+            cutoff = date.today() - timedelta(days=30)
+            expenses = (
+                db.query(Expense)
+                .filter(
+                    Expense.user_id == user.id,
+                    Expense.category_id.is_(None),
+                    Expense.date >= cutoff,
+                )
+                .all()
+            )
+            if not expenses:
+                continue
+
+            # Get user categories
+            from app.models import Category
+            cats = db.query(Category).filter(Category.user_id == user.id).all()
+            if not cats:
+                continue
+
+            # Suggest categories for each expense (high temperature for ambiguous descriptions)
+            suggestions = []
+            for exp in expenses:
+                result = llm_categorize(
+                    exp.description, exp.amount, cats, user.id, db,
+                    temperature=0.7,
+                )
+                if result and result["confidence"] >= 0.4:
+                    suggestions.append({
+                        "expense_id": exp.id,
+                        "description": exp.description,
+                        "amount": exp.amount,
+                        "date": exp.date.isoformat(),
+                        "suggested_category_id": result["category_id"],
+                        "category_name": result["category_name"],
+                        "parent_name": result.get("parent_name"),
+                        "confidence": round(result["confidence"], 2),
+                    })
+
+            if not suggestions:
+                continue
+
+            # Create single notification with all suggestions
+            count = len(suggestions)
+            notification = Notification(
+                user_id=user.id,
+                type="category_suggestions",
+                title=f"✨ {count} gasto{'s' if count != 1 else ''} sugieren categorías",
+                body="La IA encontró categorías sugeridas para gastos sin clasificar.",
+                data=json.dumps({"suggestions": suggestions, "count": count}),
+                read=False,
+            )
+            db.add(notification)
+            total_users_notified += 1
+
+        db.commit()
+        logger.info(f"Suggest uncategorized: notified {total_users_notified}/{len(users)} users")
+    except Exception as e:
+        logger.error(f"Suggest uncategorized task failed: {e}")
+        db.rollback()
+    finally:
+        db.close()

--- a/backend/app/telegram_bot.py
+++ b/backend/app/telegram_bot.py
@@ -148,8 +148,18 @@ def _save_expense(
             category_id = predicted_category_id
         else:
             cats = db.query(Category).all()
-            result = llm_categorize(parsed.get("description", ""), parsed.get("amount"), cats, user_id, db) if user_id else None
-            category_id = result["category_id"] if result else auto_categorize(parsed.get("description", ""), cats)
+            result = (
+                llm_categorize(
+                    parsed.get("description", ""), parsed.get("amount"), cats, user_id, db
+                )
+                if user_id
+                else None
+            )
+            category_id = (
+                result["category_id"]
+                if result
+                else auto_categorize(parsed.get("description", ""), cats)
+            )
 
         raw_date = parsed.get("date") or date.today().strftime("%Y-%m-%d")
         try:
@@ -265,7 +275,9 @@ def _build_cat_levels(category_id: int | None, db) -> list[str]:
     return list(reversed(levels))
 
 
-def _confirm_text(parsed: dict, payment_label: str, cat_levels: list[str] = None, debug_info: str = "") -> str:
+def _confirm_text(
+    parsed: dict, payment_label: str, cat_levels: list[str] = None, debug_info: str = ""
+) -> str:
     desc = _escape_md(parsed.get("description", ""))
     amount_str = _format_amount(parsed["amount"], parsed.get("currency", "ARS"))
     date_str = _format_date_es(parsed.get("date", date.today().strftime("%Y-%m-%d")))
@@ -323,7 +335,12 @@ async def _enhance_with_llm(
     """Run LLM in background thread, update confirmation message if better category found."""
     try:
         result = await asyncio.to_thread(
-            llm_categorize, parsed.get("description", ""), parsed.get("amount"), cats, user_id, SessionLocal()
+            llm_categorize,
+            parsed.get("description", ""),
+            parsed.get("amount"),
+            cats,
+            user_id,
+            SessionLocal(),
         )
         if not result or result["category_id"] == current_cat_id:
             return
@@ -341,7 +358,9 @@ async def _enhance_with_llm(
             ]
         ]
         await _bot_app.bot.edit_message_text(
-            _confirm_text(parsed, payment_label, cat_levels, context.user_data.get("cat_debug", "")),
+            _confirm_text(
+                parsed, payment_label, cat_levels, context.user_data.get("cat_debug", "")
+            ),
             chat_id=chat_id,
             message_id=message_id,
             parse_mode="Markdown",
@@ -849,11 +868,18 @@ async def handle_card_type(update: Update, context: ContextTypes.DEFAULT_TYPE) -
                 reply_markup=InlineKeyboardMarkup(confirm_keyboard),
             )
             # Fire LLM in background to upgrade category if possible
-            asyncio.create_task(_enhance_with_llm(
-                query.message.chat_id, query.message.message_id,
-                parsed, context.user_data["user_id"], cats,
-                predicted_category_id, label, context,
-            ))
+            asyncio.create_task(
+                _enhance_with_llm(
+                    query.message.chat_id,
+                    query.message.message_id,
+                    parsed,
+                    context.user_data["user_id"],
+                    cats,
+                    predicted_category_id,
+                    label,
+                    context,
+                )
+            )
             return WAITING_CONFIRM
     finally:
         db.close()
@@ -885,8 +911,12 @@ async def handle_installment_question(update: Update, context: ContextTypes.DEFA
             ]
         ]
         await query.edit_message_text(
-            _confirm_text(context.user_data["parsed"], payment_label, cat_levels,
-                          context.user_data.get("cat_debug", "")),
+            _confirm_text(
+                context.user_data["parsed"],
+                payment_label,
+                cat_levels,
+                context.user_data.get("cat_debug", ""),
+            ),
             parse_mode="Markdown",
             reply_markup=InlineKeyboardMarkup(confirm_keyboard),
         )
@@ -936,7 +966,12 @@ async def handle_installment_number(update: Update, context: ContextTypes.DEFAUL
     ]
 
     await update.message.reply_text(
-        _confirm_text(context.user_data["parsed"], payment_label, cat_levels, context.user_data.get("cat_debug", "")),
+        _confirm_text(
+            context.user_data["parsed"],
+            payment_label,
+            cat_levels,
+            context.user_data.get("cat_debug", ""),
+        ),
         parse_mode="Markdown",
         reply_markup=InlineKeyboardMarkup(confirm_keyboard),
     )
@@ -1007,11 +1042,18 @@ async def handle_account_select(update: Update, context: ContextTypes.DEFAULT_TY
         reply_markup=InlineKeyboardMarkup(confirm_keyboard),
     )
     # Fire LLM in background
-    asyncio.create_task(_enhance_with_llm(
-        query.message.chat_id, query.message.message_id,
-        parsed, context.user_data["user_id"], cats,
-        predicted_category_id, context.user_data["payment_label"], context,
-    ))
+    asyncio.create_task(
+        _enhance_with_llm(
+            query.message.chat_id,
+            query.message.message_id,
+            parsed,
+            context.user_data["user_id"],
+            cats,
+            predicted_category_id,
+            context.user_data["payment_label"],
+            context,
+        )
+    )
     return WAITING_CONFIRM
 
 
@@ -1085,11 +1127,18 @@ async def handle_account_create_type(update: Update, context: ContextTypes.DEFAU
         reply_markup=InlineKeyboardMarkup(confirm_keyboard),
     )
     # Fire LLM in background
-    asyncio.create_task(_enhance_with_llm(
-        query.message.chat_id, query.message.message_id,
-        parsed, context.user_data["user_id"], cats,
-        predicted_category_id, context.user_data["payment_label"], context,
-    ))
+    asyncio.create_task(
+        _enhance_with_llm(
+            query.message.chat_id,
+            query.message.message_id,
+            parsed,
+            context.user_data["user_id"],
+            cats,
+            predicted_category_id,
+            context.user_data["payment_label"],
+            context,
+        )
+    )
     return WAITING_CONFIRM
 
 
@@ -1290,11 +1339,18 @@ async def handle_card_create_confirm(update: Update, context: ContextTypes.DEFAU
                 reply_markup=InlineKeyboardMarkup(confirm_keyboard),
             )
             # Fire LLM in background
-            asyncio.create_task(_enhance_with_llm(
-                query.message.chat_id, query.message.message_id,
-                parsed, context.user_data["user_id"], cats,
-                predicted_category_id, context.user_data["payment_label"], context,
-            ))
+            asyncio.create_task(
+                _enhance_with_llm(
+                    query.message.chat_id,
+                    query.message.message_id,
+                    parsed,
+                    context.user_data["user_id"],
+                    cats,
+                    predicted_category_id,
+                    context.user_data["payment_label"],
+                    context,
+                )
+            )
             return WAITING_CONFIRM
     finally:
         db.close()
@@ -1455,11 +1511,18 @@ async def handle_card_manual(update: Update, context: ContextTypes.DEFAULT_TYPE)
                 reply_markup=InlineKeyboardMarkup(confirm_keyboard),
             )
             # Fire LLM in background
-            asyncio.create_task(_enhance_with_llm(
-                confirm_msg.chat_id, confirm_msg.message_id,
-                parsed, context.user_data["user_id"], cats,
-                predicted_category_id, label, context,
-            ))
+            asyncio.create_task(
+                _enhance_with_llm(
+                    confirm_msg.chat_id,
+                    confirm_msg.message_id,
+                    parsed,
+                    context.user_data["user_id"],
+                    cats,
+                    predicted_category_id,
+                    label,
+                    context,
+                )
+            )
             return WAITING_CONFIRM
     finally:
         db.close()

--- a/backend/app/telegram_bot.py
+++ b/backend/app/telegram_bot.py
@@ -21,10 +21,13 @@ from telegram.ext import (
 from app.database import SessionLocal
 from app.models import Account, Card, Category, Expense, User
 from app.prompts import CARD_EXTRACT_PROMPT, EXPENSE_PARSE_PROMPT
-from app.services.categorization import auto_categorize
+from app.services.categorization import auto_categorize, llm_categorize
 from app.services.import_utils import _normalize_text
 
 logger = logging.getLogger(__name__)
+
+APP_ENV = os.getenv("APP_ENV", "development")
+DEBUG_CAT = APP_ENV != "production" or os.getenv("DEBUG_CATEGORIZATION") == "1"
 
 # Module-level bot app reference for proactive messaging from web
 _bot_app: Application | None = None
@@ -145,7 +148,8 @@ def _save_expense(
             category_id = predicted_category_id
         else:
             cats = db.query(Category).all()
-            category_id = auto_categorize(parsed.get("description", ""), cats)
+            result = llm_categorize(parsed.get("description", ""), parsed.get("amount"), cats, user_id, db) if user_id else None
+            category_id = result["category_id"] if result else auto_categorize(parsed.get("description", ""), cats)
 
         raw_date = parsed.get("date") or date.today().strftime("%Y-%m-%d")
         try:
@@ -261,7 +265,7 @@ def _build_cat_levels(category_id: int | None, db) -> list[str]:
     return list(reversed(levels))
 
 
-def _confirm_text(parsed: dict, payment_label: str, cat_levels: list[str] = None) -> str:
+def _confirm_text(parsed: dict, payment_label: str, cat_levels: list[str] = None, debug_info: str = "") -> str:
     desc = _escape_md(parsed.get("description", ""))
     amount_str = _format_amount(parsed["amount"], parsed.get("currency", "ARS"))
     date_str = _format_date_es(parsed.get("date", date.today().strftime("%Y-%m-%d")))
@@ -272,6 +276,7 @@ def _confirm_text(parsed: dict, payment_label: str, cat_levels: list[str] = None
         for i, name in enumerate(cat_levels):
             indent = indents[i] if i < len(indents) else indents[-1]
             cat_tree += f"{indent}{_cat_emoji(name)} {name}\n"
+    debug_line = f"\n`{debug_info}`" if debug_info else ""
     return (
         f"Esto es lo que voy a guardar:\n\n"
         f"🛒 *{desc}*\n"
@@ -279,8 +284,71 @@ def _confirm_text(parsed: dict, payment_label: str, cat_levels: list[str] = None
         f"📅 {date_str}\n"
         f"💳 {safe_label}\n"
         f"{cat_tree}"
+        f"{debug_line}"
         f"\n¿Lo guardamos?"
     )
+
+
+def _cat_debug_str(result: dict | None, description: str, categories: list) -> str:
+    """Build debug info string for confirmation text when DEBUG_CATEGORIZATION=1."""
+    if not DEBUG_CAT:
+        return ""
+    if result:
+        parent = result.get("parent_name") or "?"
+        return f"AI: {parent} > {result['category_name']} ({result['confidence']:.0%})"
+    kw_id = auto_categorize(description, categories)
+    if kw_id:
+        cat = next((c for c in categories if c.id == kw_id), None)
+        return f"KW: {cat.name}" if cat else "KW fallback"
+    return "sin categoria"
+
+
+def _instant_categorize(parsed: dict, user_id: int, db) -> tuple[int | None, list]:
+    """Keyword-only categorization (instant). Returns (category_id, categories_list)."""
+    cats = db.query(Category).filter(Category.user_id == user_id).all()
+    cat_id = auto_categorize(parsed.get("description", ""), cats)
+    return cat_id, cats
+
+
+async def _enhance_with_llm(
+    chat_id: int,
+    message_id: int,
+    parsed: dict,
+    user_id: int,
+    cats: list,
+    current_cat_id: int | None,
+    payment_label: str,
+    context,
+):
+    """Run LLM in background thread, update confirmation message if better category found."""
+    try:
+        result = await asyncio.to_thread(
+            llm_categorize, parsed.get("description", ""), parsed.get("amount"), cats, user_id, SessionLocal()
+        )
+        if not result or result["category_id"] == current_cat_id:
+            return
+
+        # Update stored data so _save_expense uses the better category
+        context.user_data["predicted_category_id"] = result["category_id"]
+        context.user_data["llm_result"] = result
+        context.user_data["cat_debug"] = _cat_debug_str(result, parsed.get("description", ""), cats)
+
+        cat_levels = _build_cat_levels(result["category_id"], SessionLocal())
+        confirm_keyboard = [
+            [
+                InlineKeyboardButton("✅ Sí, guardar", callback_data="confirm:yes"),
+                InlineKeyboardButton("❌ Cancelar", callback_data="confirm:no"),
+            ]
+        ]
+        await _bot_app.bot.edit_message_text(
+            _confirm_text(parsed, payment_label, cat_levels, context.user_data.get("cat_debug", "")),
+            chat_id=chat_id,
+            message_id=message_id,
+            parse_mode="Markdown",
+            reply_markup=InlineKeyboardMarkup(confirm_keyboard),
+        )
+    except Exception:
+        pass  # Message already edited by user confirming, or Telegram error
 
 
 _CAT_EMOJI: dict[str, str] = {
@@ -749,9 +817,9 @@ async def handle_card_type(update: Update, context: ContextTypes.DEFAULT_TYPE) -
     parsed = context.user_data["parsed"]
     db = SessionLocal()
     try:
-        cats = db.query(Category).all()
-        predicted_category_id = auto_categorize(parsed.get("description", ""), cats)
+        predicted_category_id, cats = _instant_categorize(parsed, context.user_data["user_id"], db)
         context.user_data["predicted_category_id"] = predicted_category_id
+        context.user_data["cat_debug"] = ""
 
         # Check if we should ask about installments
         if _should_ask_installments(predicted_category_id, db):
@@ -780,6 +848,12 @@ async def handle_card_type(update: Update, context: ContextTypes.DEFAULT_TYPE) -
                 parse_mode="Markdown",
                 reply_markup=InlineKeyboardMarkup(confirm_keyboard),
             )
+            # Fire LLM in background to upgrade category if possible
+            asyncio.create_task(_enhance_with_llm(
+                query.message.chat_id, query.message.message_id,
+                parsed, context.user_data["user_id"], cats,
+                predicted_category_id, label, context,
+            ))
             return WAITING_CONFIRM
     finally:
         db.close()
@@ -811,7 +885,8 @@ async def handle_installment_question(update: Update, context: ContextTypes.DEFA
             ]
         ]
         await query.edit_message_text(
-            _confirm_text(context.user_data["parsed"], payment_label, cat_levels),
+            _confirm_text(context.user_data["parsed"], payment_label, cat_levels,
+                          context.user_data.get("cat_debug", "")),
             parse_mode="Markdown",
             reply_markup=InlineKeyboardMarkup(confirm_keyboard),
         )
@@ -861,7 +936,7 @@ async def handle_installment_number(update: Update, context: ContextTypes.DEFAUL
     ]
 
     await update.message.reply_text(
-        _confirm_text(context.user_data["parsed"], payment_label, cat_levels),
+        _confirm_text(context.user_data["parsed"], payment_label, cat_levels, context.user_data.get("cat_debug", "")),
         parse_mode="Markdown",
         reply_markup=InlineKeyboardMarkup(confirm_keyboard),
     )
@@ -910,11 +985,11 @@ async def handle_account_select(update: Update, context: ContextTypes.DEFAULT_TY
         context.user_data["account_id"] = account.id
         context.user_data["payment_label"] = f"{account.name} ({account.type})"
 
-        # Auto-categorize for cash/transfer expenses
+        # Instant keyword categorization
         parsed = context.user_data["parsed"]
-        cats = db.query(Category).all()
-        predicted_category_id = auto_categorize(parsed.get("description", ""), cats)
+        predicted_category_id, cats = _instant_categorize(parsed, context.user_data["user_id"], db)
         context.user_data["predicted_category_id"] = predicted_category_id
+        context.user_data["cat_debug"] = ""
         cat_levels = _build_cat_levels(predicted_category_id, db)
     finally:
         db.close()
@@ -931,6 +1006,12 @@ async def handle_account_select(update: Update, context: ContextTypes.DEFAULT_TY
         parse_mode="Markdown",
         reply_markup=InlineKeyboardMarkup(confirm_keyboard),
     )
+    # Fire LLM in background
+    asyncio.create_task(_enhance_with_llm(
+        query.message.chat_id, query.message.message_id,
+        parsed, context.user_data["user_id"], cats,
+        predicted_category_id, context.user_data["payment_label"], context,
+    ))
     return WAITING_CONFIRM
 
 
@@ -982,11 +1063,11 @@ async def handle_account_create_type(update: Update, context: ContextTypes.DEFAU
         context.user_data["account_id"] = new_account.id
         context.user_data["payment_label"] = f"{new_account.name} ({new_account.type})"
 
-        # Auto-categorize for cash/transfer expenses
+        # Instant keyword categorization
         parsed = context.user_data["parsed"]
-        cats = db.query(Category).all()
-        predicted_category_id = auto_categorize(parsed.get("description", ""), cats)
+        predicted_category_id, cats = _instant_categorize(parsed, context.user_data["user_id"], db)
         context.user_data["predicted_category_id"] = predicted_category_id
+        context.user_data["cat_debug"] = ""
         cat_levels = _build_cat_levels(predicted_category_id, db)
     finally:
         db.close()
@@ -1003,6 +1084,12 @@ async def handle_account_create_type(update: Update, context: ContextTypes.DEFAU
         parse_mode="Markdown",
         reply_markup=InlineKeyboardMarkup(confirm_keyboard),
     )
+    # Fire LLM in background
+    asyncio.create_task(_enhance_with_llm(
+        query.message.chat_id, query.message.message_id,
+        parsed, context.user_data["user_id"], cats,
+        predicted_category_id, context.user_data["payment_label"], context,
+    ))
     return WAITING_CONFIRM
 
 
@@ -1171,9 +1258,9 @@ async def handle_card_create_confirm(update: Update, context: ContextTypes.DEFAU
         context.user_data["card_id"] = new_card.id
 
         parsed = context.user_data["parsed"]
-        cats = db.query(Category).all()
-        predicted_category_id = auto_categorize(parsed.get("description", ""), cats)
+        predicted_category_id, cats = _instant_categorize(parsed, context.user_data["user_id"], db)
         context.user_data["predicted_category_id"] = predicted_category_id
+        context.user_data["cat_debug"] = ""
 
         if _should_ask_installments(predicted_category_id, db):
             installment_keyboard = [
@@ -1202,6 +1289,12 @@ async def handle_card_create_confirm(update: Update, context: ContextTypes.DEFAU
                 parse_mode="Markdown",
                 reply_markup=InlineKeyboardMarkup(confirm_keyboard),
             )
+            # Fire LLM in background
+            asyncio.create_task(_enhance_with_llm(
+                query.message.chat_id, query.message.message_id,
+                parsed, context.user_data["user_id"], cats,
+                predicted_category_id, context.user_data["payment_label"], context,
+            ))
             return WAITING_CONFIRM
     finally:
         db.close()
@@ -1332,9 +1425,9 @@ async def handle_card_manual(update: Update, context: ContextTypes.DEFAULT_TYPE)
     parsed = context.user_data["parsed"]
     db = SessionLocal()
     try:
-        cats = db.query(Category).all()
-        predicted_category_id = auto_categorize(parsed.get("description", ""), cats)
+        predicted_category_id, cats = _instant_categorize(parsed, context.user_data["user_id"], db)
         context.user_data["predicted_category_id"] = predicted_category_id
+        context.user_data["cat_debug"] = ""
 
         if _should_ask_installments(predicted_category_id, db):
             installment_keyboard = [
@@ -1356,11 +1449,17 @@ async def handle_card_manual(update: Update, context: ContextTypes.DEFAULT_TYPE)
                     InlineKeyboardButton("❌ Cancelar", callback_data="confirm:no"),
                 ]
             ]
-            await update.message.reply_text(
+            confirm_msg = await update.message.reply_text(
                 _confirm_text(parsed, label, cat_levels),
                 parse_mode="Markdown",
                 reply_markup=InlineKeyboardMarkup(confirm_keyboard),
             )
+            # Fire LLM in background
+            asyncio.create_task(_enhance_with_llm(
+                confirm_msg.chat_id, confirm_msg.message_id,
+                parsed, context.user_data["user_id"], cats,
+                predicted_category_id, label, context,
+            ))
             return WAITING_CONFIRM
     finally:
         db.close()

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -5,6 +5,7 @@ import type {
   AuthToken,
   User,
   Category,
+  CategorySuggestion,
   Expense,
   ExpenseCreate,
   DashboardSummary,
@@ -105,6 +106,9 @@ export const updateCategory = (id: number, data: Omit<Category, "id">) =>
   api.put<Category>(`/categories/${id}`, data).then((r) => r.data);
 
 export const deleteCategory = (id: number) => api.delete(`/categories/${id}`).then((r) => r.data);
+
+export const suggestCategory = (data: { description: string; amount?: number }) =>
+  api.post<CategorySuggestion | null>("/categories/suggest", data).then((r) => r.data);
 
 // Expenses
 export const getExpenses = (params?: {

--- a/frontend/src/components/ExpenseModals.tsx
+++ b/frontend/src/components/ExpenseModals.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { getCategories, getAccounts, getCards, createCategory } from "../api/client";
+import { getCategories, getAccounts, getCards, createCategory, suggestCategory } from "../api/client";
 import type { Expense, ExpenseCreate, Card } from "../types";
 import { Select } from "./ui/Select";
 import CardAccountModal from "./CardAccountModal";
@@ -82,6 +82,8 @@ export function ExpenseModal({
     return () => document.removeEventListener("keydown", handleEscape);
   }, [onClose]);
 
+  const [aiSuggested, setAiSuggested] = useState(false);
+
   const isCash = (cardId: number | null | undefined) => !cardId;
   const lastPayment = getLastUsedPayment();
   const isInstallmentsOnly = mode === "installments-only";
@@ -121,6 +123,44 @@ export function ExpenseModal({
   const [cuotasEnabled, setCuotasEnabled] = useState(
     isInstallmentsOnly || !!(initial?.installment_total && initial.installment_total > 1),
   );
+
+  // Local keyword matching — instant, no API cost
+  const keywordMatch = (desc: string): number | null => {
+    const lower = desc.toLowerCase();
+    const leafIds = new Set(categories.filter((c) => !categories.some((ch) => ch.parent_id === c.id)).map((c) => c.id));
+    for (const cat of categories) {
+      if (!leafIds.has(cat.id) || !cat.keywords) continue;
+      for (const kw of cat.keywords.split(",")) {
+        if (kw.trim() && lower.includes(kw.trim().toLowerCase())) return cat.id;
+      }
+    }
+    return null;
+  };
+
+  // Real-time keyword pre-fill as user types
+  useEffect(() => {
+    const desc = initial?.description ?? form.description;
+    if (!desc || desc.length < 3 || initial?.category_id || form.category_id) return;
+    const match = keywordMatch(desc);
+    if (match) {
+      setForm((f) => ({ ...f, category_id: match }));
+      setAiSuggested(false);
+    }
+  }, [form.description]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // One-shot LLM pre-fill on mount (upgrade keyword match if possible)
+  useEffect(() => {
+    const desc = initial?.description ?? form.description;
+    if (!desc || desc.length < 3 || initial?.category_id) return;
+    suggestCategory({ description: desc, amount: form.amount || undefined })
+      .then((res) => {
+        if (res?.category_id) {
+          setForm((f) => ({ ...f, category_id: res.category_id }));
+          setAiSuggested(true);
+        }
+      })
+      .catch(() => {});
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Generate installment group ID on mount for installments-only mode
   useEffect(() => {
@@ -338,7 +378,14 @@ export function ExpenseModal({
             />
           </div>
           <div>
-            <label className="text-xs font-medium text-[var(--text-secondary)]">Categoría</label>
+            <label className="text-xs font-medium text-[var(--text-secondary)]">
+              Categoría
+              {aiSuggested && (
+                <span className="ml-1.5 text-[10px] font-normal text-[var(--color-primary)] bg-[var(--color-primary)]/10 px-1.5 py-0.5 rounded-full">
+                  IA
+                </span>
+              )}
+            </label>
             <Select
               value={form.category_id ? String(form.category_id) : ""}
               onChange={async (v) => {

--- a/frontend/src/components/ExpenseModals.tsx
+++ b/frontend/src/components/ExpenseModals.tsx
@@ -1,6 +1,12 @@
 import { useState, useEffect } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { getCategories, getAccounts, getCards, createCategory, suggestCategory } from "../api/client";
+import {
+  getCategories,
+  getAccounts,
+  getCards,
+  createCategory,
+  suggestCategory,
+} from "../api/client";
 import type { Expense, ExpenseCreate, Card } from "../types";
 import { Select } from "./ui/Select";
 import CardAccountModal from "./CardAccountModal";
@@ -127,7 +133,9 @@ export function ExpenseModal({
   // Local keyword matching — instant, no API cost
   const keywordMatch = (desc: string): number | null => {
     const lower = desc.toLowerCase();
-    const leafIds = new Set(categories.filter((c) => !categories.some((ch) => ch.parent_id === c.id)).map((c) => c.id));
+    const leafIds = new Set(
+      categories.filter((c) => !categories.some((ch) => ch.parent_id === c.id)).map((c) => c.id),
+    );
     for (const cat of categories) {
       if (!leafIds.has(cat.id) || !cat.keywords) continue;
       for (const kw of cat.keywords.split(",")) {

--- a/frontend/src/components/NotificationsPanel.tsx
+++ b/frontend/src/components/NotificationsPanel.tsx
@@ -468,9 +468,7 @@ export default function NotificationsPanel({ onClose }: Props) {
                           <circle cx="8" cy="12" r="0.75" fill="currentColor" />
                         </svg>
                       )}
-                      {isCategorySuggestion && (
-                        <span className="text-sm">✨</span>
-                      )}
+                      {isCategorySuggestion && <span className="text-sm">✨</span>}
                       {n.type === "monthly_report_ready" && (
                         <svg
                           width="16"

--- a/frontend/src/components/NotificationsPanel.tsx
+++ b/frontend/src/components/NotificationsPanel.tsx
@@ -119,6 +119,10 @@ export default function NotificationsPanel({ onClose }: Props) {
         downloadReportPdf(n.data.month as string);
       }
       onClose();
+    } else if (n.type === "category_suggestions") {
+      handleMarkRead(n.id);
+      navigate("/expenses?category_suggestions=1");
+      onClose();
     }
   };
 
@@ -344,9 +348,11 @@ export default function NotificationsPanel({ onClose }: Props) {
             const isImportNotif = n.type === "import_ready" || n.type === "import_failed";
             const isUncategorizedNotif =
               n.type === "uncategorized_expense" || n.type === "uncategorized_expenses";
+            const isCategorySuggestion = n.type === "category_suggestions";
             const isClickable =
               isImportNotif ||
               isUncategorizedNotif ||
+              isCategorySuggestion ||
               n.type === "monthly_report_ready" ||
               n.type === "monthly_report_queued";
             const isFailed = n.type === "import_failed";
@@ -368,6 +374,8 @@ export default function NotificationsPanel({ onClose }: Props) {
                     ? "border-l-4 " + (isFailed ? "border-l-red-500" : "border-l-green-500")
                     : ""
                 } ${isUncategorizedNotif ? "border-l-4 border-l-amber-500" : ""} ${
+                  isCategorySuggestion ? "border-l-4 border-l-purple-500" : ""
+                } ${
                   n.type === "monthly_report_ready" || n.type === "monthly_report_queued"
                     ? "border-l-4 border-l-blue-500"
                     : ""
@@ -459,6 +467,9 @@ export default function NotificationsPanel({ onClose }: Props) {
                           />
                           <circle cx="8" cy="12" r="0.75" fill="currentColor" />
                         </svg>
+                      )}
+                      {isCategorySuggestion && (
+                        <span className="text-sm">✨</span>
                       )}
                       {n.type === "monthly_report_ready" && (
                         <svg

--- a/frontend/src/components/UserPanel.tsx
+++ b/frontend/src/components/UserPanel.tsx
@@ -1152,7 +1152,12 @@ export default function UserPanel({ open, onClose }: Props) {
                       </p>
                       <div>
                         <label className="text-[10px] text-[var(--text-secondary)]">
-                          Sensibilidad: {Number(settings?.ai_suggestions_min_confidence || "0.5") <= 0.3 ? "Baja" : Number(settings?.ai_suggestions_min_confidence || "0.5") <= 0.6 ? "Media" : "Alta"}
+                          Sensibilidad:{" "}
+                          {Number(settings?.ai_suggestions_min_confidence || "0.5") <= 0.3
+                            ? "Baja"
+                            : Number(settings?.ai_suggestions_min_confidence || "0.5") <= 0.6
+                              ? "Media"
+                              : "Alta"}
                         </label>
                         <input
                           type="range"

--- a/frontend/src/components/UserPanel.tsx
+++ b/frontend/src/components/UserPanel.tsx
@@ -1112,6 +1112,68 @@ export default function UserPanel({ open, onClose }: Props) {
                 </div>
               )}
 
+              {/* AI Suggestions Settings */}
+              <div>
+                <h3 className="text-xs font-medium text-[var(--text-secondary)] uppercase tracking-wide mb-3">
+                  Sugerencias IA
+                </h3>
+                <div className="space-y-3">
+                  <div className="flex items-center justify-between">
+                    <span className="text-xs text-[var(--text-primary)]">
+                      Sugerir categorías con IA
+                    </span>
+                    <button
+                      onClick={() => {
+                        const current = settings?.ai_suggestions_enabled !== "false";
+                        settingMut.mutate({
+                          key: "ai_suggestions_enabled",
+                          value: current ? "false" : "true",
+                        });
+                      }}
+                      className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors ${
+                        settings?.ai_suggestions_enabled !== "false"
+                          ? "bg-[var(--color-primary)]"
+                          : "bg-[var(--text-tertiary)]"
+                      }`}
+                    >
+                      <span
+                        className={`inline-block h-3.5 w-3.5 rounded-full bg-white transition-transform ${
+                          settings?.ai_suggestions_enabled !== "false"
+                            ? "translate-x-4"
+                            : "translate-x-0.5"
+                        }`}
+                      />
+                    </button>
+                  </div>
+                  {settings?.ai_suggestions_enabled !== "false" && (
+                    <>
+                      <p className="text-[10px] text-[var(--text-tertiary)]">
+                        Categorías sugeridas automáticamente al crear gastos
+                      </p>
+                      <div>
+                        <label className="text-[10px] text-[var(--text-secondary)]">
+                          Sensibilidad: {Number(settings?.ai_suggestions_min_confidence || "0.5") <= 0.3 ? "Baja" : Number(settings?.ai_suggestions_min_confidence || "0.5") <= 0.6 ? "Media" : "Alta"}
+                        </label>
+                        <input
+                          type="range"
+                          min="0.1"
+                          max="1.0"
+                          step="0.1"
+                          value={String(settings?.ai_suggestions_min_confidence || "0.5")}
+                          onChange={(e) => {
+                            settingMut.mutate({
+                              key: "ai_suggestions_min_confidence",
+                              value: e.target.value,
+                            });
+                          }}
+                          className="w-full h-1 mt-1 accent-[var(--color-primary)]"
+                        />
+                      </div>
+                    </>
+                  )}
+                </div>
+              </div>
+
               <hr className="border-[var(--border-color)]" />
 
               {/* Change password */}

--- a/frontend/src/context/NotificationsContext.tsx
+++ b/frontend/src/context/NotificationsContext.tsx
@@ -93,6 +93,8 @@ export function NotificationsProvider({ children }: { children: ReactNode }) {
       showToast(notification.title, "info", 3000, "top-right");
     } else if (notification.type === "monthly_report_failed") {
       showToast(notification.title, "error", 5000, "top-right");
+    } else if (notification.type === "category_suggestions") {
+      showToast(notification.title, "info", 5000, "top-right");
     }
 
     setState((s) => {

--- a/frontend/src/pages/ExpensesPage.tsx
+++ b/frontend/src/pages/ExpensesPage.tsx
@@ -42,6 +42,7 @@ import {
 } from "../utils/format";
 import { useExpenseFilters } from "../hooks/useExpenseFilters";
 import { ConfirmDialog } from "../components/ConfirmDialog";
+import { useNotifications } from "../hooks/useNotifications";
 
 type SortField = "date" | "description" | "category" | "bank" | "person" | "amount";
 type SortDir = "asc" | "desc";
@@ -88,6 +89,19 @@ export default function ExpensesPage() {
   const filterDateFrom = filters.dateFrom;
   const filterDateTo = filters.dateTo;
   const filterSearch = filters.search;
+
+  // Category suggestions from notifications
+  const { notifications, markRead } = useNotifications();
+  const showSuggestions = searchParams.get("category_suggestions") === "1";
+  const suggestionNotif = notifications.find(
+    (n): n is import("../types").CategorySuggestionNotification =>
+      n.type === "category_suggestions" && !n.read,
+  );
+  const suggestions = suggestionNotif?.data.suggestions ?? [];
+  const suggestionsByExpenseId = useMemo(
+    () => new Map(suggestions.map((s) => [s.expense_id, s])),
+    [suggestions],
+  );
 
   const now = new Date();
   const month = filterDateFrom
@@ -513,6 +527,47 @@ export default function ExpensesPage() {
           </button>
         </div>
       </div>
+
+      {/* Category suggestions banner */}
+      {showSuggestions && suggestions.length > 0 && (
+        <div className="card border-l-4 border-l-purple-500 bg-purple-500/5">
+          <div className="px-4 py-3 flex items-center justify-between">
+            <div>
+              <p className="text-sm font-medium text-[var(--text-primary)]">
+                ✨ IA sugirió categorías para {suggestions.length} gasto{suggestions.length !== 1 ? "s" : ""}
+              </p>
+              <p className="text-xs text-[var(--text-tertiary)] mt-0.5">
+                Revisá las sugerencias inline y aplicá las que correspondan
+              </p>
+            </div>
+            <div className="flex items-center gap-2">
+              <button
+                onClick={async () => {
+                  for (const s of suggestions) {
+                    if (s.confidence >= 0.7) {
+                      await updateExpense(s.expense_id, { category_id: s.suggested_category_id });
+                    }
+                  }
+                  queryClient.invalidateQueries({ queryKey: ["expenses"] });
+                  markRead(suggestionNotif!.id);
+                }}
+                className="gnome-btn-secondary-round text-xs"
+              >
+                Aplicar todas (≥70%)
+              </button>
+              <button
+                onClick={() => {
+                  markRead(suggestionNotif!.id);
+                  setSearchParams((prev) => { prev.delete("category_suggestions"); return prev; });
+                }}
+                className="text-xs text-[var(--text-tertiary)] hover:text-[var(--text-primary)]"
+              >
+                Cerrar
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
 
       {/* Filter panel - collapsible */}
       <div className="card">
@@ -1107,6 +1162,23 @@ export default function ExpensesPage() {
                                   }}
                                 >
                                   {exp.category_name}
+                                </span>
+                              ) : showSuggestions && suggestionsByExpenseId.has(exp.id) ? (
+                                <span className="inline-flex items-center gap-1.5">
+                                  <span className="text-[var(--text-tertiary)]">—</span>
+                                  <button
+                                    onClick={(e) => {
+                                      e.stopPropagation();
+                                      const s = suggestionsByExpenseId.get(exp.id)!;
+                                      updateExpense(exp.id, { category_id: s.suggested_category_id }).then(() =>
+                                        queryClient.invalidateQueries({ queryKey: ["expenses"] }),
+                                      );
+                                    }}
+                                    className="px-2 py-1 rounded text-xs font-medium bg-purple-500/10 text-purple-600 dark:text-purple-400 hover:bg-purple-500/20 transition"
+                                    title={`Sugerencia: ${suggestionsByExpenseId.get(exp.id)!.parent_name ? suggestionsByExpenseId.get(exp.id)!.parent_name + " > " : ""}${suggestionsByExpenseId.get(exp.id)!.category_name} (${Math.round(suggestionsByExpenseId.get(exp.id)!.confidence * 100)}%)`}
+                                  >
+                                    ✨ {suggestionsByExpenseId.get(exp.id)!.category_name}
+                                  </button>
                                 </span>
                               ) : (
                                 <span className="text-[var(--text-tertiary)]">—</span>

--- a/frontend/src/pages/ExpensesPage.tsx
+++ b/frontend/src/pages/ExpensesPage.tsx
@@ -534,7 +534,8 @@ export default function ExpensesPage() {
           <div className="px-4 py-3 flex items-center justify-between">
             <div>
               <p className="text-sm font-medium text-[var(--text-primary)]">
-                ✨ IA sugirió categorías para {suggestions.length} gasto{suggestions.length !== 1 ? "s" : ""}
+                ✨ IA sugirió categorías para {suggestions.length} gasto
+                {suggestions.length !== 1 ? "s" : ""}
               </p>
               <p className="text-xs text-[var(--text-tertiary)] mt-0.5">
                 Revisá las sugerencias inline y aplicá las que correspondan
@@ -558,7 +559,10 @@ export default function ExpensesPage() {
               <button
                 onClick={() => {
                   markRead(suggestionNotif!.id);
-                  setSearchParams((prev) => { prev.delete("category_suggestions"); return prev; });
+                  setSearchParams((prev) => {
+                    prev.delete("category_suggestions");
+                    return prev;
+                  });
                 }}
                 className="text-xs text-[var(--text-tertiary)] hover:text-[var(--text-primary)]"
               >
@@ -1170,7 +1174,9 @@ export default function ExpensesPage() {
                                     onClick={(e) => {
                                       e.stopPropagation();
                                       const s = suggestionsByExpenseId.get(exp.id)!;
-                                      updateExpense(exp.id, { category_id: s.suggested_category_id }).then(() =>
+                                      updateExpense(exp.id, {
+                                        category_id: s.suggested_category_id,
+                                      }).then(() =>
                                         queryClient.invalidateQueries({ queryKey: ["expenses"] }),
                                       );
                                     }}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -52,7 +52,11 @@ export interface GenericNotification extends BaseNotification {
   data: Record<string, unknown>;
 }
 
-export type Notification = ImportNotification | GroupInvitationNotification | CategorySuggestionNotification | GenericNotification;
+export type Notification =
+  | ImportNotification
+  | GroupInvitationNotification
+  | CategorySuggestionNotification
+  | GenericNotification;
 
 export interface GroupMember {
   id: number;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -10,6 +10,20 @@ export interface GroupInvitationData {
   group_id?: number;
 }
 
+export interface CategorySuggestionData {
+  count: number;
+  suggestions: {
+    expense_id: number;
+    description: string;
+    amount: number;
+    date: string;
+    suggested_category_id: number;
+    category_name: string;
+    parent_name?: string | null;
+    confidence: number;
+  }[];
+}
+
 export interface BaseNotification {
   id: number;
   title: string;
@@ -28,12 +42,17 @@ export interface GroupInvitationNotification extends BaseNotification {
   data: GroupInvitationData;
 }
 
+export interface CategorySuggestionNotification extends BaseNotification {
+  type: "category_suggestions";
+  data: CategorySuggestionData;
+}
+
 export interface GenericNotification extends BaseNotification {
   type: string;
   data: Record<string, unknown>;
 }
 
-export type Notification = ImportNotification | GroupInvitationNotification | GenericNotification;
+export type Notification = ImportNotification | GroupInvitationNotification | CategorySuggestionNotification | GenericNotification;
 
 export interface GroupMember {
   id: number;
@@ -77,6 +96,13 @@ export interface Category {
   color: string;
   keywords: string;
   parent_id?: number | null;
+}
+
+export interface CategorySuggestion {
+  category_id: number;
+  category_name: string;
+  parent_name?: string | null;
+  confidence: number;
 }
 
 export interface Account {


### PR DESCRIPTION
## Summary

Complete AI auto-categorization system for expenses, covering Telegram bot, web UI, and nightly batch suggestions.

## Changes

### Telegram Bot - No Lag
- `_instant_categorize()`: keyword-only categorization (instant) replaces sync LLM in all 5 handlers
- `_enhance_with_llm()`: fires LLM in background via asyncio.to_thread, updates confirmation message if better category found
- Card/account selection now shows confirmation instantly, LLM runs in background

### Web UI - Category Pre-fill
- ExpenseModals: keyword matching on type (instant) + one LLM call on mount
- Shows "IA" badge when LLM provides the suggestion

### Nightly Uncategorized Suggestions
- New Celery task at 02:00 UTC (23:00 UTC-3)
- Finds uncategorized expenses from last 30 days
- Calls llm_categorize with temperature=0.7 (higher temp for ambiguous descriptions)
- Creates single in-app notification per user with suggestions
- Does NOT modify expenses - suggestions only

### User Settings
- Toggle: AI suggestions on/off
- Slider: Sensitivity (Baja/Media/Alta) - minimum confidence threshold

### Frontend - Suggestion UI
- NotificationsPanel: purple border + star icon for category_suggestions
- ExpensesPage: purple banner with "Aplicar todas (70%+)" button
- Inline suggestion pills on each uncategorized expense row

### Backend
- llm_categorize: new temperature parameter (default 0.3, nightly uses 0.7)
- POST /categories/suggest: new endpoint for web UI pre-fill
- Debug: DEBUG_CATEGORIZATION=1 for prod, auto-enabled in dev
