### PR TITLE
fix: add secret loading to frontend docker-entrypoint

### DIFF
--- a/frontend/docker-entrypoint.sh
+++ b/frontend/docker-entrypoint.sh
@@ -1,4 +1,9 @@
 #!/bin/sh
 set -e
 
+# Load Google Client ID from podman secret
+if [ -f "/run/secrets/creditcard_frontend_dev_google_client_id" ]; then
+  export VITE_GOOGLE_CLIENT_ID="$(cat /run/secrets/creditcard_frontend_dev_google_client_id)"
+fi
+
 exec npm run dev -- --host 0.0.0.0


### PR DESCRIPTION
## Problem

VITE_GOOGLE_CLIENT_ID not loaded in dev frontend container. The entrypoint script was missing the secret loading code.

## Fix

Add secret loading to frontend/docker-entrypoint.sh:
- Read creditcard_frontend_dev_google_client_id from podman secret
- Export as VITE_GOOGLE_CLIENT_ID env var
- Vite picks it up at dev server startup

This was missing from the Dockerfile.dev build - the entrypoint was the old version without secret loading.