### PR TITLE
feat: config improvements + AI settings simplification

### DIFF
--- a/backend/app/celery_schedule.py
+++ b/backend/app/celery_schedule.py
@@ -1,32 +1,47 @@
+import os
+
 from celery.schedules import crontab
 
 from app.celery_app import celery_app
 
+
+def _cron_from_env(env_key: str, default_hour: int, default_minute: int, **kwargs):
+    """Parse a crontab from env var (format: 'H:M' or 'H:M:dow' or 'H:M:dow:dom')."""
+    val = os.getenv(env_key)
+    if val:
+        parts = val.split(":")
+        hour = int(parts[0])
+        minute = int(parts[1]) if len(parts) > 1 else 0
+        kwargs["day_of_week"] = parts[2] if len(parts) > 2 else None
+        kwargs["day_of_month"] = parts[3] if len(parts) > 3 else None
+        kwargs = {k: v for k, v in kwargs.items() if v is not None}
+        return crontab(hour=hour, minute=minute, **kwargs)
+    return crontab(hour=default_hour, minute=default_minute, **kwargs)
+
+
 celery_app.conf.beat_schedule = {
     "execute-due-installments-daily": {
         "task": "app.tasks.scheduled_expenses.execute_due_installments",
-        "schedule": crontab(hour=2, minute=0),
+        "schedule": _cron_from_env("SCHEDULE_DUE_INSTALLMENTS", 2, 0),
     },
     "cleanup-expired-import-jobs-daily": {
         "task": "app.tasks.cleanup_import_jobs.cleanup_expired_import_jobs",
-        "schedule": crontab(hour=3, minute=30),
+        "schedule": _cron_from_env("SCHEDULE_CLEANUP", 3, 30),
     },
     "daily-uncategorized-expenses": {
         "task": "app.tasks.daily_uncategorized.daily_uncategorized_check",
-        "schedule": crontab(hour=11, minute=0),  # 08:00 UTC-3 = 11:00 UTC
+        "schedule": _cron_from_env("SCHEDULE_UNCATEGORIZED", 11, 0),
     },
     "send-weekly-reports-sunday": {
         "task": "app.tasks.weekly_summary.send_weekly_reports",
-        "schedule": crontab(
-            hour=1, minute=30, day_of_week="monday"
-        ),  # 01:30 UTC Monday = 22:30 ART Sunday
+        "schedule": _cron_from_env("SCHEDULE_WEEKLY_REPORTS", 1, 30, day_of_week="monday"),
     },
     "generate-monthly-reports": {
         "task": "app.tasks.monthly_report.generate_monthly_reports",
-        "schedule": crontab(hour=3, minute=0, day_of_month="1"),  # 03:00 UTC = 00:00 ART
+        "schedule": _cron_from_env("SCHEDULE_MONTHLY_REPORTS", 3, 0, day_of_month="1"),
     },
     "suggest-uncategorized-categories-daily": {
         "task": "app.tasks.suggest_uncategorized.suggest_uncategorized_categories",
-        "schedule": crontab(hour=2, minute=0),  # 23:00 UTC-3 = 02:00 UTC
+        "schedule": _cron_from_env("SCHEDULE_SUGGEST_CATEGORIES", 2, 0),
     },
 }

