### PR TITLE
feat: secrets cleanup, email service, LLM optimization

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -402,7 +402,7 @@ jobs:
                   GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID}
                   GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET}
                   SECRET_KEY: ${SECRET_KEY}
-                  BREVO_API_KEY: ${BREVO_API_KEY}
+                  EMAIL_API_KEY: ${EMAIL_API_KEY}
                   SMTP_FROM: ${{ vars.SMTP_FROM }}
                   SMTP_FROM_ADDRESS: ${{ vars.SMTP_FROM_ADDRESS }}
                   FRONTEND_URL: https://${{ vars.DOMAIN_NAME }}
@@ -432,7 +432,7 @@ jobs:
                   GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID}
                   GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET}
                   SECRET_KEY: ${SECRET_KEY}
-                  BREVO_API_KEY: ${BREVO_API_KEY}
+                  EMAIL_API_KEY: ${EMAIL_API_KEY}
                   SMTP_FROM: ${{ vars.SMTP_FROM }}
                   SMTP_FROM_ADDRESS: ${{ vars.SMTP_FROM_ADDRESS }}
                   ADMIN_EMAIL: ${ADMIN_EMAIL}
@@ -461,7 +461,7 @@ jobs:
                   GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID}
                   GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET}
                   SECRET_KEY: ${SECRET_KEY}
-                  BREVO_API_KEY: ${BREVO_API_KEY}
+                  EMAIL_API_KEY: ${EMAIL_API_KEY}
                   SMTP_FROM: ${{ vars.SMTP_FROM }}
                   SMTP_FROM_ADDRESS: ${{ vars.SMTP_FROM_ADDRESS }}
                   ADMIN_EMAIL: ${ADMIN_EMAIL}
@@ -527,7 +527,7 @@ jobs:
             echo "GOOGLE_CLIENT_SECRET=${{ secrets.GOOGLE_CLIENT_SECRET }}" >> /opt/creditcardanalyzer/.env
             echo "SECRET_KEY=${{ secrets.SECRET_KEY }}" >> /opt/creditcardanalyzer/.env
             echo "ADMIN_EMAIL=${{ secrets.ADMIN_EMAIL }}" >> /opt/creditcardanalyzer/.env
-            echo "BREVO_API_KEY=${{ secrets.BREVO_API_KEY }}" >> /opt/creditcardanalyzer/.env
+            echo "EMAIL_API_KEY=${{ secrets.EMAIL_API_KEY }}" >> /opt/creditcardanalyzer/.env
 
             chmod 600 /opt/creditcardanalyzer/.env
             echo "Config files written"
@@ -541,7 +541,7 @@ jobs:
           port: 43422
           script: |
             cd /opt/creditcardanalyzer
-            REQUIRED="POSTGRES_PASSWORD LLM_API_KEY SECRET_KEY TELEGRAM_BOT_TOKEN GOOGLE_CLIENT_ID GOOGLE_CLIENT_SECRET BREVO_API_KEY ADMIN_EMAIL"
+            REQUIRED="POSTGRES_PASSWORD LLM_API_KEY SECRET_KEY TELEGRAM_BOT_TOKEN GOOGLE_CLIENT_ID GOOGLE_CLIENT_SECRET EMAIL_API_KEY ADMIN_EMAIL"
             MISSING=""
             for var in $REQUIRED; do
               if ! grep -q "^${var}=" .env; then

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -403,6 +403,8 @@ jobs:
                   GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET}
                   SECRET_KEY: ${SECRET_KEY}
                   BREVO_API_KEY: ${BREVO_API_KEY}
+                  SMTP_FROM: ${{ vars.SMTP_FROM }}
+                  SMTP_FROM_ADDRESS: ${{ vars.SMTP_FROM_ADDRESS }}
                   FRONTEND_URL: https://${{ vars.DOMAIN_NAME }}
                   CORS_ORIGINS: https://${{ vars.DOMAIN_NAME }}
                 deploy:
@@ -431,6 +433,8 @@ jobs:
                   GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET}
                   SECRET_KEY: ${SECRET_KEY}
                   BREVO_API_KEY: ${BREVO_API_KEY}
+                  SMTP_FROM: ${{ vars.SMTP_FROM }}
+                  SMTP_FROM_ADDRESS: ${{ vars.SMTP_FROM_ADDRESS }}
                   ADMIN_EMAIL: ${ADMIN_EMAIL}
                 deploy:
                   resources:
@@ -458,6 +462,8 @@ jobs:
                   GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET}
                   SECRET_KEY: ${SECRET_KEY}
                   BREVO_API_KEY: ${BREVO_API_KEY}
