### PR TITLE
fix: add --expand to certbot for multi-domain SSL

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -191,7 +191,7 @@ jobs:
               -v /opt/creditcardanalyzer/certbot/work:/var/lib/letsencrypt:Z \
               -v /opt/creditcardanalyzer/certbot/logs:/var/log/letsencrypt:Z \
               -p 80:80 \
-              docker.io/certbot/certbot certonly --standalone \
+              docker.io/certbot/certbot certonly --standalone --expand \
               -d ${{ vars.DOMAIN_NAME }} \
               -d www.${{ vars.DOMAIN_NAME }} \
               -d ${{ vars.PLATFORM_DOMAIN }} \


### PR DESCRIPTION
## Problem

Certbot fails when expanding an existing certificate to include new domains. It asks 'Expand?' but --non-interactive mode can't answer.

Error: Missing command line flag or config entry for this setting

## Fix

Add --expand flag to certbot command so it automatically replaces the existing cert with a new SAN cert covering all three domains (oikonomia.ar, www.oikonomia.ar, platform.oikonomia.ar).