### PR TITLE
fix: add VITE_GOOGLE_CLIENT_ID as ARG+ENV in frontend Dockerfile

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -5,6 +5,9 @@ WORKDIR /app
 ARG VITE_APP_ENV=development
 ENV VITE_APP_ENV=$VITE_APP_ENV
 
+ARG VITE_GOOGLE_CLIENT_ID
+ENV VITE_GOOGLE_CLIENT_ID=$VITE_GOOGLE_CLIENT_ID
+
 COPY package.json package-lock.json ./
 RUN npm ci --prefer-offline
 


### PR DESCRIPTION
## Problem

Google OAuth shows 'Missing required parameter: client_id' in prod. The VITE_GOOGLE_CLIENT_ID build arg was passed in CI but not declared in the Dockerfile, so Vite silently ignored it.

## Fix

Add ARG and ENV declarations for VITE_GOOGLE_CLIENT_ID in the frontend Dockerfile so Vite sees the build arg during production build.