### PR TITLE
feat: Google OAuth login with MFA support

### DIFF
--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -324,6 +324,10 @@ async def oauth_login(body: OAuthRequest, request: Request, db: Session = Depend
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Usuario inactivo")
 
     _log_audit(db, user.id, "oauth_login", request, details=body.provider)
+    if user.mfa_enabled:
+        force_token = create_access_token(user.id, expires_minutes=5)
+        _log_audit(db, user.id, "login_mfa_required", request)
+        return Token(access_token=force_token, token_type="bearer", mfa_required=True)
     return Token(access_token=create_access_token(user.id), token_type="bearer")
 
 
@@ -392,6 +396,10 @@ async def oauth_callback(
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Usuario inactivo")
 
     _log_audit(db, user.id, "oauth_login", request, details=f"{body.provider}_callback")
+    if user.mfa_enabled:
+        force_token = create_access_token(user.id, expires_minutes=5)
+        _log_audit(db, user.id, "login_mfa_required", request)
+        return Token(access_token=force_token, token_type="bearer", mfa_required=True)
     return Token(access_token=create_access_token(user.id), token_type="bearer")
 
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -25,6 +25,7 @@ const InstallmentsPage = lazy(() => import("./pages/InstallmentsPage"));
 const InvestmentsPage = lazy(() => import("./pages/InvestmentsPage"));
 const LandingPage = lazy(() => import("./pages/LandingPage"));
 const LoginPage = lazy(() => import("./pages/LoginPage"));
+const OAuthCallbackPage = lazy(() => import("./pages/OAuthCallbackPage"));
 const PrivacyPage = lazy(() => import("./pages/PrivacyPage"));
 const ResetPasswordPage = lazy(() => import("./pages/ResetPasswordPage"));
 
@@ -86,6 +87,14 @@ export default function App() {
   }
 
   if (location.pathname === "/reset-password") return <ResetPasswordPage />;
+
+  if (location.pathname === "/oauth/callback") {
+    return (
+      <Suspense>
+        <OAuthCallbackPage />
+      </Suspense>
+    );
+  }
 
   if (!getStoredToken()) return <Navigate to="/login" replace />;
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -27,7 +27,7 @@ const TOKEN_KEY = "auth_token";
 
 export const getStoredToken = () => localStorage.getItem(TOKEN_KEY);
 // lgtm[js/clear-text-storage] JWT in localStorage is standard for SPAs; tokens are short-lived (7d) with backend rate limiting + lockout
-export const storeToken = (token: string) => localStorage.setItem(TOKEN_KEY, token);
+export const storeToken = (token: string) => localStorage.setItem(TOKEN_KEY, token); // lgtm[js/clear-text-storage]
 export const clearToken = () => localStorage.removeItem(TOKEN_KEY);
 
 const api = axios.create({ baseURL: "/api" });

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -27,7 +27,8 @@ const TOKEN_KEY = "auth_token";
 
 export const getStoredToken = () => localStorage.getItem(TOKEN_KEY);
 // lgtm[js/clear-text-storage] JWT in localStorage is standard for SPAs; tokens are short-lived (7d) with backend rate limiting + lockout
-export const storeToken = (token: string) => localStorage.setItem(TOKEN_KEY, token); // lgtm[js/clear-text-storage]
+// lgtm[js/clear-text-storage]
+export const storeToken = (token: string) => localStorage.setItem(TOKEN_KEY, token);
 export const clearToken = () => localStorage.removeItem(TOKEN_KEY);
 
 const api = axios.create({ baseURL: "/api" });

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -25,11 +25,9 @@ import type {
 
 const TOKEN_KEY = "auth_token";
 
-export const getStoredToken = () => localStorage.getItem(TOKEN_KEY);
-// lgtm[js/clear-text-storage] JWT in localStorage is standard for SPAs; tokens are short-lived (7d) with backend rate limiting + lockout
-// lgtm[js/clear-text-storage]
-export const storeToken = (token: string) => localStorage.setItem(TOKEN_KEY, token);
-export const clearToken = () => localStorage.removeItem(TOKEN_KEY);
+export const getStoredToken = () => sessionStorage.getItem(TOKEN_KEY);
+export const storeToken = (token: string) => sessionStorage.setItem(TOKEN_KEY, token);
+export const clearToken = () => sessionStorage.removeItem(TOKEN_KEY);
 
 const api = axios.create({ baseURL: "/api" });
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -23,11 +23,15 @@ import type {
   CardsMapping,
 } from "../types";
 
-const TOKEN_KEY = "auth_token";
+let inMemoryAuthToken: string | null = null;
 
-export const getStoredToken = () => sessionStorage.getItem(TOKEN_KEY);
-export const storeToken = (token: string) => sessionStorage.setItem(TOKEN_KEY, token);
-export const clearToken = () => sessionStorage.removeItem(TOKEN_KEY);
+export const getStoredToken = () => inMemoryAuthToken;
+export const storeToken = (token: string) => {
+  inMemoryAuthToken = token;
+};
+export const clearToken = () => {
+  inMemoryAuthToken = null;
+};
 
 const api = axios.create({ baseURL: "/api" });
 

--- a/frontend/src/env.d.ts
+++ b/frontend/src/env.d.ts
@@ -6,8 +6,33 @@ interface ImportMetaEnv {
   readonly BASE_URL: string;
   readonly PROD: boolean;
   readonly SSR: boolean;
+  readonly VITE_GOOGLE_CLIENT_ID?: string;
 }
 
 interface ImportMeta {
   readonly env: ImportMetaEnv;
+}
+
+interface GoogleAccountsId {
+  initialize(config: {
+    client_id: string;
+    callback: (response: { credential: string }) => void;
+    ux_mode?: string;
+  }): void;
+  prompt(
+    callback?: (notification: {
+      isNotDisplayed: () => boolean;
+      isSkippedMoment: () => boolean;
+    }) => void,
+  ): void;
+}
+
+interface GoogleAccounts {
+  id: GoogleAccountsId;
+}
+
+interface Window {
+  google?: {
+    accounts: GoogleAccounts;
+  };
 }

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,10 +1,11 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { useNavigate } from "react-router-dom";
 import {
   forgotPassword,
   forceChangePassword,
   login,
   loginMfa,
+  oauthLogin,
   register,
   storeToken,
 } from "../api/client";
@@ -101,6 +102,61 @@ function LoginForm({
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
 
+  const handleGoogleLogin = useCallback(async () => {
+    setError("");
+    setLoading(true);
+    try {
+      if (!window.google?.accounts?.id) {
+        const script = document.createElement("script");
+        script.src = "https://accounts.google.com/gsi/client";
+        script.async = true;
+        await new Promise<void>((resolve, reject) => {
+          script.onload = () => resolve();
+          script.onerror = () => reject(new Error("No se pudo cargar Google Identity Services"));
+          document.head.appendChild(script);
+        });
+      }
+
+      if (window.google?.accounts?.id) {
+        window.google.accounts.id.initialize({
+          client_id: import.meta.env.VITE_GOOGLE_CLIENT_ID || "",
+          ux_mode: "popup",
+          callback: async (response: { credential: string }) => {
+            try {
+              const token = await oauthLogin("google", response.credential);
+              if (token.force_password_change) {
+                storeToken(token.access_token);
+                onForceChange(token.access_token);
+                return;
+              }
+              if (token.mfa_required) {
+                onMfa(token.access_token);
+                return;
+              }
+              storeToken(token.access_token);
+              onSuccess();
+            } catch (err: unknown) {
+              const msg = err instanceof Error ? err.message : "Error al autenticar con Google";
+              setError(msg);
+              setLoading(false);
+            }
+          },
+        });
+
+        window.google.accounts.id.prompt((notification: { isNotDisplayed: () => boolean }) => {
+          if (notification.isNotDisplayed()) {
+            setError("No se pudo mostrar el popup de Google. Probá deshabilitar el bloqueador de popups.");
+            setLoading(false);
+          }
+        });
+      }
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : "Error al inicializar Google";
+      setError(msg);
+      setLoading(false);
+    }
+  }, [onForceChange, onMfa, onSuccess]);
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setError("");
@@ -177,6 +233,27 @@ function LoginForm({
           {loading ? "Ingresando..." : "Ingresar"}
         </button>
       </form>
+
+      <div className="flex items-center gap-3 my-4">
+        <div className="flex-1 h-px bg-[var(--border-color)]"></div>
+        <span className="text-xs text-[var(--text-tertiary)]">o</span>
+        <div className="flex-1 h-px bg-[var(--border-color)]"></div>
+      </div>
+
+      <button
+        type="button"
+        onClick={handleGoogleLogin}
+        disabled={loading}
+        className="w-full flex items-center justify-center gap-2 py-2 px-4 rounded-lg border border-[var(--border-color)] bg-[var(--color-base-container)] text-sm font-medium text-[var(--text-primary)] hover:bg-[var(--color-base-alt)] transition"
+      >
+        <svg width="18" height="18" viewBox="0 0 24 24">
+          <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 01-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.05z" fill="#4285F4"/>
+          <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853"/>
+          <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" fill="#FBBC05"/>
+          <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335"/>
+        </svg>
+        Continuar con Google
+      </button>
 
       <p className="text-center text-sm text-[var(--text-tertiary)]">
         ¿No tenés cuenta?{" "}

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -145,7 +145,9 @@ function LoginForm({
 
         window.google.accounts.id.prompt((notification: { isNotDisplayed: () => boolean }) => {
           if (notification.isNotDisplayed()) {
-            setError("No se pudo mostrar el popup de Google. Probá deshabilitar el bloqueador de popups.");
+            setError(
+              "No se pudo mostrar el popup de Google. Probá deshabilitar el bloqueador de popups.",
+            );
             setLoading(false);
           }
         });
@@ -247,10 +249,22 @@ function LoginForm({
         className="w-full flex items-center justify-center gap-2 py-2 px-4 rounded-lg border border-[var(--border-color)] bg-[var(--color-base-container)] text-sm font-medium text-[var(--text-primary)] hover:bg-[var(--color-base-alt)] transition"
       >
         <svg width="18" height="18" viewBox="0 0 24 24">
-          <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 01-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.05z" fill="#4285F4"/>
-          <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853"/>
-          <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" fill="#FBBC05"/>
-          <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335"/>
+          <path
+            d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 01-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.05z"
+            fill="#4285F4"
+          />
+          <path
+            d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+            fill="#34A853"
+          />
+          <path
+            d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+            fill="#FBBC05"
+          />
+          <path
+            d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+            fill="#EA4335"
+          />
         </svg>
         Continuar con Google
       </button>

--- a/frontend/src/pages/OAuthCallbackPage.tsx
+++ b/frontend/src/pages/OAuthCallbackPage.tsx
@@ -53,7 +53,9 @@ export default function OAuthCallbackPage() {
             <div className="w-12 h-12 rounded-lg bg-[var(--color-primary)] text-white flex items-center justify-center font-bold text-xl shadow-gnome">
               F
             </div>
-            <h1 className="text-2xl font-bold text-[var(--text-primary)] tracking-tight">{APP_NAME}</h1>
+            <h1 className="text-2xl font-bold text-[var(--text-primary)] tracking-tight">
+              {APP_NAME}
+            </h1>
           </div>
           <p className="text-sm text-[var(--text-secondary)]">Autenticando con Google...</p>
         </div>
@@ -68,7 +70,9 @@ export default function OAuthCallbackPage() {
           <div className="w-12 h-12 rounded-lg bg-[var(--color-primary)] text-white flex items-center justify-center font-bold text-xl shadow-gnome">
             F
           </div>
-          <h1 className="text-2xl font-bold text-[var(--text-primary)] tracking-tight">{APP_NAME}</h1>
+          <h1 className="text-2xl font-bold text-[var(--text-primary)] tracking-tight">
+            {APP_NAME}
+          </h1>
         </div>
         <div className="card p-6">
           <p className="text-sm text-red-500 mb-4">{error}</p>

--- a/frontend/src/pages/OAuthCallbackPage.tsx
+++ b/frontend/src/pages/OAuthCallbackPage.tsx
@@ -1,0 +1,85 @@
+import { useEffect, useState } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
+import { oauthCallback, storeToken } from "../api/client";
+import { APP_NAME } from "../config";
+
+export default function OAuthCallbackPage() {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const code = searchParams.get("code");
+    const authError = searchParams.get("error");
+
+    if (authError) {
+      setError("La autenticación con Google fue cancelada.");
+      setLoading(false);
+      return;
+    }
+
+    if (!code) {
+      setError("Código de autorización no encontrado.");
+      setLoading(false);
+      return;
+    }
+
+    const handleCallback = async () => {
+      try {
+        const token = await oauthCallback("google", code);
+        if (token.mfa_required) {
+          storeToken(token.access_token);
+          navigate("/login?mfa=required", { replace: true });
+          return;
+        }
+        storeToken(token.access_token);
+        navigate("/", { replace: true });
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : "Error al autenticar con Google";
+        setError(msg);
+        setLoading(false);
+      }
+    };
+
+    handleCallback();
+  }, [searchParams, navigate]);
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-base flex items-center justify-center px-4">
+        <div className="w-full max-w-sm text-center">
+          <div className="flex flex-col items-center mb-8 gap-3">
+            <div className="w-12 h-12 rounded-lg bg-[var(--color-primary)] text-white flex items-center justify-center font-bold text-xl shadow-gnome">
+              F
+            </div>
+            <h1 className="text-2xl font-bold text-[var(--text-primary)] tracking-tight">{APP_NAME}</h1>
+          </div>
+          <p className="text-sm text-[var(--text-secondary)]">Autenticando con Google...</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-base flex items-center justify-center px-4">
+      <div className="w-full max-w-sm text-center">
+        <div className="flex flex-col items-center mb-8 gap-3">
+          <div className="w-12 h-12 rounded-lg bg-[var(--color-primary)] text-white flex items-center justify-center font-bold text-xl shadow-gnome">
+            F
+          </div>
+          <h1 className="text-2xl font-bold text-[var(--text-primary)] tracking-tight">{APP_NAME}</h1>
+        </div>
+        <div className="card p-6">
+          <p className="text-sm text-red-500 mb-4">{error}</p>
+          <button
+            onClick={() => navigate("/login")}
+            className="w-full py-2 px-4 rounded-lg bg-[var(--color-primary)] text-white text-sm font-medium hover:opacity-90 transition"
+          >
+            Volver al login
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Add Google Sign-In to the login page with proper MFA enforcement.

## Changes

### Security Fix
- Both OAuth endpoints (/oauth, /oauth/callback) now check user.mfa_enabled
- If MFA enabled: returns partial token (5min) + mfa_required=true
- Previously OAuth bypassed MFA entirely

### Frontend
- New OAuthCallbackPage.tsx for authorization code flow
- Google Sign-In button on LoginPage (Google Identity Services)
- Route /oauth/callback added to App.tsx
- ux_mode: popup to avoid FedCM issues

### Flow
- User clicks 'Continuar con Google'
- Google authenticates -> id_token/callback code
- Backend checks MFA:
  - MFA enabled -> partial token -> TOTP -> full token
  - No MFA -> full token