### PR TITLE
fix: CSP style-src for Google + VITE_GOOGLE_CLIENT_ID build arg

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -68,6 +68,7 @@ jobs:
           push: true
           build-args: |
             VITE_APP_ENV=production
+            VITE_GOOGLE_CLIENT_ID=${{ secrets.GOOGLE_CLIENT_ID }}
           tags: |
             ${{ env.FRONTEND_IMAGE }}:${{ github.sha }}
             ${{ env.FRONTEND_IMAGE }}:latest

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -8,7 +8,7 @@ server {
     add_header X-XSS-Protection "1; mode=block";
     add_header Referrer-Policy "strict-origin-when-cross-origin";
     add_header Permissions-Policy "camera=(), microphone=(), geolocation=()";
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' https://accounts.google.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' https://fonts.googleapis.com https://fonts.gstatic.com; connect-src 'self' https:; frame-ancestors 'none'";
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' https://accounts.google.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://accounts.google.com; img-src 'self' data: https:; font-src 'self' https://fonts.googleapis.com https://fonts.gstatic.com; connect-src 'self' https:; frame-ancestors 'none'";
 
     # React SPA — serve index.html for all routes
     location / {

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -68,7 +68,7 @@ server {
     add_header X-Frame-Options DENY;
     add_header X-XSS-Protection "1; mode=block";
     add_header Referrer-Policy "strict-origin-when-cross-origin";
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' https://accounts.google.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' https://fonts.googleapis.com https://fonts.gstatic.com; connect-src 'self' https:; frame-ancestors 'none'";
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' https://accounts.google.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://accounts.google.com; img-src 'self' data: https:; font-src 'self' https://fonts.googleapis.com https://fonts.gstatic.com; connect-src 'self' https:; frame-ancestors 'none'";
 
     gzip on;
     gzip_types text/plain text/css application/json application/javascript text/xml;


### PR DESCRIPTION
## Problem

1. CSP blocks Google stylesheet: 'Refused to load https://accounts.google.com/gsi/style'
2. GOOGLE_CLIENT_ID empty in prod frontend build

## Fix

### CSP
Add https://accounts.google.com to style-src in both nginx configs (nginx/nginx.conf + frontend/nginx.conf)

### Frontend build
Add VITE_GOOGLE_CLIENT_ID as build arg in CI pipeline so it's baked into the production build