### PR TITLE
fix: OAuth callback 405 + Epiphany WebApp manifest

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -15,7 +15,9 @@
       media="(prefers-color-scheme: dark)"
     />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
-    <title>NikoFin</title>
+    <meta name="theme-color" content="#3584e4" />
+    <link rel="manifest" href="/manifest.json" />
+    <title>Oikonomia</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -10,6 +10,11 @@ server {
     add_header Permissions-Policy "camera=(), microphone=(), geolocation=()";
     add_header Content-Security-Policy "default-src 'self'; script-src 'self' https://accounts.google.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://accounts.google.com; img-src 'self' data: https:; font-src 'self' https://fonts.googleapis.com https://fonts.gstatic.com; connect-src 'self' https:; frame-src https://accounts.google.com; frame-ancestors 'none'";
 
+    # OAuth callback — must serve SPA for redirect flow
+    location /oauth/ {
+        try_files $uri /index.html;
+    }
+
     # React SPA — serve index.html for all routes
     location / {
         try_files $uri $uri/ /index.html;

--- a/frontend/public/manifest.json
+++ b/frontend/public/manifest.json
@@ -1,0 +1,25 @@
+{
+  "name": "Oikonomia",
+  "short_name": "Oikonomia",
+  "description": "Tu planificador financiero personal con inteligencia artificial",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#f6f5f4",
+  "theme_color": "#3584e4",
+  "orientation": "any",
+  "icons": [
+    {
+      "src": "/favicon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "any"
+    },
+    {
+      "src": "/favicon-dark.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "maskable"
+    }
+  ],
+  "categories": ["finance", "productivity"]
+}

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -73,6 +73,14 @@ server {
     gzip on;
     gzip_types text/plain text/css application/json application/javascript text/xml;
 
+    location /oauth/ {
+        proxy_pass http://frontend:80;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
     location / {
         proxy_pass http://frontend:80;
         proxy_set_header Host $host;
@@ -82,6 +90,7 @@ server {
         proxy_buffering off;
         proxy_cache off;
         proxy_read_timeout 86400;
-        chunked_transfer_encoding on;
+        chunked transfer_encoding on;
     }
+}
 }


### PR DESCRIPTION
## Fixes

### 1. OAuth callback 405 Not Allowed
Added explicit `/oauth/` location blocks to both nginx configs so the SPA fallback handles the Google redirect correctly:
- `frontend/nginx.conf`: `location /oauth/ { try_files $uri /index.html; }`
- `nginx/nginx.conf`: `location /oauth/ { proxy_pass http://frontend:80; ... }`

### 2. Epiphany WebApp install
Added PWA manifest so Epiphany's "Install Site" works:
- `public/manifest.json`: app name, theme color, icons, standalone display
- `index.html`: manifest link + theme-color meta tag
- Title updated: NikoFin → Oikonomia