### PR TITLE
feat: AI auto-categorization with dedicated suggestions table

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -698,7 +698,7 @@ jobs:
             set +a
 
             echo "Running database migrations..."
-            for script in migrate_add_reset_token migrate_remove_haberes migrate_encrypt_settings migrate_add_monthly_reports migrate_db_structure migrate_add_card_account_link migrate_add_budgets; do
+            for script in migrate_add_reset_token migrate_remove_haberes migrate_encrypt_settings migrate_add_monthly_reports migrate_db_structure migrate_add_card_account_link migrate_add_budgets migrate_add_category_suggestions; do
               if ! podman-compose run --rm backend python -m scripts.$script; then
                 echo "::warning::Migration $script had issues (may already be applied)"
               fi

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -241,6 +241,31 @@ class Expense(Base):
     card_rel = relationship("Card")
 
 
+class CategorySuggestion(Base):
+    __tablename__ = "category_suggestions"
+    __table_args__ = (
+        Index("ix_category_suggestions_user_id", "user_id"),
+        Index("ix_category_suggestions_expense_id", "expense_id"),
+        Index("ix_category_suggestions_status", "status"),
+    )
+    id = Column(Integer, primary_key=True, index=True)
+    expense_id = Column(
+        Integer, ForeignKey("expenses.id", ondelete="CASCADE"), unique=True, nullable=False
+    )
+    user_id = Column(Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
+    suggested_category_id = Column(
+        Integer, ForeignKey("categories.id", ondelete="CASCADE"), nullable=False
+    )
+    confidence = Column(Float, nullable=False)
+    status = Column(String, default="pending")  # pending | approved | rejected
+    source = Column(String, default="llm")  # llm | keyword
+    created_at = Column(DateTime, default=datetime.utcnow)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    expense = relationship("Expense")
+    suggested_category = relationship("Category")
+
+
 class AnalysisHistory(Base):
     __tablename__ = "analysis_history"
     __table_args__ = (Index("ix_analysis_history_user_id", "user_id"),)

--- a/backend/app/routers/suggestions.py
+++ b/backend/app/routers/suggestions.py
@@ -1,0 +1,201 @@
+"""API endpoints for AI category suggestions."""
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from app.database import get_db
+from app.models import CategorySuggestion, Expense, Notification
+from app.services.auth import get_current_user
+
+router = APIRouter(prefix="/suggestions", tags=["suggestions"])
+
+
+class SuggestionResponse(BaseModel):
+    id: int
+    expense_id: int
+    description: str
+    amount: float
+    date: str
+    suggested_category_id: int
+    category_name: str
+    parent_name: str | None = None
+    confidence: float
+    status: str
+    source: str
+
+    model_config = {"from_attributes": True}
+
+
+@router.get("", response_model=list[SuggestionResponse])
+def get_pending_suggestions(
+    status: str = "pending",
+    db: Session = Depends(get_db),
+    current_user=Depends(get_current_user),
+):
+    """Get all suggestions for the current user, optionally filtered by status."""
+    suggestions = (
+        db.query(CategorySuggestion)
+        .filter(
+            CategorySuggestion.user_id == current_user.id,
+            CategorySuggestion.status == status,
+        )
+        .all()
+    )
+
+    result = []
+    for s in suggestions:
+        expense = db.query(Expense).filter(Expense.id == s.expense_id).first()
+        if not expense:
+            continue
+        result.append(
+            SuggestionResponse(
+                id=s.id,
+                expense_id=s.expense_id,
+                description=expense.description,
+                amount=expense.amount,
+                date=expense.date.isoformat(),
+                suggested_category_id=s.suggested_category_id,
+                category_name=s.suggested_category.name if s.suggested_category else "Unknown",
+                parent_name=(
+                    s.suggested_category.parent.name
+                    if s.suggested_category and s.suggested_category.parent
+                    else None
+                ),
+                confidence=s.confidence,
+                status=s.status,
+                source=s.source,
+            )
+        )
+
+    return result
+
+
+@router.post("/{suggestion_id}/approve")
+def approve_suggestion(
+    suggestion_id: int,
+    db: Session = Depends(get_db),
+    current_user=Depends(get_current_user),
+):
+    """Approve a suggestion and apply the category to the expense."""
+    suggestion = (
+        db.query(CategorySuggestion)
+        .filter(
+            CategorySuggestion.id == suggestion_id,
+            CategorySuggestion.user_id == current_user.id,
+        )
+        .first()
+    )
+    if not suggestion:
+        raise HTTPException(status_code=404, detail="Sugerencia no encontrada")
+
+    # Apply category to expense
+    expense = db.query(Expense).filter(Expense.id == suggestion.expense_id).first()
+    if expense:
+        expense.category_id = suggestion.suggested_category_id
+
+    # Mark suggestion as approved
+    suggestion.status = "approved"
+
+    # Check if all suggestions are resolved, cleanup notification
+    _cleanup_notification_if_done(current_user.id, db)
+
+    db.commit()
+    return {"detail": "Categoría aplicada correctamente"}
+
+
+@router.post("/{suggestion_id}/reject")
+def reject_suggestion(
+    suggestion_id: int,
+    db: Session = Depends(get_db),
+    current_user=Depends(get_current_user),
+):
+    """Reject a suggestion."""
+    suggestion = (
+        db.query(CategorySuggestion)
+        .filter(
+            CategorySuggestion.id == suggestion_id,
+            CategorySuggestion.user_id == current_user.id,
+        )
+        .first()
+    )
+    if not suggestion:
+        raise HTTPException(status_code=404, detail="Sugerencia no encontrada")
+
+    suggestion.status = "rejected"
+
+    # Check if all suggestions are resolved, cleanup notification
+    _cleanup_notification_if_done(current_user.id, db)
+
+    db.commit()
+    return {"detail": "Sugerencia descartada"}
+
+
+@router.post("/approve-all")
+def approve_all_suggestions(
+    min_confidence: float = 0.7,
+    db: Session = Depends(get_db),
+    current_user=Depends(get_current_user),
+):
+    """Approve all pending suggestions with confidence >= threshold."""
+    suggestions = (
+        db.query(CategorySuggestion)
+        .filter(
+            CategorySuggestion.user_id == current_user.id,
+            CategorySuggestion.status == "pending",
+            CategorySuggestion.confidence >= min_confidence,
+        )
+        .all()
+    )
+
+    count = 0
+    for s in suggestions:
+        expense = db.query(Expense).filter(Expense.id == s.expense_id).first()
+        if expense:
+            expense.category_id = s.suggested_category_id
+        s.status = "approved"
+        count += 1
+
+    _cleanup_notification_if_done(current_user.id, db)
+    db.commit()
+    return {"detail": f"{count} categorías aplicadas", "count": count}
+
+
+@router.post("/discard-all")
+def discard_all_suggestions(
+    db: Session = Depends(get_db),
+    current_user=Depends(get_current_user),
+):
+    """Reject all pending suggestions."""
+    suggestions = (
+        db.query(CategorySuggestion)
+        .filter(
+            CategorySuggestion.user_id == current_user.id,
+            CategorySuggestion.status == "pending",
+        )
+        .all()
+    )
+
+    for s in suggestions:
+        s.status = "rejected"
+
+    _cleanup_notification_if_done(current_user.id, db)
+    db.commit()
+    return {"detail": f"{len(suggestions)} sugerencias descartadas"}
+
+
+def _cleanup_notification_if_done(user_id: int, db: Session):
+    """Delete category_suggestions notification if no pending suggestions remain."""
+    pending_count = (
+        db.query(CategorySuggestion)
+        .filter(
+            CategorySuggestion.user_id == user_id,
+            CategorySuggestion.status == "pending",
+        )
+        .count()
+    )
+    if pending_count == 0:
+        db.query(Notification).filter(
+            Notification.user_id == user_id,
+            Notification.type == "category_suggestions",
+        ).delete()

--- a/backend/app/tasks/suggest_uncategorized.py
+++ b/backend/app/tasks/suggest_uncategorized.py
@@ -5,7 +5,7 @@ import logging
 
 from app.celery_app import celery_app
 from app.database import SessionLocal
-from app.models import Expense, Notification, User
+from app.models import CategorySuggestion, Expense, Notification, User
 from app.services.categorization import llm_categorize
 
 logger = logging.getLogger(__name__)
@@ -18,7 +18,7 @@ MAX_DAYS_LOOKBACK = 7
 def suggest_uncategorized_categories():
     """Find uncategorized expenses and suggest categories via LLM (high temperature).
 
-    Creates in-app notifications with suggestions — does NOT modify expenses.
+    Stores suggestions in category_suggestions table and creates notification.
     Capped at MAX_EXPENSES_PER_USER per user, last MAX_DAYS_LOOKBACK days.
     """
     db = SessionLocal()
@@ -73,7 +73,7 @@ def suggest_uncategorized_categories():
                 continue
 
             # Suggest categories for each expense (high temperature for ambiguous descriptions)
-            suggestions = []
+            suggestions_data = []
             for exp in expenses:
                 result = llm_categorize(
                     exp.description,
@@ -84,7 +84,18 @@ def suggest_uncategorized_categories():
                     temperature=0.7,
                 )
                 if result and result["confidence"] >= 0.4:
-                    suggestions.append(
+                    # Store in CategorySuggestion table
+                    suggestion = CategorySuggestion(
+                        expense_id=exp.id,
+                        user_id=user.id,
+                        suggested_category_id=result["category_id"],
+                        confidence=round(result["confidence"], 2),
+                        status="pending",
+                        source="llm",
+                    )
+                    db.add(suggestion)
+
+                    suggestions_data.append(
                         {
                             "expense_id": exp.id,
                             "description": exp.description,
@@ -97,17 +108,17 @@ def suggest_uncategorized_categories():
                         }
                     )
 
-            if not suggestions:
+            if not suggestions_data:
                 continue
 
             # Create single notification with all suggestions
-            count = len(suggestions)
+            count = len(suggestions_data)
             notification = Notification(
                 user_id=user.id,
                 type="category_suggestions",
                 title=f"✨ {count} gasto{'s' if count != 1 else ''} sugieren categorías",
                 body="La IA encontró categorías sugeridas para gastos sin clasificar.",
-                data=json.dumps({"suggestions": suggestions, "count": count}),
+                data=json.dumps({"suggestions": suggestions_data, "count": count}),
                 read=False,
             )
             db.add(notification)

--- a/backend/main.py
+++ b/backend/main.py
@@ -33,6 +33,7 @@ from app.routers import (
     mfa,
     notifications,
     scheduled_expenses,
+    suggestions,
 )
 from app.scheduler import price_refresh_loop
 from app.seed import _apply_base_hierarchy
@@ -122,3 +123,4 @@ app.include_router(groups.router)
 app.include_router(notifications.router)
 app.include_router(scheduled_expenses.router)
 app.include_router(budgets.router)
+app.include_router(suggestions.router)

--- a/backend/scripts/migrate_add_category_suggestions.py
+++ b/backend/scripts/migrate_add_category_suggestions.py
@@ -1,0 +1,50 @@
+"""Migration: Add category_suggestions table for AI auto-categorization."""
+
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from app.database import engine
+from sqlalchemy import text
+
+
+def migrate():
+    with engine.begin() as conn:
+        # Create category_suggestions table
+        conn.execute(
+            text(
+                """
+                CREATE TABLE IF NOT EXISTS category_suggestions (
+                    id SERIAL PRIMARY KEY,
+                    expense_id INTEGER NOT NULL REFERENCES expenses(id) ON DELETE CASCADE UNIQUE,
+                    user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+                    suggested_category_id INTEGER NOT NULL REFERENCES categories(id) ON DELETE CASCADE,
+                    confidence FLOAT NOT NULL,
+                    status VARCHAR(20) DEFAULT 'pending',
+                    source VARCHAR(20) DEFAULT 'llm',
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                )
+                """
+            )
+        )
+
+        # Create indexes
+        conn.execute(
+            text("CREATE INDEX IF NOT EXISTS ix_category_suggestions_user_id ON category_suggestions(user_id)")
+        )
+        conn.execute(
+            text(
+                "CREATE INDEX IF NOT EXISTS ix_category_suggestions_expense_id ON category_suggestions(expense_id)"
+            )
+        )
+        conn.execute(
+            text("CREATE INDEX IF NOT EXISTS ix_category_suggestions_status ON category_suggestions(status)")
+        )
+
+        print("✅ category_suggestions table created successfully")
+
+
+if __name__ == "__main__":
+    migrate()

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -159,10 +159,11 @@ export const rejectSuggestion = (id: number) =>
   api.post(`/suggestions/${id}/reject`).then((r) => r.data);
 
 export const approveAllSuggestions = (minConfidence: number = 0.7) =>
-  api.post("/suggestions/approve-all", null, { params: { min_confidence: minConfidence } }).then((r) => r.data);
+  api
+    .post("/suggestions/approve-all", null, { params: { min_confidence: minConfidence } })
+    .then((r) => r.data);
 
-export const discardAllSuggestions = () =>
-  api.post("/suggestions/discard-all").then((r) => r.data);
+export const discardAllSuggestions = () => api.post("/suggestions/discard-all").then((r) => r.data);
 
 // Budgets
 export const getBudgets = () => api.get<Budget[]>("/budgets").then((r) => r.data);

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -134,6 +134,36 @@ export const deleteCategory = (id: number) => api.delete(`/categories/${id}`).th
 export const suggestCategory = (data: { description: string; amount?: number }) =>
   api.post<CategorySuggestion | null>("/categories/suggest", data).then((r) => r.data);
 
+// Suggestions (AI auto-categorization)
+export interface SuggestionItem {
+  id: number;
+  expense_id: number;
+  description: string;
+  amount: number;
+  date: string;
+  suggested_category_id: number;
+  category_name: string;
+  parent_name?: string | null;
+  confidence: number;
+  status: string;
+  source: string;
+}
+
+export const getSuggestions = (status: string = "pending") =>
+  api.get<SuggestionItem[]>("/suggestions", { params: { status } }).then((r) => r.data);
+
+export const approveSuggestion = (id: number) =>
+  api.post(`/suggestions/${id}/approve`).then((r) => r.data);
+
+export const rejectSuggestion = (id: number) =>
+  api.post(`/suggestions/${id}/reject`).then((r) => r.data);
+
+export const approveAllSuggestions = (minConfidence: number = 0.7) =>
+  api.post("/suggestions/approve-all", null, { params: { min_confidence: minConfidence } }).then((r) => r.data);
+
+export const discardAllSuggestions = () =>
+  api.post("/suggestions/discard-all").then((r) => r.data);
+
 // Budgets
 export const getBudgets = () => api.get<Budget[]>("/budgets").then((r) => r.data);
 

--- a/frontend/src/pages/ExpensesPage.tsx
+++ b/frontend/src/pages/ExpensesPage.tsx
@@ -47,7 +47,6 @@ import {
 } from "../utils/format";
 import { useExpenseFilters } from "../hooks/useExpenseFilters";
 import { ConfirmDialog } from "../components/ConfirmDialog";
-import { useNotifications } from "../hooks/useNotifications";
 
 type SortField = "date" | "description" | "category" | "bank" | "person" | "amount";
 type SortDir = "asc" | "desc";

--- a/frontend/src/pages/ExpensesPage.tsx
+++ b/frontend/src/pages/ExpensesPage.tsx
@@ -14,6 +14,11 @@ import {
   deleteExpense,
   bulkDeleteExpenses,
   bulkUpdateFields,
+  getSuggestions,
+  approveSuggestion,
+  rejectSuggestion,
+  approveAllSuggestions,
+  discardAllSuggestions,
 } from "../api/client";
 import type { Expense, ExpenseCreate } from "../types";
 import { Select } from "../components/ui/Select";
@@ -90,17 +95,16 @@ export default function ExpensesPage() {
   const filterDateTo = filters.dateTo;
   const filterSearch = filters.search;
 
-  // Category suggestions from notifications
-  const { notifications, markRead } = useNotifications();
-  const showSuggestions = searchParams.get("category_suggestions") === "1";
-  const suggestionNotif = notifications.find(
-    (n): n is import("../types").CategorySuggestionNotification =>
-      n.type === "category_suggestions" && !n.read,
-  );
-  const suggestions = suggestionNotif?.data.suggestions ?? [];
+  // Category suggestions from API
+  const { data: suggestionsData = [], refetch: refetchSuggestions } = useQuery({
+    queryKey: ["suggestions"],
+    queryFn: () => getSuggestions("pending"),
+    staleTime: 30_000,
+  });
+  const showSuggestions = suggestionsData.length > 0;
   const suggestionsByExpenseId = useMemo(
-    () => new Map(suggestions.map((s) => [s.expense_id, s])),
-    [suggestions],
+    () => new Map(suggestionsData.map((s) => [s.expense_id, s])),
+    [suggestionsData],
   );
 
   const now = new Date();
@@ -552,13 +556,13 @@ export default function ExpensesPage() {
       </div>
 
       {/* Category suggestions banner */}
-      {showSuggestions && suggestions.length > 0 && (
+      {showSuggestions && (
         <div className="card border-l-4 border-l-purple-500 bg-purple-500/5">
           <div className="px-4 py-3 flex items-center justify-between">
             <div>
               <p className="text-sm font-medium text-[var(--text-primary)]">
-                ✨ IA sugirió categorías para {suggestions.length} gasto
-                {suggestions.length !== 1 ? "s" : ""}
+                ✨ IA sugirió categorías para {suggestionsData.length} gasto
+                {suggestionsData.length !== 1 ? "s" : ""}
               </p>
               <p className="text-xs text-[var(--text-tertiary)] mt-0.5">
                 Revisá las sugerencias inline y aplicá las que correspondan
@@ -567,31 +571,22 @@ export default function ExpensesPage() {
             <div className="flex items-center gap-2">
               <button
                 onClick={async () => {
-                  for (const s of suggestions) {
-                    if (s.confidence >= 0.7) {
-                      await updateExpense(s.expense_id, {
-                        category_id: s.suggested_category_id,
-                      });
-                    }
-                  }
+                  await approveAllSuggestions(0.7);
                   queryClient.invalidateQueries({ queryKey: ["expenses"] });
-                  markRead(suggestionNotif!.id);
+                  refetchSuggestions();
                 }}
                 className="gnome-btn-secondary-round text-xs"
               >
                 Aplicar todas (≥70%)
               </button>
               <button
-                onClick={() => {
-                  markRead(suggestionNotif!.id);
-                  setSearchParams((prev) => {
-                    prev.delete("category_suggestions");
-                    return prev;
-                  });
+                onClick={async () => {
+                  await discardAllSuggestions();
+                  refetchSuggestions();
                 }}
                 className="text-xs text-[var(--text-tertiary)] hover:text-[var(--text-primary)]"
               >
-                Cerrar
+                Descartar todas
               </button>
             </div>
           </div>
@@ -1204,18 +1199,18 @@ export default function ExpensesPage() {
                                 <span className="inline-flex items-center gap-1.5">
                                   <span className="text-[var(--text-tertiary)]">—</span>
                                   <button
-                                    onClick={(e) => {
+                                    onClick={async (e) => {
                                       e.stopPropagation();
                                       const s = suggestionsByExpenseId.get(exp.id)!;
-                                      updateExpense(exp.id, {
-                                        category_id: s.suggested_category_id,
-                                      }).then(() =>
-                                        queryClient.invalidateQueries({
-                                          queryKey: ["expenses"],
-                                        }),
-                                      );
+                                      await approveSuggestion(s.id);
+                                      queryClient.invalidateQueries({ queryKey: ["expenses"] });
+                                      refetchSuggestions();
                                     }}
-                                    className="px-2 py-1 rounded text-xs font-medium bg-purple-500/10 text-purple-600 dark:text-purple-400 hover:bg-purple-500/20 transition"
+                                    className={`px-2 py-1 rounded text-xs font-medium transition ${
+                                      suggestionsByExpenseId.get(exp.id)!.confidence >= 0.7
+                                        ? "bg-purple-500/10 text-purple-600 dark:text-purple-400 hover:bg-purple-500/20"
+                                        : "bg-purple-500/5 text-purple-400/70 dark:text-purple-500/50 hover:bg-purple-500/10"
+                                    }`}
                                     title={`Sugerencia: ${
                                       suggestionsByExpenseId.get(exp.id)!.parent_name
                                         ? suggestionsByExpenseId.get(exp.id)!.parent_name + " > "
@@ -1227,6 +1222,18 @@ export default function ExpensesPage() {
                                     )}%)`}
                                   >
                                     ✨ {suggestionsByExpenseId.get(exp.id)!.category_name}
+                                  </button>
+                                  <button
+                                    onClick={async (e) => {
+                                      e.stopPropagation();
+                                      const s = suggestionsByExpenseId.get(exp.id)!;
+                                      await rejectSuggestion(s.id);
+                                      refetchSuggestions();
+                                    }}
+                                    className="text-[var(--text-tertiary)] hover:text-red-500 transition text-xs"
+                                    title="Descartar sugerencia"
+                                  >
+                                    ✗
                                   </button>
                                 </span>
                               ) : (


### PR DESCRIPTION
## Changes

### Problem
- Suggestions only visible when clicking notification (URL param required)
- No persistent storage — suggestions lost when notification read
- No rejection flow — users could only approve or ignore
- LLM called on every expense detail modal mount (no caching)

### Solution

#### Backend
- **CategorySuggestion model** — Dedicated table for persistent suggestion storage
- **New API endpoints** — GET /suggestions, approve, reject, bulk operations
- **Updated Celery task** — Stores suggestions in DB alongside notification
- **Auto-cleanup** — Notification deleted when all suggestions resolved

#### Frontend
- **Fetch from API** — Suggestions loaded from /suggestions endpoint, not notification JSON
- **Always visible** — Banner shows automatically when suggestions exist (no URL param)
- **Inline badges** — Purple suggestion badges on expense rows with approve (✨) and reject (✗) buttons
- **Confidence styling** — Low confidence (<70%) shown with lighter style
- **Bulk actions** — Aplicar todas (≥70%) and Descartar todas

#### Deploy
- Added migration script to deploy workflow (idempotent)

### Flow
