### PR TITLE
fix: switch Google OAuth from popup to redirect mode

### DIFF
--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -338,7 +338,7 @@ async def oauth_callback(
     if not body.code:
         raise HTTPException(status_code=400, detail="Falta código de autorización")
 
-    redirect_uri = f"{os.getenv('FRONTEND_URL', 'http://localhost:5173')}/oauth/google/callback"
+    redirect_uri = f"{os.getenv('FRONTEND_URL', 'http://localhost:5173')}/oauth/callback"
     google_data = await exchange_google_code(body.code, redirect_uri)
 
     email = google_data.get("email", "").lower()

--- a/frontend/src/env.d.ts
+++ b/frontend/src/env.d.ts
@@ -17,7 +17,8 @@ interface GoogleAccountsId {
   initialize(config: {
     client_id: string;
     callback: (response: { credential: string }) => void;
-    ux_mode?: string;
+    ux_mode?: "popup" | "redirect";
+    login_uri?: string;
   }): void;
   prompt(
     callback?: (notification: {

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -6,7 +6,6 @@ import {
   getStoredToken,
   login,
   loginMfa,
-  oauthLogin,
   register,
   storeToken,
 } from "../api/client";
@@ -133,28 +132,11 @@ function LoginForm({
         if (window.google?.accounts?.id) {
           window.google.accounts.id.initialize({
             client_id: import.meta.env.VITE_GOOGLE_CLIENT_ID || "",
-            callback: async (response: { credential: string }) => {
-              setError("");
-              setLoading(true);
-              try {
-                const token = await oauthLogin("google", response.credential);
-                if (token.force_password_change) {
-                  storeToken(token.access_token);
-                  onForceChange(token.access_token);
-                  return;
-                }
-                if (token.mfa_required) {
-                  onMfa(token.access_token);
-                  return;
-                }
-                storeToken(token.access_token);
-                onSuccess();
-              } catch (err: unknown) {
-                const msg = err instanceof Error ? err.message : "Error al autenticar con Google";
-                setError(msg);
-                setLoading(false);
-              }
-            },
+            ux_mode: "redirect",
+            login_uri: `${window.location.origin}/oauth/callback`,
+            // In redirect mode, Google redirects to login_uri instead of calling this callback.
+            // Kept as required by the GIS API but not used in redirect flow.
+            callback: () => {},
           });
 
           window.google.accounts.id.renderButton(node, {

--- a/frontend/src/pages/OAuthCallbackPage.tsx
+++ b/frontend/src/pages/OAuthCallbackPage.tsx
@@ -28,6 +28,15 @@ export default function OAuthCallbackPage() {
     const handleCallback = async () => {
       try {
         const token = await oauthCallback("google", code);
+        if (token.force_password_change) {
+          storeToken(token.access_token);
+          navigate("/login?force_change=1", { replace: true });
+          return;
+        }
+        if (token.mfa_required) {
+          navigate("/login?mfa=1", { replace: true, state: { token: token.access_token } });
+          return;
+        }
         storeToken(token.access_token);
         navigate("/", { replace: true });
       } catch (err: unknown) {


### PR DESCRIPTION
## Problem

Google OAuth popup stays blank when using Epiphany (GNOME Web) as a WebApp. Epiphany's WebApp mode restricts popup behavior via WebKit, causing the Google auth popup to open but render nothing.

## Solution

Switch Google Identity Services from **popup mode** (default) to **redirect mode**. Instead of opening a popup, Google redirects the entire browser to a callback URL with the auth code. This works universally, including Epiphany WebApps.

## Changes

- **LoginPage.tsx**: GIS initialize() with ux_mode:'redirect' and login_uri pointing to /oauth/callback
- **env.d.ts**: Updated type declaration for ux_mode and login_uri
- **OAuthCallbackPage.tsx**: Added MFA + force_password_change handling (was missing)
- **auth.py**: Fixed redirect_uri from /oauth/google/callback to /oauth/callback (route mismatch)

## Flow (after fix)
1. User clicks 'Continuar con Google'
2. Browser redirects to accounts.google.com (full page, no popup)
3. User authenticates
4. Google redirects back to platform.oikonomia.ar/oauth/callback?code=...
5. OAuthCallbackPage reads code, sends to POST /api/auth/oauth/callback
6. Backend exchanges code for tokens, returns JWT
7. Frontend stores token, handles MFA/force_password_change if needed

## Required External Step

The redirect URI `https://platform.oikonomia.ar/oauth/callback` must be registered in **Google Cloud Console** → OAuth 2.0 Client → Authorized redirect URIs.