+                  SMTP_FROM: ${{ vars.SMTP_FROM }}
+                  SMTP_FROM_ADDRESS: ${{ vars.SMTP_FROM_ADDRESS }}
                   ADMIN_EMAIL: ${ADMIN_EMAIL}
                 deploy:
                   resources:

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ Add in `Settings → Secrets → Actions`:
 | `GOOGLE_CLIENT_ID` | Google OAuth client ID |
 | `GOOGLE_CLIENT_SECRET` | Google OAuth client secret |
 | `SECRET_KEY` | JWT secret key |
-| `BREVO_API_KEY` | Brevo email service key |
+| `EMAIL_API_KEY` | Resend email service key |
 | `ADMIN_EMAIL` | Admin alert email |
 ```
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,8 +1,8 @@
 GOOGLE_CLIENT_ID=your-client-id.apps.googleusercontent.com
 GOOGLE_CLIENT_SECRET=your-client-secret
 
-# Email notifications (Brevo)
-BREVO_API_KEY=your-brevo-api-key
+# Email notifications (Resend)
+EMAIL_API_KEY=re_xxxxx
 ADMIN_EMAIL=admin@yourdomain.com
 
 # Environment (dev/production)

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,4 +1,3 @@
-GOOGLE_API_KEY=AIza...
 GOOGLE_CLIENT_ID=your-client-id.apps.googleusercontent.com
 GOOGLE_CLIENT_SECRET=your-client-secret
 

--- a/backend/app/services/auth.py
+++ b/backend/app/services/auth.py
@@ -23,9 +23,6 @@ ALGORITHM = "HS256"
 JWT_EXPIRE_DAYS = int(os.getenv("JWT_EXPIRE_DAYS", "7"))
 GOOGLE_CLIENT_ID = os.getenv("GOOGLE_CLIENT_ID", "")
 GOOGLE_CLIENT_SECRET = os.getenv("GOOGLE_CLIENT_SECRET", "")
-APPLE_CLIENT_ID = os.getenv("APPLE_CLIENT_ID", "")
-APPLE_KEY_ID = os.getenv("APPLE_KEY_ID", "")
-APPLE_TEAM_ID = os.getenv("APPLE_TEAM_ID", "")
 
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/auth/login")
 
@@ -100,65 +97,3 @@ async def exchange_google_code(code: str, redirect_uri: str) -> dict:
         if not id_token:
             raise HTTPException(status_code=400, detail="No se recibió id_token de Google")
         return await verify_google_token(id_token)
-
-
-async def verify_apple_token(code: str) -> dict:
-    async with httpx.AsyncClient() as client:
-        resp = await client.post(
-            "https://appleid.apple.com/auth/token",
-            data={
-                "grant_type": "authorization_code",
-                "code": code,
-                "client_id": APPLE_CLIENT_ID,
-                "client_secret": _generate_apple_client_secret(),
-            },
-        )
-        if resp.status_code != 200:
-            raise HTTPException(status_code=401, detail="Token de Apple inválido")
-        data = resp.json()
-        id_token = data.get("id_token")
-        if not id_token:
-            raise HTTPException(status_code=401, detail="No se recibió id_token de Apple")
-
-        # Verify against Apple's public keys
-        import requests as _req
-
-        apple_keys_resp = _req.get("https://appleid.apple.com/auth/keys", timeout=10)
-        if apple_keys_resp.status_code != 200:
-            raise HTTPException(
-                status_code=502, detail="No se pudieron obtener las claves de Apple"
-            )
-        from jose import jwt as jose_jwt
-
-        header = jose_jwt.get_unverified_header(id_token)
-        kid = header.get("kid")
-        keys = apple_keys_resp.json().get("keys", [])
-        matching_key = next((k for k in keys if k.get("kid") == kid), None)
-        if not matching_key:
-            raise HTTPException(
-                status_code=401, detail="Token de Apple inválido: kid no encontrado"
-            )
-        public_key = jose_jwt.construct_rsa_key(matching_key)
-        return jose_jwt.decode(id_token, public_key, algorithms=["RS256"], audience=APPLE_CLIENT_ID)
-
-
-def _generate_apple_client_secret() -> str:
-    from jose import jwt as jose_jwt
-
-    apple_private_key = os.getenv("APPLE_PRIVATE_KEY", "")
-    if not apple_private_key:
-        raise RuntimeError(
-            "APPLE_PRIVATE_KEY environment variable is required for Sign in with Apple"
-        )
-
-    now = datetime.now(UTC)
-    payload = {
-        "iss": APPLE_TEAM_ID,
-        "iat": now,
-        "exp": now + timedelta(hours=1),
-        "aud": "https://appleid.apple.com",
-        "sub": APPLE_CLIENT_ID,
-    }
-    return jose_jwt.encode(
-        payload, apple_private_key, algorithm="RS256", headers={"kid": APPLE_KEY_ID}
-    )

--- a/backend/app/services/email.py
+++ b/backend/app/services/email.py
@@ -2,31 +2,33 @@ import logging
 import os
 from datetime import datetime
 
-from brevo import Brevo
-from brevo.transactional_emails import SendTransacEmailRequestSender, SendTransacEmailRequestToItem
+import resend
 
 logger = logging.getLogger(__name__)
 
-brevo_api_key = os.getenv("BREVO_API_KEY")
-client = Brevo(api_key=brevo_api_key) if brevo_api_key else None
+email_api_key = os.getenv("EMAIL_API_KEY")
+if email_api_key:
+    resend.api_key = email_api_key
 
 FROM_NAME = os.getenv("SMTP_FROM", "NikoFin")
-FROM_ADDRESS = os.getenv("SMTP_FROM_ADDRESS", "noreply@brevo.com")
+FROM_ADDRESS = os.getenv("SMTP_FROM_ADDRESS", "noreply@resend.dev")
 ADMIN_EMAIL = os.getenv("ADMIN_EMAIL", "admin@nikofin.com")
 
 
 def _send(subject: str, html: str, to: str, to_name: str = "") -> bool:
-    """Send a transactional email via Brevo. Returns True on success."""
-    if not client:
-        logger.warning("BREVO_API_KEY not set — cannot send email")
+    """Send a transactional email via Resend. Returns True on success."""
+    if not email_api_key:
+        logger.warning("EMAIL_API_KEY not set — cannot send email")
         return False
     try:
-        client.transactional_emails.send_transac_email(
-            subject=subject,
-            html_content=html,
-            sender=SendTransacEmailRequestSender(name=FROM_NAME, email=FROM_ADDRESS),
-            to=[SendTransacEmailRequestToItem(email=to, name=to_name or to)],
-        )
+        from_addr = f"{FROM_NAME} <{FROM_ADDRESS}>"
+        params: resend.Emails.SendParams = {
+            "from": from_addr,
+            "to": [to],
+            "subject": subject,
+            "html": html,
+        }
+        resend.Emails.send(params)
         return True
     except Exception as e:
         logger.error(f"Failed to send email to {to}: {e}")

--- a/backend/docker-entrypoint.sh
+++ b/backend/docker-entrypoint.sh
@@ -30,7 +30,7 @@ load_secret "TELEGRAM_BOT_TOKEN" "creditcard_backend_telegram_bot_token" "credit
 load_secret "GOOGLE_CLIENT_ID" "creditcard_backend_google_client_id" "creditcard_backend_dev_google_client_id"
 load_secret "GOOGLE_CLIENT_SECRET" "creditcard_backend_google_client_secret" "creditcard_backend_dev_google_client_secret"
 load_secret "SECRET_KEY" "creditcard_backend_secret_key" "creditcard_backend_dev_secret_key"
-load_secret "BREVO_API_KEY" "creditcard_backend_brevo_api_key" "creditcard_backend_dev_brevo_api_key"
+load_secret "EMAIL_API_KEY" "creditcard_backend_email_api_key" "creditcard_backend_dev_email_api_key"
 
 # Create database indices if needed (idempotent - safe to run multiple times)
 echo "Checking database indices..."

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -29,7 +29,7 @@ playwright>=1.61.0
 jinja2>=3.1.0
 
 # Email (password recovery)
-brevo-python>=5.0.0
+resend>=2.0.0
 
 # Security: rate limiting, MFA, audit
 slowapi>=0.1.9

--- a/docs/Deployment.md
+++ b/docs/Deployment.md
@@ -113,7 +113,7 @@ Required secrets:
 | `GOOGLE_CLIENT_ID` | Google OAuth client ID |
 | `GOOGLE_CLIENT_SECRET` | Google OAuth client secret |
 | `SECRET_KEY` | JWT secret key |
-| `BREVO_API_KEY` | Brevo email service key |
+| `EMAIL_API_KEY` | Resend email service key |
 | `ADMIN_EMAIL` | Admin alert email |
 
 ### CI/CD Pipeline
@@ -151,7 +151,7 @@ Monthly report generation has built-in resilience:
 - **Admin email alerts**: When all retries fail, an email is sent to `ADMIN_EMAIL` via Resend with error details (user_id, month, error, timestamp)
 - **In-app notifications**: Users receive a `monthly_report_failed` notification
 
-The `celery_worker` and `celery_beat` containers require `BREVO_API_KEY` and `ADMIN_EMAIL` in their environment for email alerts to work.
+The `celery_worker` and `celery_beat` containers require `EMAIL_API_KEY` and `ADMIN_EMAIL` in their environment for email alerts to work.
 
 ### Investment Price Refresh
 
@@ -211,7 +211,7 @@ COPY nginx.conf /etc/nginx/conf.d/default.conf
 | `MESSAGES_BOT_LLM_API_KEY` | Telegram bot LLM key         | -                           |
 | `TELEGRAM_BOT_TOKEN_PROD`  | Production bot token         | -                           |
 | `TELEGRAM_BOT_TOKEN_DEV`   | Development bot token        | -                           |
-| `BREVO_API_KEY`             | Email service key            | -                           |
+| `EMAIL_API_KEY`               | Email service key            | -                           |
 | `ADMIN_EMAIL`              | Admin alert email address    | admin@financialplanning.com |
 | `JWT_EXPIRE_DAYS`          | Token expiry                 | 7                           |
 

--- a/podman-compose.yml
+++ b/podman-compose.yml
@@ -106,11 +106,13 @@ services:
       - creditcard_backend_dev_google_client_id
       - creditcard_backend_dev_google_client_secret
       - creditcard_backend_dev_secret_key
+      - creditcard_backend_dev_brevo_api_key
     environment:
       PYTHONPATH: /app
       DATABASE_URL: postgresql://expenses_user:${POSTGRES_PASSWORD_DEV}@db:5432/expenses
       REDIS_URL: redis://redis:6379/1
       PYTHONUNBUFFERED: "1"
+      ADMIN_EMAIL: ${ADMIN_EMAIL:-admin@nikofin.com}
     volumes:
       - ./backend/app:/app/app:z
       - ./backend/main.py:/app/main.py:z
@@ -135,11 +137,13 @@ services:
       - creditcard_backend_dev_google_client_id
       - creditcard_backend_dev_google_client_secret
       - creditcard_backend_dev_secret_key
+      - creditcard_backend_dev_brevo_api_key
     environment:
       PYTHONPATH: /app
       DATABASE_URL: postgresql://expenses_user:${POSTGRES_PASSWORD_DEV}@db:5432/expenses
       REDIS_URL: redis://redis:6379/1
       PYTHONUNBUFFERED: "1"
+      ADMIN_EMAIL: ${ADMIN_EMAIL:-admin@nikofin.com}
     volumes:
       - ./backend/app:/app/app:z
       - ./backend/main.py:/app/main.py:z

--- a/podman-compose.yml
+++ b/podman-compose.yml
@@ -49,14 +49,14 @@ services:
       - creditcard_backend_dev_google_client_id
       - creditcard_backend_dev_google_client_secret
       - creditcard_backend_dev_secret_key
-      - creditcard_backend_dev_brevo_api_key
+      - creditcard_backend_dev_email_api_key
     environment:
       PYTHONPATH: /app
       DATABASE_URL: postgresql://expenses_user:${POSTGRES_PASSWORD_DEV}@db:5432/expenses
       REDIS_URL: redis://redis:6379/1
       PYTHONUNBUFFERED: "1"
       SMTP_FROM: ${SMTP_FROM:-NikoFin}
-      SMTP_FROM_ADDRESS: ${SMTP_FROM_ADDRESS:-noreply@brevo.com}
+      SMTP_FROM_ADDRESS: ${SMTP_FROM_ADDRESS:-noreply@resend.dev}
     volumes:
       - ./backend/app:/app/app:z
       - ./backend/main.py:/app/main.py:z
@@ -108,7 +108,7 @@ services:
       - creditcard_backend_dev_google_client_id
       - creditcard_backend_dev_google_client_secret
       - creditcard_backend_dev_secret_key
-      - creditcard_backend_dev_brevo_api_key
+      - creditcard_backend_dev_email_api_key
     environment:
       PYTHONPATH: /app
       DATABASE_URL: postgresql://expenses_user:${POSTGRES_PASSWORD_DEV}@db:5432/expenses
@@ -116,7 +116,7 @@ services:
       PYTHONUNBUFFERED: "1"
       ADMIN_EMAIL: ${ADMIN_EMAIL:-admin@nikofin.com}
       SMTP_FROM: ${SMTP_FROM:-NikoFin}
-      SMTP_FROM_ADDRESS: ${SMTP_FROM_ADDRESS:-noreply@brevo.com}
+      SMTP_FROM_ADDRESS: ${SMTP_FROM_ADDRESS:-noreply@resend.dev}
     volumes:
       - ./backend/app:/app/app:z
       - ./backend/main.py:/app/main.py:z
@@ -141,7 +141,7 @@ services:
       - creditcard_backend_dev_google_client_id
       - creditcard_backend_dev_google_client_secret
       - creditcard_backend_dev_secret_key
-      - creditcard_backend_dev_brevo_api_key
+      - creditcard_backend_dev_email_api_key
     environment:
       PYTHONPATH: /app
       DATABASE_URL: postgresql://expenses_user:${POSTGRES_PASSWORD_DEV}@db:5432/expenses
@@ -149,7 +149,7 @@ services:
       PYTHONUNBUFFERED: "1"
       ADMIN_EMAIL: ${ADMIN_EMAIL:-admin@nikofin.com}
       SMTP_FROM: ${SMTP_FROM:-NikoFin}
-      SMTP_FROM_ADDRESS: ${SMTP_FROM_ADDRESS:-noreply@brevo.com}
+      SMTP_FROM_ADDRESS: ${SMTP_FROM_ADDRESS:-noreply@resend.dev}
     volumes:
       - ./backend/app:/app/app:z
       - ./backend/main.py:/app/main.py:z
@@ -184,9 +184,9 @@ secrets:
   creditcard_backend_dev_secret_key:
     external: true
     env: SECRET_KEY_DEV
-  creditcard_backend_dev_brevo_api_key:
+  creditcard_backend_dev_email_api_key:
     external: true
-    env: BREVO_API_KEY_DEV
+    env: EMAIL_API_KEY_DEV
   creditcard_frontend_dev_google_client_id:
     external: true
     env: GOOGLE_CLIENT_ID_DEV

--- a/podman-compose.yml
+++ b/podman-compose.yml
@@ -55,6 +55,8 @@ services:
       DATABASE_URL: postgresql://expenses_user:${POSTGRES_PASSWORD_DEV}@db:5432/expenses
       REDIS_URL: redis://redis:6379/1
       PYTHONUNBUFFERED: "1"
+      SMTP_FROM: ${SMTP_FROM:-NikoFin}
+      SMTP_FROM_ADDRESS: ${SMTP_FROM_ADDRESS:-noreply@brevo.com}
     volumes:
       - ./backend/app:/app/app:z
       - ./backend/main.py:/app/main.py:z
@@ -113,6 +115,8 @@ services:
       REDIS_URL: redis://redis:6379/1
       PYTHONUNBUFFERED: "1"
       ADMIN_EMAIL: ${ADMIN_EMAIL:-admin@nikofin.com}
+      SMTP_FROM: ${SMTP_FROM:-NikoFin}
+      SMTP_FROM_ADDRESS: ${SMTP_FROM_ADDRESS:-noreply@brevo.com}
     volumes:
       - ./backend/app:/app/app:z
       - ./backend/main.py:/app/main.py:z
@@ -144,6 +148,8 @@ services:
       REDIS_URL: redis://redis:6379/1
       PYTHONUNBUFFERED: "1"
       ADMIN_EMAIL: ${ADMIN_EMAIL:-admin@nikofin.com}
+      SMTP_FROM: ${SMTP_FROM:-NikoFin}
+      SMTP_FROM_ADDRESS: ${SMTP_FROM_ADDRESS:-noreply@brevo.com}
     volumes:
       - ./backend/app:/app/app:z
       - ./backend/main.py:/app/main.py:z


### PR DESCRIPTION
## Summary

Secrets management cleanup, email service migration, and LLM call optimization.

## Changes

### Secrets Management
- Remove APP_SECRETS_B64: all 10 secrets now individual GitHub Actions secrets
- Remove Apple Sign-In code (unused, never wired to routers/frontend)
- Remove dead GOOGLE_API_KEY from .env.example
- Add ADMIN_EMAIL to celery_worker_dev and celery_beat_dev

### Email Service
- Resend SDK with vendor-agnostic `EMAIL_API_KEY` (not tied to provider)
- Configurable sender via SMTP_FROM + SMTP_FROM_ADDRESS variables
- Default: NikoFin <noreply@resend.dev>

### LLM Optimization
- Remove _enhance_with_llm from normal Telegram flow (5 call sites)
- Add batch limits to suggest_uncategorized (20/user, 7 days)
- Add in-memory cache to /dashboard/ai-trends (5min TTL)

### Infrastructure
- Worker memory 512M → 1G, concurrency 6 → 2 (Playwright needs)
- Weekly report schedule: 01:30 UTC Monday (22:30 ART Sunday)