### PR TITLE
fix: onboarding spotlight highlights correct elements per step

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -672,15 +672,16 @@ function MainLayout() {
               <AIAssistant open={aiDrawerOpen} onToggle={() => toggleDrawer(!aiDrawerOpen)} />
             )}
             {isInvestments && <InvestmentsAssistant />}
-            <Suspense fallback={null}>
-              <OnboardingWalkthrough onOpenPanel={setUserPanelOpen} />
-            </Suspense>
           </div>
 
           <UserPanel open={userPanelOpen} onClose={() => setUserPanelOpen(false)} />
           {notifOpen && <NotificationsPanel onClose={() => setNotifOpen(false)} />}
         </div>
       </FamilyGroupProvider>
+      {/* Onboarding - rendered at root to avoid overflow clipping */}
+      <Suspense fallback={null}>
+        <OnboardingWalkthrough onOpenPanel={setUserPanelOpen} />
+      </Suspense>
       {ToastContainer}
     </UploadProgressProvider>
   );

--- a/frontend/src/components/OnboardingWalkthrough.tsx
+++ b/frontend/src/components/OnboardingWalkthrough.tsx
@@ -190,10 +190,6 @@ function CustomTooltip({
     <div
       {...tooltipProps}
       style={{
-        position: "fixed",
-        top: "50%",
-        left: "50%",
-        transform: "translate(-50%, -50%)",
         width: 500,
         maxWidth: "90vw",
         borderRadius: 20,
@@ -202,7 +198,6 @@ function CustomTooltip({
         border: "1px solid rgba(0,0,0,0.06)",
         fontFamily: 'system-ui, -apple-system, "Segoe UI", Roboto, sans-serif',
         background: "#ffffff",
-        zIndex: 10001,
       }}
     >
       {/* Header with icon */}
@@ -384,7 +379,8 @@ export default function OnboardingWalkthrough({
     ...(cfg.target ? { target: cfg.target } : { target: "body" }),
     title: cfg.title,
     content: cfg.content,
-    ...(cfg.placement ? { placement: cfg.placement } : {}),
+    ...(cfg.placement ? { placement: cfg.placement } : { placement: "center" as const }),
+    skipBeacon: true,
     data: { ...cfg, _total: totalSteps } as unknown,
     ...(cfg.before ? { before: cfg.before } : {}),
     ...(cfg.after ? { after: cfg.after } : {}),
@@ -409,12 +405,12 @@ export default function OnboardingWalkthrough({
         primaryColor: "#3584e4",
         textColor: "#1c1b1f",
         backgroundColor: "#ffffff",
-        overlayColor: "rgba(0, 0, 0, 0.4)",
+        overlayColor: "rgba(0, 0, 0, 0.5)",
         showProgress: false,
         spotlightPadding: 12,
         spotlightRadius: 10,
         offset: 14,
-        zIndex: 100,
+        zIndex: 10000,
       }}
       styles={{
         tooltip: {
@@ -424,7 +420,11 @@ export default function OnboardingWalkthrough({
           lineHeight: 1.5,
         },
         tooltipContainer: {
-          borderRadius: 16,
+          position: "fixed",
+          top: 0,
+          left: 0,
+          width: 0,
+          height: 0,
           border: "none",
           boxShadow: "none",
           padding: 0,

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -958,3 +958,14 @@
     transform: none !important;
   }
 }
+
+/* Onboarding: ensure tooltip is above overlay */
+.react-joyride__floater {
+  z-index: 10001 !important;
+}
+
+/* Onboarding: tooltip sizing */
+.react-joyride__tooltip {
+  width: 420px !important;
+  max-width: 90vw !important;
+}


### PR DESCRIPTION
## Problem
The onboarding tooltip was appearing at the bottom of the screen, cut off, and not highlighting the actual UI elements being described. It also used `createPortal` which broke the spotlight overlay connection.

## Solution
- Removed `createPortal` approach that disconnected the tooltip from react-joyride's spotlight
- Each step now uses its original `placement` config:
  - Sidebar items → `placement: "right"` (tooltip to the right of the element)
  - User panel Telegram → `placement: "left"` (tooltip to the left)
  - Welcome step → `placement: "center"` (centered on screen)
- Added CSS `z-index` override to ensure tooltip renders above the overlay
- `skipBeacon: true` on all steps so tooltip shows immediately (no click needed)

## Steps behavior
| Step | Target | Placement |
|------|--------|-----------|
| Welcome | body | center |
| Panel de control | sidebar-home | right |
| Cuentas y tarjetas | sidebar-accounts | right |
| Tus gastos | sidebar-expenses | right |
| Presupuestos | sidebar-budget | right |
| Bot de Telegram | userpanel-telegram | left |
| Importar datos | sidebar-import | right |
| Notificaciones | sidebar-notifications | right |
| Guía de usuario | sidebar-guide | right |
| Mi cuenta | sidebar-account | right |

## Testing
```sql
UPDATE users SET onboarding_completed = false WHERE id = 1;
```
Log in again — onboarding should auto-start, highlighting each element with a dark overlay and spotlight cutout.