### PR TITLE
fix: weekly report delivery + bot bug fixes + worker config

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -414,7 +414,7 @@ jobs:
 
               celery_worker:
                 image: ${BACKEND_IMAGE}:${IMAGE_TAG}
-                command: celery -A app.celery_app worker --loglevel=info
+                command: celery -A app.celery_app worker --loglevel=info --concurrency=2
                 depends_on:
                   - db
                   - redis
@@ -435,7 +435,7 @@ jobs:
                 deploy:
                   resources:
                     limits:
-                      memory: 512M
+                      memory: 1G
                       cpus: "1.0"
                 restart: unless-stopped
 

--- a/backend/app/celery_app.py
+++ b/backend/app/celery_app.py
@@ -11,7 +11,7 @@ celery_app.conf.update(
     task_serializer="json",
     accept_content=["json"],
     result_serializer="json",
-    timezone="America/Argentina/Buenos_Aires",
+    timezone="UTC",
     enable_utc=True,
     task_track_started=True,
     task_time_limit=600,

--- a/backend/app/celery_schedule.py
+++ b/backend/app/celery_schedule.py
@@ -18,8 +18,8 @@ celery_app.conf.beat_schedule = {
     "send-weekly-reports-sunday": {
         "task": "app.tasks.weekly_summary.send_weekly_reports",
         "schedule": crontab(
-            hour=0, minute=50, day_of_week="monday"
-        ),  # 00:50 UTC Monday = 21:50 ART Sunday
+            hour=1, minute=30, day_of_week="monday"
+        ),  # 01:30 UTC Monday = 22:30 ART Sunday
     },
     "generate-monthly-reports": {
         "task": "app.tasks.monthly_report.generate_monthly_reports",

--- a/backend/app/celery_schedule.py
+++ b/backend/app/celery_schedule.py
@@ -17,11 +17,13 @@ celery_app.conf.beat_schedule = {
     },
     "send-weekly-reports-sunday": {
         "task": "app.tasks.weekly_summary.send_weekly_reports",
-        "schedule": crontab(hour=23, minute=0, day_of_week="sunday"),  # 20:00 UTC-3 = 23:00 UTC
+        "schedule": crontab(
+            hour=0, minute=30, day_of_week="monday"
+        ),  # 00:30 UTC Monday = 21:30 ART Sunday
     },
     "generate-monthly-reports": {
         "task": "app.tasks.monthly_report.generate_monthly_reports",
-        "schedule": crontab(hour=23, minute=0, day_of_month="1"),  # 20:00 UTC-3 = 23:00 UTC
+        "schedule": crontab(hour=3, minute=0, day_of_month="1"),  # 03:00 UTC = 00:00 ART
     },
     "suggest-uncategorized-categories-daily": {
         "task": "app.tasks.suggest_uncategorized.suggest_uncategorized_categories",

--- a/backend/app/celery_schedule.py
+++ b/backend/app/celery_schedule.py
@@ -18,8 +18,8 @@ celery_app.conf.beat_schedule = {
     "send-weekly-reports-sunday": {
         "task": "app.tasks.weekly_summary.send_weekly_reports",
         "schedule": crontab(
-            hour=0, minute=30, day_of_week="monday"
-        ),  # 00:30 UTC Monday = 21:30 ART Sunday
+            hour=0, minute=50, day_of_week="monday"
+        ),  # 00:50 UTC Monday = 21:50 ART Sunday
     },
     "generate-monthly-reports": {
         "task": "app.tasks.monthly_report.generate_monthly_reports",

--- a/backend/app/prompts.py
+++ b/backend/app/prompts.py
@@ -163,16 +163,15 @@ Hoy es {today}.
 
 Extraé del siguiente mensaje de notificación bancaria:
 - "amount": monto numérico (float, siempre positivo). Si no hay monto claro, null.
-- "description": descripción del comercio o merchant (texto limpio).
+- "description": descripción del comercio o merchant (texto limpio, sin incluir nombre del banco ni tarjeta).
 - "date": fecha en formato "YYYY-MM-DD". Si no se menciona fecha, usá hoy.
 - "currency": "ARS" si es pesos o no se menciona, "USD" si es dólares.
-- "card_last4": últimos 4 dígitos de la tarjeta (si aparecen, sino null).
 - "card_type": "credito" si es compra con tarjeta de crédito, "debito" si es débito directo o transferencia.
 - "bank": nombre del banco emisor si se menciona, sino null.
 
 Ejemplos de entrada → salida:
-"Compra aprobada Visa ****4521 $15.200 Supermercado Coto" → {{"amount": 15200.0, "description": "Supermercado Coto", "date": "{today}", "currency": "ARS", "card_last4": "4521", "card_type": "credito", "bank": null}}
-"Débito en cuenta Galicia por $8.500 Netflix" → {{"amount": 8500.0, "description": "Netflix", "date": "{today}", "currency": "ARS", "card_last4": null, "card_type": "debito", "bank": "Galicia"}}
-"Tu tarjeta Mastercard terminada en 1234 fue debitada por $3.200 Farmacity" → {{"amount": 3200.0, "description": "Farmacity", "date": "{today}", "currency": "ARS", "card_last4": "1234", "card_type": "credito", "bank": null}}
+"Compra aprobada Visa ****4521 $15.200 Supermercado Coto" → {{"amount": 15200.0, "description": "Supermercado Coto", "date": "{today}", "currency": "ARS", "card_type": "credito", "bank": null}}
+"Débito en cuenta Galicia por $8.500 Netflix" → {{"amount": 8500.0, "description": "Netflix", "date": "{today}", "currency": "ARS", "card_type": "debito", "bank": "Galicia"}}
+"Tu tarjeta Mastercard terminada en 1234 fue debitada por $3.200 Farmacity" → {{"amount": 3200.0, "description": "Farmacity", "date": "{today}", "currency": "ARS", "card_type": "credito", "bank": null}}
 
 Respondé ÚNICAMENTE con un objeto JSON válido, sin markdown, sin texto adicional."""

--- a/backend/app/tasks/weekly_summary.py
+++ b/backend/app/tasks/weekly_summary.py
@@ -1,11 +1,14 @@
 """Weekly summary task - generates and sends weekly report images via Telegram."""
 
+import logging
 from collections import defaultdict
 from datetime import date, timedelta
 
 from app.celery_app import celery_app
 from app.database import SessionLocal
 from app.models import Category, Expense, ScheduledExpense, Setting, User
+
+logger = logging.getLogger(__name__)
 
 MONTHS_ES = {
     1: "Enero",
@@ -53,7 +56,7 @@ def _generate_weekly_llm_analysis(report_data: dict) -> dict:
 
         api_key = os.getenv("LLM_API_KEY")
         if not api_key:
-            print("[WEEKLY LLM] No API key found, skipping LLM analysis")
+            logger.info("[WEEKLY LLM] No API key found, skipping LLM analysis")
             return None
 
         total = report_data.get("total_expenses", 0)
@@ -109,7 +112,7 @@ Devolve SOLO el texto del análisis, sin formato JSON."""
             "tip": tip,
         }
     except Exception as e:
-        print(f"[WEEKLY LLM] Error generating analysis: {e}")
+        logger.error(f"[WEEKLY LLM] Error generating analysis: {e}")
         return None
 
 
@@ -241,7 +244,7 @@ def send_weekly_reports():
         # Global dedup: check if weekly report was already sent for this week
         global_setting = db.query(Setting).filter(Setting.key == "weekly_report_last_sent").first()
         if global_setting and global_setting.value == week_key:
-            print(f"[WEEKLY REPORT] Already sent for week {week_key}, skipping")
+            logger.info(f"[WEEKLY REPORT] Already sent for week {week_key}, skipping")
             return
 
         # Get all users with Telegram connected
@@ -286,18 +289,23 @@ def send_weekly_reports():
                 if llm and llm.get("tip"):
                     caption += f"\n\n💡 {llm['tip']}"
 
+                # Truncate caption to Telegram's 1024-char limit
+                caption = caption[:1024]
+
                 # Send via Telegram
                 from app.telegram_bot import send_photo_to_chat
 
-                send_photo_to_chat(user.telegram_chat_id, png_bytes, caption)
-                sent_count += 1
-                print(f"[WEEKLY REPORT] Sent report to user {user.id}")
+                if send_photo_to_chat(user.telegram_chat_id, png_bytes, caption):
+                    sent_count += 1
+                    logger.info(f"[WEEKLY REPORT] Sent report to user {user.id}")
+                else:
+                    logger.warning(f"[WEEKLY REPORT] Failed to send report to user {user.id}")
 
             except Exception as e:
-                print(f"[WEEKLY REPORT] Error sending to user {user.id}: {e}")
+                logger.error(f"[WEEKLY REPORT] Error sending to user {user.id}: {e}")
                 continue
 
-        print(f"[WEEKLY REPORT] Sent {sent_count} weekly reports")
+        logger.info(f"[WEEKLY REPORT] Sent {sent_count} weekly reports")
 
         # Mark week as sent to prevent duplicate dispatches on restart
         if sent_count > 0:
@@ -307,7 +315,7 @@ def send_weekly_reports():
                 db.add(Setting(key="weekly_report_last_sent", value=week_key))
             db.commit()
     except Exception as e:
-        print(f"[WEEKLY REPORT] Error: {e}")
+        logger.error(f"[WEEKLY REPORT] Error: {e}")
         db.rollback()
     finally:
         db.close()

--- a/backend/app/telegram_bot.py
+++ b/backend/app/telegram_bot.py
@@ -118,8 +118,6 @@ BANK_NOTIFICATION_PATTERNS = [
     r"naranja\s+terminada",
     r"cr[eé]dito\s+(aprobado|confirmado|registrado)",
     r"transferencia\s+(saliente|enviada|realizada)",
-    r" débito ",
-    r" crédito ",
 ]
 
 

--- a/backend/app/telegram_bot.py
+++ b/backend/app/telegram_bot.py
@@ -261,18 +261,7 @@ def _save_expense(
             category_id = predicted_category_id
         else:
             cats = db.query(Category).all()
-            result = (
-                llm_categorize(
-                    parsed.get("description", ""), parsed.get("amount"), cats, user_id, db
-                )
-                if user_id
-                else None
-            )
-            category_id = (
-                result["category_id"]
-                if result
-                else auto_categorize(parsed.get("description", ""), cats)
-            )
+            category_id = auto_categorize(parsed.get("description", ""), cats)
 
         raw_date = parsed.get("date") or date.today().strftime("%Y-%m-%d")
         try:

--- a/backend/app/telegram_bot.py
+++ b/backend/app/telegram_bot.py
@@ -643,8 +643,8 @@ def send_message_to_chat(chat_id: str, text: str) -> None:
         logger.warning("[TELEGRAM] Bot event loop not available")
 
 
-def send_photo_to_chat(chat_id: str, image_bytes: bytes, caption: str = None) -> None:
-    """Send an image to a Telegram chat. Safe to call from any thread."""
+def send_photo_to_chat(chat_id: str, image_bytes: bytes, caption: str = None) -> bool:
+    """Send an image to a Telegram chat. Returns True on success."""
     # Try using bot instance first
     if _bot_app and _bot_app.bot:
 
@@ -657,26 +657,31 @@ def send_photo_to_chat(chat_id: str, image_bytes: bytes, caption: str = None) ->
                 await _bot_app.bot.send_photo(
                     chat_id=chat_id, photo=photo, caption=caption, parse_mode="Markdown"
                 )
+                return True
             except Exception as e:
                 logger.warning(f"[TELEGRAM] Could not send photo to {chat_id}: {e}")
+                return False
 
         loop = _bot_app.bot._local._loop if hasattr(_bot_app.bot, "_local") else None
         if loop and loop.is_running():
-            asyncio.run_coroutine_threadsafe(_send(), loop)
-            return
+            future = asyncio.run_coroutine_threadsafe(_send(), loop)
+            try:
+                return future.result(timeout=30)
+            except Exception:
+                return False
 
     # Fallback: use direct Telegram Bot API (for celery workers)
-    _send_photo_via_api(chat_id, image_bytes, caption)
+    return _send_photo_via_api(chat_id, image_bytes, caption)
 
 
-def _send_photo_via_api(chat_id: str, image_bytes: bytes, caption: str = None) -> None:
-    """Send photo using direct Telegram Bot API HTTP call."""
+def _send_photo_via_api(chat_id: str, image_bytes: bytes, caption: str = None) -> bool:
+    """Send photo using direct Telegram Bot API HTTP call. Returns True on success."""
     import os
 
     token = os.getenv("TELEGRAM_BOT_TOKEN")
     if not token:
         logger.warning("[TELEGRAM] No bot token available, cannot send photo")
-        return
+        return False
 
     try:
         from io import BytesIO
@@ -688,16 +693,18 @@ def _send_photo_via_api(chat_id: str, image_bytes: bytes, caption: str = None) -
         files = {"photo": ("report.png", BytesIO(image_bytes), "image/png")}
         data = {"chat_id": chat_id, "parse_mode": "Markdown"}
         if caption:
-            data["caption"] = caption
+            data["caption"] = caption[:1024]
 
         with httpx.Client(timeout=30) as client:
             resp = client.post(url, files=files, data=data)
             if resp.status_code != 200:
                 logger.warning(f"[TELEGRAM] API error {resp.status_code}: {resp.text[:200]}")
-            else:
-                logger.info(f"[TELEGRAM] Photo sent to {chat_id}")
+                return False
+            logger.info(f"[TELEGRAM] Photo sent to {chat_id}")
+            return True
     except Exception as e:
         logger.warning(f"[TELEGRAM] Could not send photo via API to {chat_id}: {e}")
+        return False
 
 
 async def start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
@@ -863,6 +870,7 @@ async def _handle_bank_notification(
         context.user_data["card_selected"] = card.card_name
         context.user_data["card_bank"] = card.bank or ""
         context.user_data["payment_label"] = payment_label
+        context.user_data["payment_method"] = "tarjeta"
 
         # Auto-categorize
         predicted_category_id, cats = _instant_categorize(parsed, user_id, db)
@@ -880,7 +888,6 @@ async def _handle_bank_notification(
         desc = _escape_md(parsed.get("description", ""))
         amount_str = _format_amount(parsed["amount"], parsed.get("currency", "ARS"))
         date_str = _format_date_es(parsed.get("date", date.today().strftime("%Y-%m-%d")))
-        last4 = parsed.get("card_last4", "")
 
         confirm_keyboard = [
             [
@@ -893,7 +900,7 @@ async def _handle_bank_notification(
             f"🛒 *{desc}*\n"
             f"💰 {amount_str}\n"
             f"📅 {date_str}\n"
-            f"💳 {payment_label}" + (f" ••{last4}" if last4 else "") + "\n"
+            f"💳 {payment_label}\n"
             f"{cat_tree}"
             f"\n¿Lo guardamos?",
             parse_mode="Markdown",

--- a/backend/app/telegram_bot.py
+++ b/backend/app/telegram_bot.py
@@ -979,10 +979,28 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
                 context.user_data["card_selected"] = matched_card.card_name
                 context.user_data["card_bank"] = matched_card.bank or ""
                 context.user_data["payment_label"] = payment_label
+                context.user_data["payment_method"] = "tarjeta"
 
                 predicted_category_id, cats = _instant_categorize(parsed, user_id, db)
                 context.user_data["predicted_category_id"] = predicted_category_id
                 context.user_data["cat_debug"] = ""
+
+                # Check installment requirement
+                amount = parsed.get("amount", 0)
+                if _should_ask_installments(
+                    predicted_category_id, db, amount, matched_card.card_type
+                ):
+                    installment_keyboard = [
+                        [
+                            InlineKeyboardButton("✅ Sí", callback_data="installment:yes"),
+                            InlineKeyboardButton("❌ No", callback_data="installment:no"),
+                        ]
+                    ]
+                    await update.message.reply_text(
+                        "¿Lo pagaste en cuotas?",
+                        reply_markup=InlineKeyboardMarkup(installment_keyboard),
+                    )
+                    return WAITING_INSTALLMENT_QUESTION
 
                 confirm_keyboard = [
                     [

--- a/podman-compose.yml
+++ b/podman-compose.yml
@@ -96,7 +96,7 @@ services:
       context: ./backend
       dockerfile: Dockerfile.dev
     user: "1000:1000"
-    command: celery -A app.celery_app worker --loglevel=info
+    command: celery -A app.celery_app worker --loglevel=info --concurrency=2
     secrets:
       - creditcard_backend_dev_postgres_password
       - creditcard_backend_dev_llm_api_key
@@ -117,7 +117,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: 512M
+          memory: 1G
           cpus: "1.0"
 
   celery_beat_dev:


### PR DESCRIPTION
## Summary

Bug fixes and config improvements from this session.

## Changes

### Bank notification save fix
- Set `payment_method='tarjeta'` in `_handle_bank_notification`
- Removed `card_last4` from LLM prompt and confirmation message

### Weekly report delivery fix
- `send_photo_to_chat` now returns `bool` — only increment `sent_count` on actual success
- Worker memory: 512M → 1G (Playwright + Chromium needs ~400MB)
- Worker concurrency: 6 → 2 (reduce memory pressure)
- Celery timezone: `America/Argentina/Buenos_Aires` → `UTC` (was ambiguous with `enable_utc=True`)
- Schedule: weekly report at 01:30 UTC Monday = 22:30 ART Sunday

### Telegram bot
- Remove blocking `llm_categorize` from `_save_expense` — replaced with instant `auto_categorize`
- Remove ` crédito ` / ` débito ` patterns from bank notification detection (too broad, caught natural language)
- Installment check added to embedded card detection path
- Caption truncated to 1024 chars (Telegram limit)
- `print()` → `logger` in `weekly_summary.py`

### Config
- `podman-compose.yml`: worker 512M → 1G, concurrency 6 → 2
- `deploy.yml`: prod worker 512M → 1G, concurrency 6 → 2
