### PR TITLE
feat: migrate email service from Resend to Brevo

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -402,7 +402,7 @@ jobs:
                   GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID}
                   GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET}
                   SECRET_KEY: ${SECRET_KEY}
-                  RESEND_API_KEY: ${RESEND_API_KEY}
+                  BREVO_API_KEY: ${BREVO_API_KEY}
                   FRONTEND_URL: https://${{ vars.DOMAIN_NAME }}
                   CORS_ORIGINS: https://${{ vars.DOMAIN_NAME }}
                 deploy:
@@ -430,7 +430,7 @@ jobs:
                   GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID}
                   GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET}
                   SECRET_KEY: ${SECRET_KEY}
-                  RESEND_API_KEY: ${RESEND_API_KEY}
+                  BREVO_API_KEY: ${BREVO_API_KEY}
                   ADMIN_EMAIL: ${ADMIN_EMAIL}
                 deploy:
                   resources:
@@ -457,7 +457,7 @@ jobs:
                   GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID}
                   GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET}
                   SECRET_KEY: ${SECRET_KEY}
-                  RESEND_API_KEY: ${RESEND_API_KEY}
+                  BREVO_API_KEY: ${BREVO_API_KEY}
                   ADMIN_EMAIL: ${ADMIN_EMAIL}
                 deploy:
                   resources:
@@ -530,7 +530,7 @@ jobs:
           port: 43422
           script: |
             cd /opt/creditcardanalyzer
-            REQUIRED="POSTGRES_PASSWORD LLM_API_KEY SECRET_KEY TELEGRAM_BOT_TOKEN GOOGLE_CLIENT_ID GOOGLE_CLIENT_SECRET RESEND_API_KEY ADMIN_EMAIL"
+            REQUIRED="POSTGRES_PASSWORD LLM_API_KEY SECRET_KEY TELEGRAM_BOT_TOKEN GOOGLE_CLIENT_ID GOOGLE_CLIENT_SECRET BREVO_API_KEY ADMIN_EMAIL"
             MISSING=""
             for var in $REQUIRED; do
               if ! grep -q "^${var}=" .env; then

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ Add in `Settings → Secrets → Actions`:
   "GOOGLE_CLIENT_ID": "your-google-client-id",
   "GOOGLE_CLIENT_SECRET": "your-google-client-secret",
   "SECRET_KEY": "your-jwt-secret-key",
