### PR TITLE
fix: Google OAuth initCodeClient - same-window redirect for Epiphany

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -12,6 +12,7 @@ server {
 
     # OAuth callback — must serve SPA for redirect flow
     location /oauth/ {
+        error_page 405 =200 /index.html;
         try_files $uri /index.html;
     }
 

--- a/frontend/src/env.d.ts
+++ b/frontend/src/env.d.ts
@@ -37,8 +37,23 @@ interface GoogleAccountsId {
   ): void;
 }
 
+interface GoogleCodeClient {
+  requestCode(): void;
+}
+
+interface GoogleAccountsOauth2 {
+  initCodeClient(config: {
+    client_id: string;
+    scope: string;
+    ux_mode: "popup" | "redirect";
+    redirect_uri: string;
+    state?: string;
+  }): GoogleCodeClient;
+}
+
 interface GoogleAccounts {
   id: GoogleAccountsId;
+  oauth2: GoogleAccountsOauth2;
 }
 
 interface Window {

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -113,44 +113,31 @@ function LoginForm({
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
-  const googleBtnRef = useCallback(
-    (node: HTMLDivElement | null) => {
-      if (!node) return;
-      const initGoogle = async () => {
-        // Load Google Identity Services
-        if (!window.google?.accounts?.id) {
-          const script = document.createElement("script");
-          script.src = "https://accounts.google.com/gsi/client";
-          script.async = true;
-          await new Promise<void>((resolve, reject) => {
-            script.onload = () => resolve();
-            script.onerror = () => reject(new Error("No se pudo cargar Google Identity Services"));
-            document.head.appendChild(script);
-          });
-        }
 
-        if (window.google?.accounts?.id) {
-          window.google.accounts.id.initialize({
-            client_id: import.meta.env.VITE_GOOGLE_CLIENT_ID || "",
-            ux_mode: "redirect",
-            login_uri: `${window.location.origin}/oauth/callback`,
-            // In redirect mode, Google redirects to login_uri instead of calling this callback.
-            // Kept as required by the GIS API but not used in redirect flow.
-            callback: () => {},
-          });
+  // Google OAuth2 — authorization code flow (same-window redirect, no iframe/popup)
+  const googleCodeClient = useCallback(() => {
+    if (!window.google?.accounts?.oauth2) return null;
+    return window.google.accounts.oauth2.initCodeClient({
+      client_id: import.meta.env.VITE_GOOGLE_CLIENT_ID || "",
+      scope: "email profile openid",
+      ux_mode: "redirect",
+      redirect_uri: `${window.location.origin}/oauth/callback`,
+    });
+  }, []);
 
-          window.google.accounts.id.renderButton(node, {
-            theme: "outline",
-            size: "large",
-            width: "100%",
-            text: "continue_with",
-          });
-        }
-      };
-      initGoogle();
-    },
-    [onForceChange, onMfa, onSuccess],
-  );
+  const handleGoogleLogin = useCallback(() => {
+    const client = googleCodeClient();
+    if (client) client.requestCode();
+  }, [googleCodeClient]);
+
+  // Load GIS script
+  useEffect(() => {
+    if (window.google?.accounts?.oauth2) return;
+    const script = document.createElement("script");
+    script.src = "https://accounts.google.com/gsi/client";
+    script.async = true;
+    document.head.appendChild(script);
+  }, []);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -235,7 +222,31 @@ function LoginForm({
         <div className="flex-1 h-px bg-[var(--border-color)]"></div>
       </div>
 
-      <div ref={googleBtnRef} className="w-full flex justify-center" />
+      <button
+        type="button"
+        onClick={handleGoogleLogin}
+        className="w-full flex items-center justify-center gap-3 px-4 py-3 rounded-xl border-2 border-[var(--border-color)] text-[var(--text-primary)] font-semibold hover:bg-[var(--color-base-alt)] transition"
+      >
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none">
+          <path
+            d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.07z"
+            fill="#4285F4"
+          />
+          <path
+            d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.78 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+            fill="#34A853"
+          />
+          <path
+            d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+            fill="#FBBC05"
+          />
+          <path
+            d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+            fill="#EA4335"
+          />
+        </svg>
+        Continuar con Google
+      </button>
 
       <p className="text-center text-sm text-[var(--text-tertiary)]">
         ¿No tenés cuenta?{" "}


### PR DESCRIPTION
## Problem

Three issues caused by using the wrong Google Identity Services API:

1. **405 Not Allowed**: renderButton() POSTs JWT to login_uri, nginx returns 405
2. **Epiphany WebApp new window**: renderButton() renders in cross-origin iframe, Epiphany blocks iframe navigation
3. **GSI_LOGGER warning**: renderButton() width:100% is invalid

## Solution

Switch to google.accounts.oauth2.initCodeClient (authorization code flow):

- Redirects from main frame (no iframe, no popup) - works in Epiphany WebApp
- Sends GET with code parameter - nginx serves SPA correctly
- Uses custom button - no renderButton warning

## Changes

- LoginPage.tsx: Replace google.accounts.id with google.accounts.oauth2.initCodeClient. Custom styled button with Google logo.
- env.d.ts: Add GoogleCodeClient and GoogleAccountsOauth2 type declarations.
- nginx.conf: Add error_page 405 safety net for OAuth routes.

## Flow

Custom button -> codeClient.requestCode() -> same-window redirect to Google -> /oauth/callback?code=... -> OAuthCallbackPage -> backend exchange
