### PR TITLE
fix: switch Google OAuth from prompt() to renderButton()

### DIFF
--- a/frontend/src/env.d.ts
+++ b/frontend/src/env.d.ts
@@ -25,6 +25,15 @@ interface GoogleAccountsId {
       isSkippedMoment: () => boolean;
     }) => void,
   ): void;
+  renderButton(
+    element: HTMLElement,
+    options: {
+      theme?: string;
+      size?: string;
+      width?: string;
+      text?: string;
+    },
+  ): void;
 }
 
 interface GoogleAccounts {

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -101,11 +101,10 @@ function LoginForm({
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
-
-  const handleGoogleLogin = useCallback(async () => {
-    setError("");
-    setLoading(true);
-    try {
+  const googleBtnRef = useCallback((node: HTMLDivElement | null) => {
+    if (!node) return;
+    const initGoogle = async () => {
+      // Load Google Identity Services
       if (!window.google?.accounts?.id) {
         const script = document.createElement("script");
         script.src = "https://accounts.google.com/gsi/client";
@@ -120,8 +119,9 @@ function LoginForm({
       if (window.google?.accounts?.id) {
         window.google.accounts.id.initialize({
           client_id: import.meta.env.VITE_GOOGLE_CLIENT_ID || "",
-          ux_mode: "popup",
           callback: async (response: { credential: string }) => {
+            setError("");
+            setLoading(true);
             try {
               const token = await oauthLogin("google", response.credential);
               if (token.force_password_change) {
@@ -143,20 +143,15 @@ function LoginForm({
           },
         });
 
-        window.google.accounts.id.prompt((notification: { isNotDisplayed: () => boolean }) => {
-          if (notification.isNotDisplayed()) {
-            setError(
-              "No se pudo mostrar el popup de Google. Probá deshabilitar el bloqueador de popups.",
-            );
-            setLoading(false);
-          }
+        window.google.accounts.id.renderButton(node, {
+          theme: "outline",
+          size: "large",
+          width: "100%",
+          text: "continue_with",
         });
       }
-    } catch (err: unknown) {
-      const msg = err instanceof Error ? err.message : "Error al inicializar Google";
-      setError(msg);
-      setLoading(false);
-    }
+    };
+    initGoogle();
   }, [onForceChange, onMfa, onSuccess]);
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -242,32 +237,7 @@ function LoginForm({
         <div className="flex-1 h-px bg-[var(--border-color)]"></div>
       </div>
 
-      <button
-        type="button"
-        onClick={handleGoogleLogin}
-        disabled={loading}
-        className="w-full flex items-center justify-center gap-2 py-2 px-4 rounded-lg border border-[var(--border-color)] bg-[var(--color-base-container)] text-sm font-medium text-[var(--text-primary)] hover:bg-[var(--color-base-alt)] transition"
-      >
-        <svg width="18" height="18" viewBox="0 0 24 24">
-          <path
-            d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 01-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.05z"
-            fill="#4285F4"
-          />
-          <path
-            d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
-            fill="#34A853"
-          />
-          <path
-            d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
-            fill="#FBBC05"
-          />
-          <path
-            d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
-            fill="#EA4335"
-          />
-        </svg>
-        Continuar con Google
-      </button>
+      <div ref={googleBtnRef} className="w-full flex justify-center" />
 
       <p className="text-center text-sm text-[var(--text-tertiary)]">
         ¿No tenés cuenta?{" "}

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -101,58 +101,61 @@ function LoginForm({
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
-  const googleBtnRef = useCallback((node: HTMLDivElement | null) => {
-    if (!node) return;
-    const initGoogle = async () => {
-      // Load Google Identity Services
-      if (!window.google?.accounts?.id) {
-        const script = document.createElement("script");
-        script.src = "https://accounts.google.com/gsi/client";
-        script.async = true;
-        await new Promise<void>((resolve, reject) => {
-          script.onload = () => resolve();
-          script.onerror = () => reject(new Error("No se pudo cargar Google Identity Services"));
-          document.head.appendChild(script);
-        });
-      }
+  const googleBtnRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      if (!node) return;
+      const initGoogle = async () => {
+        // Load Google Identity Services
+        if (!window.google?.accounts?.id) {
+          const script = document.createElement("script");
+          script.src = "https://accounts.google.com/gsi/client";
+          script.async = true;
+          await new Promise<void>((resolve, reject) => {
+            script.onload = () => resolve();
+            script.onerror = () => reject(new Error("No se pudo cargar Google Identity Services"));
+            document.head.appendChild(script);
+          });
+        }
 
-      if (window.google?.accounts?.id) {
-        window.google.accounts.id.initialize({
-          client_id: import.meta.env.VITE_GOOGLE_CLIENT_ID || "",
-          callback: async (response: { credential: string }) => {
-            setError("");
-            setLoading(true);
-            try {
-              const token = await oauthLogin("google", response.credential);
-              if (token.force_password_change) {
+        if (window.google?.accounts?.id) {
+          window.google.accounts.id.initialize({
+            client_id: import.meta.env.VITE_GOOGLE_CLIENT_ID || "",
+            callback: async (response: { credential: string }) => {
+              setError("");
+              setLoading(true);
+              try {
+                const token = await oauthLogin("google", response.credential);
+                if (token.force_password_change) {
+                  storeToken(token.access_token);
+                  onForceChange(token.access_token);
+                  return;
+                }
+                if (token.mfa_required) {
+                  onMfa(token.access_token);
+                  return;
+                }
                 storeToken(token.access_token);
-                onForceChange(token.access_token);
-                return;
+                onSuccess();
+              } catch (err: unknown) {
+                const msg = err instanceof Error ? err.message : "Error al autenticar con Google";
+                setError(msg);
+                setLoading(false);
               }
-              if (token.mfa_required) {
-                onMfa(token.access_token);
-                return;
-              }
-              storeToken(token.access_token);
-              onSuccess();
-            } catch (err: unknown) {
-              const msg = err instanceof Error ? err.message : "Error al autenticar con Google";
-              setError(msg);
-              setLoading(false);
-            }
-          },
-        });
+            },
+          });
 
-        window.google.accounts.id.renderButton(node, {
-          theme: "outline",
-          size: "large",
-          width: "100%",
-          text: "continue_with",
-        });
-      }
-    };
-    initGoogle();
-  }, [onForceChange, onMfa, onSuccess]);
+          window.google.accounts.id.renderButton(node, {
+            theme: "outline",
+            size: "large",
+            width: "100%",
+            text: "continue_with",
+          });
+        }
+      };
+      initGoogle();
+    },
+    [onForceChange, onMfa, onSuccess],
+  );
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();


### PR DESCRIPTION
## Problem

Google OAuth popup doesn't appear in prod. The old GSI prompt() API is deprecated due to FedCM migration.

## Fix

Switch from prompt() to Google's official renderButton() API:
- Uses Google's branded button (no custom SVG needed)
- Works with FedCM (Federated Credential Management)
- More reliable across browsers (Chrome, Firefox, Safari)
- Follows Google's recommended migration path

## Changes
- Replace handleGoogleLogin + prompt() with renderButton() callback ref
- Remove custom button SVG, use Google's rendered button
- Add renderButton type to env.d.ts
- Set theme: outline, size: large, text: continue_with