### PR TITLE
fix: add Google to CSP script-src for OAuth

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -8,7 +8,7 @@ server {
     add_header X-XSS-Protection "1; mode=block";
     add_header Referrer-Policy "strict-origin-when-cross-origin";
     add_header Permissions-Policy "camera=(), microphone=(), geolocation=()";
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' https://fonts.googleapis.com https://fonts.gstatic.com; connect-src 'self' https:; frame-ancestors 'none'";
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' https://accounts.google.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' https://fonts.googleapis.com https://fonts.gstatic.com; connect-src 'self' https:; frame-ancestors 'none'";
 
     # React SPA — serve index.html for all routes
     location / {

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -68,7 +68,7 @@ server {
     add_header X-Frame-Options DENY;
     add_header X-XSS-Protection "1; mode=block";
     add_header Referrer-Policy "strict-origin-when-cross-origin";
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' https://fonts.googleapis.com https://fonts.gstatic.com; connect-src 'self' https:; frame-ancestors 'none'";
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' https://accounts.google.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' https://fonts.googleapis.com https://fonts.gstatic.com; connect-src 'self' https:; frame-ancestors 'none'";
 
     gzip on;
     gzip_types text/plain text/css application/json application/javascript text/xml;


### PR DESCRIPTION
## Problem

Google Identity Services script (https://accounts.google.com/gsi/client) was blocked by Content Security Policy in production.

Error: Refused to load https://accounts.google.com/gsi/client because it does not appear in the script-src directive of the Content Security Policy.

## Fix

Add https://accounts.google.com to script-src in both nginx configs:
- nginx/nginx.conf (production reverse proxy)
- frontend/nginx.conf (frontend container)

This allows Google Identity Services to load for OAuth login.