--- a/backend/app/routers/analysis.py
+++ b/backend/app/routers/analysis.py
@@ -112,7 +112,7 @@ TOP 10 GASTOS MÁS ALTOS:
         try:
             client = genai.Client(api_key=api_key)
             async for chunk in await client.aio.models.generate_content_stream(
-                model="gemini-flash-latest",
+                model=os.getenv("LLM_MODEL_NAME", "gemini-flash-latest"),
                 contents=user_message,
                 config=genai_types.GenerateContentConfig(
                     system_instruction=(None if req.debug_mode else ANALYSIS_SYSTEM_PROMPT),
@@ -199,7 +199,7 @@ async def summarize_chat(
         try:
             client = _genai.Client(api_key=api_key)
             async for chunk in await client.aio.models.generate_content_stream(
-                model="gemini-flash-latest",
+                model=os.getenv("LLM_MODEL_NAME", "gemini-flash-latest"),
                 contents=prompt,
                 config=_gtypes.GenerateContentConfig(temperature=0.3),
             ):

--- a/backend/app/routers/dashboard.py
+++ b/backend/app/routers/dashboard.py
@@ -578,7 +578,7 @@ Sé específico con los números. Respondé en español, de forma clara y amigab
 
             client = genai.Client(api_key=api_key)
             response = await client.aio.models.generate_content(
-                model="gemini-flash-latest",
+                model=os.getenv("LLM_MODEL_NAME", "gemini-flash-latest"),
                 contents=llm_context,
                 config=genai_types.GenerateContentConfig(
                     system_instruction=prompt,
@@ -1892,7 +1892,7 @@ Fecha actual: {today.isoformat()}
     client = genai.Client(api_key=api_key)
     try:
         response = await client.aio.models.generate_content(
-            model="gemini-flash-latest",
+            model=os.getenv("LLM_MODEL_NAME", "gemini-flash-latest"),
             contents=context,
             config=genai_types.GenerateContentConfig(
                 system_instruction=AI_TRENDS_PROMPT,

--- a/backend/app/routers/investments.py
+++ b/backend/app/routers/investments.py
@@ -1011,7 +1011,7 @@ async def investments_chat_stream(
         try:
             client = genai.Client(api_key=api_key)
             async for chunk in await client.aio.models.generate_content_stream(
-                model="gemini-flash-latest",
+                model=os.getenv("LLM_MODEL_NAME", "gemini-flash-latest"),
                 contents=user_message,
                 config=genai_types.GenerateContentConfig(
                     system_instruction=INVESTMENTS_SYSTEM_PROMPT,

--- a/backend/app/services/categorization.py
+++ b/backend/app/services/categorization.py
@@ -157,7 +157,7 @@ def llm_categorize(
                 logger.info("[AI-CAT] Disabled for user %s", user_id)
             return None
 
-        min_confidence = float(_get_setting(db, "ai_suggestions_min_confidence", user_id) or "0.5")
+        min_confidence = 0.5
 
         formatted = _build_formatted_categories(categories)
         if not formatted.strip():
@@ -177,7 +177,7 @@ def llm_categorize(
 
         client = _llm_client()
         response = client.models.generate_content(
-            model="gemini-flash-latest",
+            model=os.getenv("LLM_MODEL_NAME", "gemini-flash-latest"),
             contents=prompt,
             config={"temperature": temperature},
         )

--- a/backend/app/services/smart_import_core.py
+++ b/backend/app/services/smart_import_core.py
@@ -221,7 +221,7 @@ async def run_smart_import(file_content: bytes, filename: str, db: Session, user
     prompt_with_context = SMART_IMPORT_PROMPT.replace("{user_full_name}", user_full_name)
     try:
         response = await client.aio.models.generate_content(
-            model="gemini-flash-latest",
+            model=os.getenv("LLM_MODEL_NAME", "gemini-flash-latest"),
             contents=f"Extracto bancario:\n\n{raw_text[:20000]}",
             config=genai_types.GenerateContentConfig(
                 system_instruction=prompt_with_context,

--- a/backend/app/tasks/monthly_report.py
+++ b/backend/app/tasks/monthly_report.py
@@ -460,7 +460,7 @@ Usa flags para tendencias preocupantes a monitorear."""
 
             async def _call_llm():
                 return await client.aio.models.generate_content(
-                    model="gemini-flash-latest",
+                    model=os.getenv("LLM_MODEL_NAME", "gemini-flash-latest"),
                     contents=llm_context,
                     config=genai_types.GenerateContentConfig(
                         system_instruction=prompt,

--- a/backend/app/tasks/weekly_summary.py
+++ b/backend/app/tasks/weekly_summary.py
@@ -88,7 +88,7 @@ Devolve SOLO el texto del análisis, sin formato JSON."""
 
         async def _call_llm():
             return await client.aio.models.generate_content(
-                model="gemini-flash-latest",
+                model=os.getenv("LLM_MODEL_NAME", "gemini-flash-latest"),
                 contents=llm_context,
                 config=genai_types.GenerateContentConfig(
                     system_instruction=prompt,

--- a/backend/app/telegram_bot.py
+++ b/backend/app/telegram_bot.py
@@ -61,7 +61,7 @@ def _parse_expense(text: str) -> dict | None:
     try:
         client = _gemini_client()
         response = client.models.generate_content(
-            model="gemini-flash-latest",
+            model=os.getenv("LLM_MODEL_NAME", "gemini-flash-latest"),
             contents=prompt,
         )
         raw = response.text.strip()
@@ -90,7 +90,7 @@ def _extract_card_info(raw_input: str, card_type: str) -> dict:
     try:
         client = genai.Client(api_key=api_key)
         response = client.models.generate_content(
-            model="gemini-flash-latest",
+            model=os.getenv("LLM_MODEL_NAME", "gemini-flash-latest"),
             contents=prompt,
         )
         raw = response.text.strip()
@@ -168,7 +168,7 @@ def _parse_bank_notification(text: str) -> dict | None:
 
     try:
         client = genai.Client(api_key=api_key)
-        response = client.models.generate_content(model="gemini-flash-latest", contents=prompt)
+        response = client.models.generate_content(model=os.getenv("LLM_MODEL_NAME", "gemini-flash-latest"), contents=prompt)
         raw = response.text.strip()
         if "```" in raw:
             raw = raw.split("```")[1]

--- a/backend/app/telegram_bot.py
+++ b/backend/app/telegram_bot.py
@@ -168,7 +168,9 @@ def _parse_bank_notification(text: str) -> dict | None:
 
     try:
         client = genai.Client(api_key=api_key)
-        response = client.models.generate_content(model=os.getenv("LLM_MODEL_NAME", "gemini-flash-latest"), contents=prompt)
+        response = client.models.generate_content(
+            model=os.getenv("LLM_MODEL_NAME", "gemini-flash-latest"), contents=prompt
+        )
         raw = response.text.strip()
         if "```" in raw:
             raw = raw.split("```")[1]

--- a/backend/main.py
+++ b/backend/main.py
@@ -47,12 +47,12 @@ async def lifespan(application: FastAPI):
     if db.query(Category).count() == 0:
         _apply_base_hierarchy(db)
 
-    seed_email = os.getenv("SEED_USER_EMAIL", "mmendoza0989@gmail.com")
+    seed_email = os.getenv("SEED_USER_EMAIL", "admin@nikofin.com")
     if not db.query(User).filter(User.email == seed_email).first():
         seed_user = User(
             email=seed_email,
             full_name=os.getenv("SEED_USER_NAME", "Admin"),
-            hashed_password=get_password_hash(os.getenv("SEED_USER_PASSWORD", "changeme123")),
+            hashed_password=get_password_hash(os.getenv("SEED_USER_PASSWORD", "ChangeMe123!")),
             email_verified=True,
         )
         db.add(seed_user)

--- a/frontend/src/components/UserPanel.tsx
+++ b/frontend/src/components/UserPanel.tsx
@@ -1185,35 +1185,9 @@ export default function UserPanel({ open, onClose }: Props) {
                     </button>
                   </div>
                   {settings?.ai_suggestions_enabled !== "false" && (
-                    <>
-                      <p className="text-[10px] text-[var(--text-tertiary)]">
-                        Categorías sugeridas automáticamente al crear gastos
-                      </p>
-                      <div>
-                        <label className="text-[10px] text-[var(--text-secondary)]">
-                          Sensibilidad:{" "}
-                          {Number(settings?.ai_suggestions_min_confidence || "0.5") <= 0.3
-                            ? "Baja"
-                            : Number(settings?.ai_suggestions_min_confidence || "0.5") <= 0.6
-                              ? "Media"
-                              : "Alta"}
-                        </label>
-                        <input
-                          type="range"
-                          min="0.1"
-                          max="1.0"
-                          step="0.1"
-                          value={String(settings?.ai_suggestions_min_confidence || "0.5")}
-                          onChange={(e) => {
-                            settingMut.mutate({
-                              key: "ai_suggestions_min_confidence",
-                              value: e.target.value,
-                            });
-                          }}
-                          className="w-full h-1 mt-1 accent-[var(--color-primary)]"
-                        />
-                      </div>
-                    </>
+                    <p className="text-[10px] text-[var(--text-tertiary)]">
+                      Categorías sugeridas automáticamente al crear gastos
+                    </p>
                   )}
                 </div>
               </div>


### PR DESCRIPTION
## Summary

Make hardcoded configuration env-configurable and simplify AI suggestion settings.

## Changes

### LLM Model (12 files)
- Add LLM_MODEL_NAME env var (default: gemini-flash-latest)
- Change model in 1 place instead of 12

### Celery Schedules (6 schedules)
- All configurable via env vars:
  - SCHEDULE_DUE_INSTALLMENTS (default: 2:00)
  - SCHEDULE_CLEANUP (default: 3:30)
  - SCHEDULE_UNCATEGORIZED (default: 11:00)
  - SCHEDULE_WEEKLY_REPORTS (default: 1:30 mon)
  - SCHEDULE_MONTHLY_REPORTS (default: 3:00 day 1)
  - SCHEDULE_SUGGEST_CATEGORIES (default: 2:00)
- Format: H:M or H:M:dow or H:M:dow:dom

### Seed User Config
- Default email: admin@nikofin.com (was personal email)
- Default password: ChangeMe123! (was weak default)

### AI Settings
- Remove confidence slider from UserPanel
- Hardcode threshold to 0.5
- Keep on/off toggle only