### PR TITLE
fix: add frame-src to CSP for Google OAuth iframe

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -8,7 +8,7 @@ server {
     add_header X-XSS-Protection "1; mode=block";
     add_header Referrer-Policy "strict-origin-when-cross-origin";
     add_header Permissions-Policy "camera=(), microphone=(), geolocation=()";
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' https://accounts.google.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://accounts.google.com; img-src 'self' data: https:; font-src 'self' https://fonts.googleapis.com https://fonts.gstatic.com; connect-src 'self' https:; frame-ancestors 'none'";
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' https://accounts.google.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://accounts.google.com; img-src 'self' data: https:; font-src 'self' https://fonts.googleapis.com https://fonts.gstatic.com; connect-src 'self' https:; frame-src https://accounts.google.com; frame-ancestors 'none'";
 
     # React SPA — serve index.html for all routes
     location / {

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -68,7 +68,7 @@ server {
     add_header X-Frame-Options DENY;
     add_header X-XSS-Protection "1; mode=block";
     add_header Referrer-Policy "strict-origin-when-cross-origin";
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' https://accounts.google.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://accounts.google.com; img-src 'self' data: https:; font-src 'self' https://fonts.googleapis.com https://fonts.gstatic.com; connect-src 'self' https:; frame-ancestors 'none'";
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' https://accounts.google.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://accounts.google.com; img-src 'self' data: https:; font-src 'self' https://fonts.googleapis.com https://fonts.gstatic.com; connect-src 'self' https:; frame-src https://accounts.google.com; frame-ancestors 'none'";
 
     gzip on;
     gzip_types text/plain text/css application/json application/javascript text/xml;


### PR DESCRIPTION
## Problem

Google OAuth popup uses an internal iframe at accounts.google.com. CSP blocks it with 'default-src self'.

Error: Content-Security-Policy blocked frame-src https://accounts.google.com/gsi/iframe/select

## Fix

Add frame-src https://accounts.google.com to CSP in both nginx configs.