-  "RESEND_API_KEY": "your-resend-api-key",
+  "BREVO_API_KEY": "your-brevo-api-key",
   "ADMIN_EMAIL": "admin@yourdomain.com"
 }
 ```

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -2,8 +2,8 @@ GOOGLE_API_KEY=AIza...
 GOOGLE_CLIENT_ID=your-client-id.apps.googleusercontent.com
 GOOGLE_CLIENT_SECRET=your-client-secret
 
-# Email notifications (Resend)
-RESEND_API_KEY=re_xxxxx
+# Email notifications (Brevo)
+BREVO_API_KEY=your-brevo-api-key
 ADMIN_EMAIL=admin@yourdomain.com
 
 # Environment (dev/production)

--- a/backend/app/services/email.py
+++ b/backend/app/services/email.py
@@ -2,33 +2,48 @@ import logging
 import os
 from datetime import datetime
 
-import resend
+from brevo import Brevo
+from brevo.transactional_emails import SendTransacEmailRequestSender, SendTransacEmailRequestToItem
 
 logger = logging.getLogger(__name__)
 
-resend_api_key = os.getenv("RESEND_API_KEY")
-if resend_api_key:
-    resend.api_key = resend_api_key
+brevo_api_key = os.getenv("BREVO_API_KEY")
+client = Brevo(api_key=brevo_api_key) if brevo_api_key else None
 
-FROM_EMAIL = os.getenv("SMTP_FROM", "Financial Planning <onboarding@resend.dev>")
-ADMIN_EMAIL = os.getenv("ADMIN_EMAIL", "admin@financialplanning.com")
+FROM_NAME = os.getenv("SMTP_FROM", "NikoFin")
+FROM_ADDRESS = os.getenv("SMTP_FROM_ADDRESS", "noreply@brevo.com")
+ADMIN_EMAIL = os.getenv("ADMIN_EMAIL", "admin@nikofin.com")
+
+
+def _send(subject: str, html: str, to: str, to_name: str = "") -> bool:
+    """Send a transactional email via Brevo. Returns True on success."""
+    if not client:
+        logger.warning("BREVO_API_KEY not set — cannot send email")
+        return False
+    try:
+        client.transactional_emails.send_transac_email(
+            subject=subject,
+            html_content=html,
+            sender=SendTransacEmailRequestSender(name=FROM_NAME, email=FROM_ADDRESS),
+            to=[SendTransacEmailRequestToItem(email=to, name=to_name or to)],
+        )
+        return True
+    except Exception as e:
+        logger.error(f"Failed to send email to {to}: {e}")
+        return False
 
 
 def send_password_reset_email(to: str, token: str, base_url: str) -> bool:
-    if not resend_api_key:
-        logger.warning("RESEND_API_KEY not set — cannot send password reset email")
-        return False
-
     reset_url = f"{base_url}/reset-password?token={token}"
 
     html = f"""
     <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; max-width: 480px; margin: 0 auto; padding: 32px;">
       <div style="text-align: center; margin-bottom: 32px;">
-        <div style="display: inline-block; width: 48px; height: 48px; border-radius: 8px; background: #3b82f6; color: white; font-weight: bold; font-size: 20px; line-height: 48px;">F</div>
+        <div style="display: inline-block; width: 48px; height: 48px; border-radius: 8px; background: #3b82f6; color: white; font-weight: bold; font-size: 20px; line-height: 48px;">N</div>
       </div>
       <h1 style="font-size: 20px; font-weight: 600; color: #1a1a1a; margin-bottom: 8px;">Restablecer contraseña</h1>
       <p style="color: #666; font-size: 14px; line-height: 1.5; margin-bottom: 24px;">
-        Recibimos una solicitud para restablecer tu contraseña en Financial Planning. Haz clic en el botón de abajo para elegir una nueva contraseña.
+        Recibimos una solicitud para restablecer tu contraseña en NikoFin. Haz clic en el botón de abajo para elegir una nueva contraseña.
       </p>
       <div style="text-align: center; margin-bottom: 24px;">
         <a href="{reset_url}" style="display: inline-block; padding: 12px 24px; background: #3b82f6; color: white; text-decoration: none; border-radius: 6px; font-weight: 500; font-size: 14px;">Restablecer contraseña</a>
@@ -39,36 +54,23 @@ def send_password_reset_email(to: str, token: str, base_url: str) -> bool:
     </div>
     """
 
-    try:
-        params: resend.Emails.SendParams = {
-            "from": FROM_EMAIL,
-            "to": [to],
-            "subject": "Restablecer contraseña — Financial Planning",
-            "html": html,
-        }
-        result = resend.Emails.send(params)
-        logger.info(f"Password reset email sent to {to}: {result}")
-        return True
-    except Exception as e:
-        logger.error(f"Failed to send password reset email to {to}: {e}")
-        return False
+    result = _send("Restablecer contraseña — NikoFin", html, to)
+    if result:
+        logger.info(f"Password reset email sent to {to}")
+    return result
 
 
 def send_verification_email(to: str, token: str, base_url: str) -> bool:
-    if not resend_api_key:
-        logger.warning("RESEND_API_KEY not set — cannot send verification email")
-        return False
-
     verify_url = f"{base_url}/verify-email?token={token}"
 
     html = f"""
     <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; max-width: 480px; margin: 0 auto; padding: 32px;">
       <div style="text-align: center; margin-bottom: 32px;">
-        <div style="display: inline-block; width: 48px; height: 48px; border-radius: 8px; background: #3b82f6; color: white; font-weight: bold; font-size: 20px; line-height: 48px;">F</div>
+        <div style="display: inline-block; width: 48px; height: 48px; border-radius: 8px; background: #3b82f6; color: white; font-weight: bold; font-size: 20px; line-height: 48px;">N</div>
       </div>
       <h1 style="font-size: 20px; font-weight: 600; color: #1a1a1a; margin-bottom: 8px;">Verificar tu email</h1>
       <p style="color: #666; font-size: 14px; line-height: 1.5; margin-bottom: 24px;">
-        Gracias por registrarte en Financial Planning. Verificá tu email haciendo clic en el botón de abajo.
+        Gracias por registrarte en NikoFin. Verificá tu email haciendo clic en el botón de abajo.
       </p>
       <div style="text-align: center; margin-bottom: 24px;">
         <a href="{verify_url}" style="display: inline-block; padding: 12px 24px; background: #3b82f6; color: white; text-decoration: none; border-radius: 6px; font-weight: 500; font-size: 14px;">Verificar email</a>
@@ -79,27 +81,15 @@ def send_verification_email(to: str, token: str, base_url: str) -> bool:
     </div>
     """
 
-    try:
-        params: resend.Emails.SendParams = {
-            "from": FROM_EMAIL,
-            "to": [to],
-            "subject": "Verificar tu email — Financial Planning",
-            "html": html,
-        }
-        result = resend.Emails.send(params)
-        logger.info(f"Verification email sent to {to}: {result}")
-        return True
-    except Exception as e:
-        logger.error(f"Failed to send verification email to {to}: {e}")
-        return False
+    result = _send("Verificar tu email — NikoFin", html, to)
+    if result:
+        logger.info(f"Verification email sent to {to}")
+    return result
 
 
 def send_report_failure_email(user_id: int, month_str: str, error: str) -> bool:
-    if not resend_api_key:
-        logger.warning("RESEND_API_KEY not set — cannot send report failure email")
-        return False
-
     timestamp = datetime.utcnow().strftime("%d/%m/%Y %H:%M:%S UTC")
+
     html = f"""
     <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; max-width: 480px; margin: 0 auto; padding: 32px;">
       <div style="text-align: center; margin-bottom: 32px;">
@@ -121,16 +111,11 @@ def send_report_failure_email(user_id: int, month_str: str, error: str) -> bool:
     </div>
     """
 
-    try:
-        params: resend.Emails.SendParams = {
-            "from": FROM_EMAIL,
-            "to": [ADMIN_EMAIL],
-            "subject": f"[ALERTA] Reporte mensual falló — {month_str} — User {user_id}",
-            "html": html,
-        }
-        result = resend.Emails.send(params)
-        logger.info(f"Report failure email sent for user {user_id}, month {month_str}: {result}")
-        return True
-    except Exception as e:
-        logger.error(f"Failed to send report failure email for user {user_id}: {e}")
-        return False
+    result = _send(
+        f"[ALERTA] Reporte mensual falló — {month_str} — User {user_id}",
+        html,
+        ADMIN_EMAIL,
+    )
+    if result:
+        logger.info(f"Report failure email sent for user {user_id}, month {month_str}")
+    return result

--- a/backend/docker-entrypoint.sh
+++ b/backend/docker-entrypoint.sh
@@ -30,7 +30,7 @@ load_secret "TELEGRAM_BOT_TOKEN" "creditcard_backend_telegram_bot_token" "credit
 load_secret "GOOGLE_CLIENT_ID" "creditcard_backend_google_client_id" "creditcard_backend_dev_google_client_id"
 load_secret "GOOGLE_CLIENT_SECRET" "creditcard_backend_google_client_secret" "creditcard_backend_dev_google_client_secret"
 load_secret "SECRET_KEY" "creditcard_backend_secret_key" "creditcard_backend_dev_secret_key"
-load_secret "RESEND_API_KEY" "creditcard_backend_resend_api_key" "creditcard_backend_dev_resend_api_key"
+load_secret "BREVO_API_KEY" "creditcard_backend_brevo_api_key" "creditcard_backend_dev_brevo_api_key"
 
 # Create database indices if needed (idempotent - safe to run multiple times)
 echo "Checking database indices..."

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -29,7 +29,7 @@ playwright>=1.61.0
 jinja2>=3.1.0
 
 # Email (password recovery)
-resend>=2.0.0
+brevo-python>=5.0.0
 
 # Security: rate limiting, MFA, audit
 slowapi>=0.1.9

--- a/docs/Deployment.md
+++ b/docs/Deployment.md
@@ -117,7 +117,7 @@ The `app-secrets.json` contains:
   "LLM_API_KEY": "...",
   "INVESTMENTS_LLM_API_KEY": "...",
   "MESSAGES_BOT_LLM_API_KEY": "...",
-  "RESEND_API_KEY": "...",
+  "BREVO_API_KEY": "...",
   "ADMIN_EMAIL": "...",
   "POSTGRES_PASSWORD_PROD": "...",
   "TELEGRAM_BOT_TOKEN_PROD": "...",
@@ -160,7 +160,7 @@ Monthly report generation has built-in resilience:
 - **Admin email alerts**: When all retries fail, an email is sent to `ADMIN_EMAIL` via Resend with error details (user_id, month, error, timestamp)
 - **In-app notifications**: Users receive a `monthly_report_failed` notification
 
-The `celery_worker` and `celery_beat` containers require `RESEND_API_KEY` and `ADMIN_EMAIL` in their environment for email alerts to work.
+The `celery_worker` and `celery_beat` containers require `BREVO_API_KEY` and `ADMIN_EMAIL` in their environment for email alerts to work.
 
 ### Investment Price Refresh
 
@@ -220,7 +220,7 @@ COPY nginx.conf /etc/nginx/conf.d/default.conf
 | `MESSAGES_BOT_LLM_API_KEY` | Telegram bot LLM key         | -                           |
 | `TELEGRAM_BOT_TOKEN_PROD`  | Production bot token         | -                           |
 | `TELEGRAM_BOT_TOKEN_DEV`   | Development bot token        | -                           |
-| `RESEND_API_KEY`           | Email service key            | -                           |
+| `BREVO_API_KEY`             | Email service key            | -                           |
 | `ADMIN_EMAIL`              | Admin alert email address    | admin@financialplanning.com |
 | `JWT_EXPIRE_DAYS`          | Token expiry                 | 7                           |
 

--- a/podman-compose.yml
+++ b/podman-compose.yml
@@ -49,7 +49,7 @@ services:
       - creditcard_backend_dev_google_client_id
       - creditcard_backend_dev_google_client_secret
       - creditcard_backend_dev_secret_key
-      - creditcard_backend_dev_resend_api_key
+      - creditcard_backend_dev_brevo_api_key
     environment:
       PYTHONPATH: /app
       DATABASE_URL: postgresql://expenses_user:${POSTGRES_PASSWORD_DEV}@db:5432/expenses
@@ -174,9 +174,9 @@ secrets:
   creditcard_backend_dev_secret_key:
     external: true
     env: SECRET_KEY_DEV
-  creditcard_backend_dev_resend_api_key:
+  creditcard_backend_dev_brevo_api_key:
     external: true
-    env: RESEND_API_KEY_DEV
+    env: BREVO_API_KEY_DEV
   creditcard_frontend_dev_google_client_id:
     external: true
     env: GOOGLE_CLIENT_ID_DEV


### PR DESCRIPTION
## Summary

Migrate email service from Resend to Brevo for free tier with no domain verification required.

## Why

- Resend test mode only allows sending to owner email (no domain verification)
- SendGrid free tier has time-limited trial concerns
- **Brevo**: free forever, 300 emails/day, no domain verification needed

## Changes

### Backend
- requirements.txt: resend>=2.0.0 → brevo-python>=5.0.0
- email.py: Full rewrite with Brevo SDK
  - Extract _send() helper for DRY email sending
  - send_password_reset_email() — same HTML template
  - send_verification_email() — same HTML template
  - send_report_failure_email() — same HTML template
  - FROM: NikoFin <noreply@brevo.com> (no domain verification needed)
- .env.example: RESEND_API_KEY → BREVO_API_KEY

### Config
- docker-entrypoint.sh: load_secret updated for Brevo
- podman-compose.yml: Secret renamed to creditcard_backend_dev_brevo_api_key
- deploy.yml: All env vars + validation updated (4 lines)

### Documentation
- README.md: Updated secret reference
- docs/Deployment.md: Updated secret reference + worker requirements

## No changes needed
- auth.py — function signatures unchanged
- monthly_report.py — function signatures unchanged
- All callers work without modification

## Testing
- Brevo SDK installed and imported successfully
- Client initializes with API key
- FROM address configured as NikoFin <noreply@brevo.com>
