### PR TITLE
fix: remove MFA check from OAuth endpoints

### DIFF
--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -324,10 +324,6 @@ async def oauth_login(body: OAuthRequest, request: Request, db: Session = Depend
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Usuario inactivo")
 
     _log_audit(db, user.id, "oauth_login", request, details=body.provider)
-    if user.mfa_enabled:
-        force_token = create_access_token(user.id, expires_minutes=5)
-        _log_audit(db, user.id, "login_mfa_required", request)
-        return Token(access_token=force_token, token_type="bearer", mfa_required=True)
     return Token(access_token=create_access_token(user.id), token_type="bearer")
 
 
@@ -396,10 +392,6 @@ async def oauth_callback(
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Usuario inactivo")
 
     _log_audit(db, user.id, "oauth_login", request, details=f"{body.provider}_callback")
-    if user.mfa_enabled:
-        force_token = create_access_token(user.id, expires_minutes=5)
-        _log_audit(db, user.id, "login_mfa_required", request)
-        return Token(access_token=force_token, token_type="bearer", mfa_required=True)
     return Token(access_token=create_access_token(user.id), token_type="bearer")
 
 

--- a/frontend/src/pages/OAuthCallbackPage.tsx
+++ b/frontend/src/pages/OAuthCallbackPage.tsx
@@ -28,11 +28,6 @@ export default function OAuthCallbackPage() {
     const handleCallback = async () => {
       try {
         const token = await oauthCallback("google", code);
-        if (token.mfa_required) {
-          storeToken(token.access_token);
-          navigate("/login?mfa=required", { replace: true });
-          return;
-        }
         storeToken(token.access_token);
         navigate("/", { replace: true });
       } catch (err: unknown) {


### PR DESCRIPTION
## Problem

OAuth users were asked for MFA after Google authentication. This is redundant — Google already verifies identity via their account (password + their own MFA).

## Fix

- Remove MFA check from /oauth and /oauth/callback endpoints
- OAuth now returns full token directly (no partial token, no MFA prompt)
- Simplify OAuthCallbackPage (remove mfa_required handling)
- Password login still checks MFA as before