### PR TITLE
fix: update weekly report schedule text to 22:30 Argentina time

### DIFF
--- a/frontend/src/components/UserPanel.tsx
+++ b/frontend/src/components/UserPanel.tsx
@@ -1129,7 +1129,7 @@ export default function UserPanel({ open, onClose }: Props) {
                     </div>
                     {settings?.weekly_summary_enabled !== "false" && (
                       <p className="text-[10px] text-[var(--text-tertiary)]">
-                        Se envía todos los domingos a las 20:00 por Telegram
+                        Se envía todos los domingos a las 22:30 (Argentina) por Telegram
                       </p>
                     )}
                   </div>


### PR DESCRIPTION
## Problem
The UserPanel settings showed "Se envía todos los domingos a las 20:00 por Telegram" but the weekly report Celery task actually runs at 01:30 UTC (Monday), which is **22:30 Argentina time (UTC-3)** on Sunday.

## Solution
Updated the text to: "Se envía todos los domingos a las 22:30 (Argentina) por Telegram"

## Context
- Celery schedule: `SCHEDULE_WEEKLY_REPORTS` default = `1:30` UTC on `day_of_week="monday"`  
- 01:30 UTC = 22:30 ART (Argentina, UTC-3)