### PR TITLE
feat: Field-level encryption for sensitive data

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -723,13 +723,46 @@ jobs:
             source .env
             set +a
 
-            echo "Running database migrations..."
+            echo "=== Step 1: Database structure migration ==="
             for script in migrate_add_reset_token migrate_remove_haberes migrate_encrypt_settings migrate_add_monthly_reports migrate_db_structure migrate_add_card_account_link migrate_add_budgets migrate_add_category_suggestions; do
               if ! podman-compose run --rm backend python -m scripts.$script; then
                 echo "::warning::Migration $script had issues (may already be applied)"
               fi
             done
-            echo "Migrations complete"
+
+            echo "=== Step 2: Dry-run encryption migration ==="
+            DRY_RUN=$(podman-compose run --rm backend python scripts/dry_run_migration.py 2>&1)
+            echo "$DRY_RUN"
+
+            if echo "$DRY_RUN" | grep -q "Status: FAIL"; then
+              echo "::error::Dry-run failed! Aborting deployment."
+              exit 1
+            fi
+
+            echo "=== Step 3: Run encryption migration ==="
+            if ! podman-compose run --rm backend python scripts/migrate_encrypt_fields.py; then
+              echo "::error::Encryption migration failed!"
+              exit 1
+            fi
+
+            echo "=== Step 4: Verify encryption ==="
+            VERIFY=$(podman-compose run --rm backend python scripts/verify_encryption.py 2>&1)
+            echo "$VERIFY"
+
+            if echo "$VERIFY" | grep -q "Status: FAIL"; then
+              echo "::error::Verification failed! Rolling back database..."
+              LATEST=$(ls -t /opt/creditcardanalyzer/backups/db_*.sql.gz | head -1)
+              if [ -n "$LATEST" ]; then
+                echo "Restoring from: $LATEST"
+                gunzip -c $LATEST | podman exec -i creditcardanalyzer_db_1 psql -U expenses_user expenses
+                echo "Database restored from backup"
+              else
+                echo "::error::No backup found!"
+              fi
+              exit 1
+            fi
+
+            echo "=== Migration complete and verified ==="
 
   restart-and-verify:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -723,6 +723,21 @@ jobs:
             source .env
             set +a
 
+            echo "=== Step 0: Verify SECRET_KEY ==="
+            KEY_CHECK=$(podman-compose run --rm backend python -c "
+            from app.services.encryption import verify_key_works
+            if verify_key_works():
+                print('KEY_VALID')
+            else:
+                print('KEY_INVALID')
+            " 2>&1)
+
+            if echo "$KEY_CHECK" | grep -q "KEY_INVALID"; then
+              echo "::error::SECRET_KEY cannot encrypt/decrypt! Aborting deployment."
+              exit 1
+            fi
+            echo "SECRET_KEY verified successfully"
+
             echo "=== Step 1: Database structure migration ==="
             for script in migrate_add_reset_token migrate_remove_haberes migrate_encrypt_settings migrate_add_monthly_reports migrate_db_structure migrate_add_card_account_link migrate_add_budgets migrate_add_category_suggestions; do
               if ! podman-compose run --rm backend python -m scripts.$script; then

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,9 +29,35 @@ env:
   FRONTEND_IMAGE: ghcr.io/${{ github.repository_owner }}/perexp/frontend
 
 jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: |
+          cd backend
+          pip install -r requirements.txt
+          pip install pytest
+
+      - name: Run encryption tests
+        env:
+          SECRET_KEY: "test-secret-key-for-ci-that-is-at-least-32-chars"
+        run: |
+          cd backend
+          python -m pytest tests/test_encryption.py -v
+
   build-and-push:
     if: github.event_name == 'push' || inputs.action == 'full'
     runs-on: ubuntu-latest
+    needs: test
     permissions:
       contents: read
       packages: write

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -195,10 +195,13 @@ class Card(Base):
     )
     id = Column(Integer, primary_key=True, index=True)
     card_name = Column(EncryptedType, nullable=False)  # Visa, Mastercard, etc
+    card_name_search = Column(String, nullable=True, index=True)
     bank = Column(EncryptedType, default="")
+    bank_search = Column(String, nullable=True, index=True)
     holder = Column(
         EncryptedType, default=""
     )  # Primer nombre del usuario (para agrupar en grupo familiar)
+    holder_search = Column(String, nullable=True, index=True)
     card_type = Column(String, default="credito")  # credito, debito
     linked_account_id = Column(
         Integer, ForeignKey("accounts.id", ondelete="SET NULL"), nullable=True

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -17,26 +17,28 @@ from sqlalchemy import (
 from sqlalchemy.orm import relationship
 
 from app.database import Base
+from app.types.encrypted import EncryptedType
 
 
 class User(Base):
     __tablename__ = "users"
     id = Column(Integer, primary_key=True, index=True)
-    full_name = Column(String, nullable=False, default="")
+    full_name = Column(EncryptedType, nullable=False, default="")
     email = Column(String, unique=True, nullable=False)
     invite_code = Column(String(8), nullable=True, unique=True, index=True)
     hashed_password = Column(String, nullable=True)
     is_active = Column(Boolean, default=True)
     created_at = Column(DateTime, default=datetime.utcnow)
     telegram_key = Column(String(12), nullable=True, unique=True, index=True)
-    telegram_chat_id = Column(String, nullable=True, unique=True, index=True)
+    telegram_chat_id = Column(EncryptedType, nullable=True)
+    telegram_chat_hash = Column(String(64), nullable=True, unique=True, index=True)
     provider = Column(String, nullable=True)
     provider_id = Column(String, nullable=True, index=True)
     avatar_url = Column(String, nullable=True)
     reset_token = Column(String(64), nullable=True, unique=True, index=True)
     reset_token_expires = Column(DateTime, nullable=True)
     # Security: MFA
-    mfa_secret = Column(String(32), nullable=True)
+    mfa_secret = Column(EncryptedType, nullable=True)
     mfa_enabled = Column(Boolean, default=False)
     # Security: Email verification
     email_verified = Column(Boolean, default=False)
@@ -192,10 +194,10 @@ class Card(Base):
         Index("ix_cards_linked_account_id", "linked_account_id"),
     )
     id = Column(Integer, primary_key=True, index=True)
-    card_name = Column(String, nullable=False)  # Visa, Mastercard, etc
-    bank = Column(String, default="")
+    card_name = Column(EncryptedType, nullable=False)  # Visa, Mastercard, etc
+    bank = Column(EncryptedType, default="")
     holder = Column(
-        String, default=""
+        EncryptedType, default=""
     )  # Primer nombre del usuario (para agrupar en grupo familiar)
     card_type = Column(String, default="credito")  # credito, debito
     linked_account_id = Column(
@@ -220,10 +222,11 @@ class Expense(Base):
     )
     id = Column(Integer, primary_key=True, index=True)
     date = Column(Date, nullable=False)
-    description = Column(String, nullable=False)
+    description = Column(EncryptedType, nullable=False)
+    description_search = Column(String, nullable=True, index=True)
     amount = Column(Float, nullable=False)
     category_id = Column(Integer, ForeignKey("categories.id", ondelete="SET NULL"), nullable=True)
-    notes = Column(Text, default="")
+    notes = Column(EncryptedType, default="")
     transaction_id = Column(String, nullable=True, index=True)
     currency = Column(String, default="ARS")
     installment_number = Column(Integer, nullable=True)
@@ -300,7 +303,7 @@ class Investment(Base):
     avg_cost = Column(Float, default=0.0)
     current_price = Column(Float, nullable=True)
     currency = Column(String, default="ARS")
-    notes = Column(Text, default="")
+    notes = Column(EncryptedType, default="")
     updated_at = Column(DateTime, default=datetime.utcnow)
     user_id = Column(Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
 
@@ -375,7 +378,7 @@ class MonthlyReport(Base):
     user_id = Column(Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
     month = Column(String(7), nullable=False)  # YYYY-MM format
     status = Column(String(20), default="READY")  # PENDING | READY | FAILED
-    report_data = Column(Text, nullable=True)  # JSON with full report data
+    report_data = Column(EncryptedType, nullable=True)  # JSON with full report data
     pdf_data = Column(LargeBinary, nullable=True)  # Generated PDF bytes (legacy)
     png_data = Column(LargeBinary, nullable=True)  # Generated PNG image bytes
     error_message = Column(Text, nullable=True)  # Error if FAILED
@@ -390,7 +393,7 @@ class AuditLog(Base):
     id = Column(Integer, primary_key=True, index=True)
     user_id = Column(Integer, ForeignKey("users.id", ondelete="SET NULL"), nullable=True)
     action = Column(String(50), nullable=False)
-    ip_address = Column(String(45), nullable=True)
-    user_agent = Column(String(500), nullable=True)
+    ip_address = Column(EncryptedType, nullable=True)
+    user_agent = Column(EncryptedType, nullable=True)
     details = Column(Text, nullable=True)
     created_at = Column(DateTime, default=datetime.utcnow)

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -343,7 +343,8 @@ class ScheduledExpense(Base):
     scheduled_date = Column(Date, nullable=False, index=True)
     amount = Column(Float, nullable=False)
     currency = Column(String, default="ARS")
-    description = Column(String, nullable=False)
+    description = Column(EncryptedType, nullable=False)
+    description_search = Column(String, nullable=True, index=True)
 
     # Structured fields
     card_id = Column(Integer, ForeignKey("cards.id", ondelete="SET NULL"), nullable=True)

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -570,6 +570,7 @@ def regenerate_telegram_key(
 
     current_user.telegram_key = _generate_telegram_key()
     current_user.telegram_chat_id = None
+    current_user.telegram_chat_hash = None
     db.commit()
     db.refresh(current_user)
     return TelegramKeyResponse(telegram_key=current_user.telegram_key)

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -563,7 +563,7 @@ def regenerate_telegram_key(
     db: Session = Depends(get_db),
 ):
     # Notify the bot before clearing the session
-    if current_user.telegram_chat_id:
+    if current_user.telegram_chat_id and current_user.telegram_chat_id != "[encrypted]":
         from app.telegram_bot import send_disconnect_notification
 
         send_disconnect_notification(current_user.telegram_chat_id)

--- a/backend/app/routers/cards.py
+++ b/backend/app/routers/cards.py
@@ -302,6 +302,7 @@ def sync_card_holders(
 
         card.holder = get_first_name(current_user.full_name or "")
         if card.holder:
+            card.holder_search = tokenize_description(card.holder)
             updated += 1
 
     db.commit()

--- a/backend/app/routers/cards.py
+++ b/backend/app/routers/cards.py
@@ -9,6 +9,7 @@ from app.database import get_db
 from app.models import Card, User
 from app.routers.groups import get_group_user_ids
 from app.services.auth import get_current_user
+from app.services.encryption import tokenize_description
 
 router = APIRouter(prefix="/cards", tags=["cards"])
 
@@ -129,8 +130,8 @@ def create_card(
         db.query(Card)
         .filter(
             Card.user_id == current_user.id,
-            func.lower(func.trim(Card.card_name)) == card_name.lower(),
-            func.lower(func.trim(Card.bank)) == bank.lower(),
+            func.lower(Card.card_name_search) == card_name.lower(),
+            func.lower(Card.bank_search) == bank.lower(),
             Card.card_type == card.card_type,
         )
         .first()
@@ -154,8 +155,11 @@ def create_card(
 
     db_card = Card(
         card_name=card_name,
+        card_name_search=tokenize_description(card_name),
         bank=bank,
+        bank_search=tokenize_description(bank),
         holder=holder,
+        holder_search=tokenize_description(holder),
         card_type=card.card_type,
         linked_account_id=linked_account_id,
         user_id=current_user.id,
@@ -231,6 +235,14 @@ def update_card(
         if isinstance(value, str):
             value = value.strip()
         setattr(db_card, key, value)
+
+    # Update search tokens if card_name, bank, or holder changed
+    if "card_name" in update_data:
+        db_card.card_name_search = tokenize_description(db_card.card_name)
+    if "bank" in update_data:
+        db_card.bank_search = tokenize_description(db_card.bank)
+    if "holder" in update_data:
+        db_card.holder_search = tokenize_description(db_card.holder)
 
     db.commit()
     db.refresh(db_card)

--- a/backend/app/routers/dashboard.py
+++ b/backend/app/routers/dashboard.py
@@ -92,13 +92,13 @@ def _apply_filters(q, month_val, search_val, person_val, cat_id_val, bank_val=No
         q = q.filter(Expense.description.ilike(f"%{search_val}%"))
     if person_val:
         q = q.join(Card, Expense.card_id == Card.id, isouter=True).filter(
-            Card.holder.ilike(f"%{person_val}%")
+            Card.holder_search.ilike(f"%{person_val}%")
         )
     if cat_id_val is not None:
         q = q.filter(Expense.category_id == cat_id_val)
     if bank_val:
         q = q.join(Card, Expense.card_id == Card.id, isouter=True).filter(
-            Card.bank.ilike(f"%{bank_val}%")
+            Card.bank_search.ilike(f"%{bank_val}%")
         )
     return q
 
@@ -1482,11 +1482,11 @@ def get_top_merchants(
             pass
     if person:
         q = q.join(Card, Expense.card_id == Card.id, isouter=True).filter(
-            Card.holder.ilike(f"%{person}%")
+            Card.holder_search.ilike(f"%{person}%")
         )
     if bank:
         q = q.join(Card, Expense.card_id == Card.id, isouter=True).filter(
-            Card.bank.ilike(f"%{bank}%")
+            Card.bank_search.ilike(f"%{bank}%")
         )
 
     rows = q.all()
@@ -1693,7 +1693,7 @@ def get_card_category_breakdown(
             pass
     if bank:
         q = q.join(Card, Expense.card_id == Card.id, isouter=True).filter(
-            Card.bank.ilike(f"%{bank}%")
+            Card.bank_search.ilike(f"%{bank}%")
         )
 
     exps = q.all()
@@ -1776,7 +1776,7 @@ def get_category_trend(
     )
     if person:
         rows_raw = rows_raw.outerjoin(Card, Expense.card_id == Card.id).filter(
-            Card.holder.ilike(f"%{person}%")
+            Card.holder_search.ilike(f"%{person}%")
         )
     rows_raw = rows_raw.group_by(
         func.to_char(Expense.date, "YYYY-MM"), Category.name, Category.color

--- a/backend/app/routers/dashboard.py
+++ b/backend/app/routers/dashboard.py
@@ -15,6 +15,7 @@ from app.models import Card, Category, Expense, MonthlyReport, Notification, Use
 from app.routers.groups import get_group_user_ids
 from app.services.auth import get_current_user
 from app.services.date_utils import add_months
+from app.services.encryption import tokenize_description
 from app.services.normalizers import normalize_bank
 
 router = APIRouter(prefix="/dashboard", tags=["dashboard"])
@@ -89,7 +90,7 @@ def _apply_filters(q, month_val, search_val, person_val, cat_id_val, bank_val=No
         except (ValueError, IndexError):
             pass
     if search_val:
-        q = q.filter(Expense.description.ilike(f"%{search_val}%"))
+        q = q.filter(Expense.description_search.ilike(f"%{tokenize_description(search_val)}%"))
     if person_val:
         q = q.join(Card, Expense.card_id == Card.id, isouter=True).filter(
             Card.holder_search.ilike(f"%{person_val}%")

--- a/backend/app/routers/expenses.py
+++ b/backend/app/routers/expenses.py
@@ -74,15 +74,15 @@ def get_expenses(
         q = q.filter(Expense.category_id.is_(None))
     if bank:
         q = q.join(Card, Expense.card_id == Card.id, isouter=True).filter(
-            Card.bank.ilike(f"%{bank}%")
+            Card.bank_search.ilike(f"%{bank}%")
         )
     if person:
         q = q.join(Card, Expense.card_id == Card.id, isouter=True).filter(
-            Card.holder.ilike(f"%{person}%")
+            Card.holder_search.ilike(f"%{person}%")
         )
     if card:
         q = q.join(Card, Expense.card_id == Card.id, isouter=True).filter(
-            Card.card_name.ilike(f"%{card}%")
+            Card.card_name_search.ilike(f"%{card}%")
         )
     if card_type:
         q = q.join(Card, Expense.card_id == Card.id, isouter=True).filter(
@@ -590,11 +590,11 @@ def get_expense_stats(
         )
     elif card:
         q = q.join(Card, Expense.card_id == Card.id, isouter=True).filter(
-            Card.card_name.ilike(f"%{card}%")
+            Card.card_name_search.ilike(f"%{card}%")
         )
     elif bank:
         q = q.join(Card, Expense.card_id == Card.id, isouter=True).filter(
-            Card.bank.ilike(f"%{bank}%")
+            Card.bank_search.ilike(f"%{bank}%")
         )
 
     total, count = q.one()
@@ -616,11 +616,11 @@ def get_expense_stats(
             pass
     if card:
         last_used_q = last_used_q.join(Card, Expense.card_id == Card.id).filter(
-            Card.card_name.ilike(f"%{card}%")
+            Card.card_name_search.ilike(f"%{card}%")
         )
     elif bank:
         last_used_q = last_used_q.join(Card, Expense.card_id == Card.id).filter(
-            Card.bank.ilike(f"%{bank}%")
+            Card.bank_search.ilike(f"%{bank}%")
         )
     last_used = last_used_q.scalar()
 
@@ -675,7 +675,7 @@ def get_expenses_by_category(
         q = q.filter(Expense.account_id == account_id)
     if card:
         q = q.join(Card, Expense.card_id == Card.id, isouter=True).filter(
-            Card.card_name.ilike(f"%{card}%")
+            Card.card_name_search.ilike(f"%{card}%")
         )
 
     rows = q.all()

--- a/backend/app/routers/expenses.py
+++ b/backend/app/routers/expenses.py
@@ -253,7 +253,7 @@ def check_duplicate(
         dupe = base.filter(
             Expense.date == exp_date,
             Expense.amount == amount,
-            func.lower(Expense.description) == description.lower(),
+            func.lower(Expense.description_search) == tokenize_description(description),
         ).first()
     if dupe:
         return {

--- a/backend/app/routers/expenses.py
+++ b/backend/app/routers/expenses.py
@@ -15,6 +15,7 @@ from app.schemas import ExpenseCreate, ExpenseResponse, ExpenseUpdate
 from app.services.auth import get_current_user
 from app.services.categorization import _resolve_category, auto_categorize
 from app.services.date_utils import _normalize_date_str, add_months
+from app.services.encryption import tokenize_description
 from app.services.import_utils import _is_duplicate, _normalize_text
 
 router = APIRouter(prefix="/expenses", tags=["expenses"])
@@ -100,7 +101,7 @@ def get_expenses(
             Account.name.ilike(f"%{account}%")
         )
     if search:
-        q = q.filter(Expense.description.ilike(f"%{search}%"))
+        q = q.filter(Expense.description_search.ilike(f"%{search}%"))
     # Only exclude future installments when NOT filtering by specific category
     # (category-specific views like side panel need to show all expenses)
     if not category_id and not category_ids:
@@ -289,6 +290,7 @@ def create_expense(
     # Normalize description
     if data.get("description"):
         data["description"] = _normalize_text(data["description"])
+        data["description_search"] = tokenize_description(data["description"])
 
     # Always store amount as positive (no sign convention)
     data["amount"] = abs(data["amount"])
@@ -397,6 +399,9 @@ def update_expense(
             data["date"] = pd.to_datetime(normalized, dayfirst=True).date()
     for k, v in data.items():
         setattr(db_exp, k, v)
+    # Update search index if description changed
+    if "description" in data:
+        db_exp.description_search = tokenize_description(data["description"])
     db.commit()
     db.refresh(db_exp)
     return db_exp

--- a/backend/app/routers/investments.py
+++ b/backend/app/routers/investments.py
@@ -1,4 +1,5 @@
 import contextlib
+import os
 from datetime import date, datetime, timedelta
 
 from fastapi import APIRouter, Depends, HTTPException

--- a/backend/app/routers/investments.py
+++ b/backend/app/routers/investments.py
@@ -1,6 +1,4 @@
 import contextlib
-import hashlib
-import os
 from datetime import date, datetime, timedelta
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -11,45 +9,12 @@ from app.models import Investment, Setting, User
 from app.routers.groups import get_group_user_ids
 from app.schemas import InvestmentCreate
 from app.services.auth import get_current_user
+from app.services.encryption import decrypt_value, encrypt_value
 
 router = APIRouter(tags=["investments"])
 
 # Sensitive setting keys that should be encrypted at rest
 SENSITIVE_KEYS = {"iol_password", "ppi_api_key", "ppi_api_secret"}
-
-
-def _get_encryptor():
-    """Get Fernet encryptor using SECRET_KEY."""
-    from cryptography.fernet import Fernet
-
-    secret = os.getenv("SECRET_KEY", "")
-    if not secret:
-        raise RuntimeError("SECRET_KEY environment variable is required for encryption")
-    if len(secret) < 32:
-        raise RuntimeError("SECRET_KEY must be at least 32 characters")
-    key = hashlib.sha256(secret.encode()).digest()
-    fernet_key = __import__("base64").urlsafe_b64encode(key)
-    return Fernet(fernet_key)
-
-
-def _encrypt_value(value: str) -> str:
-    """Encrypt a sensitive value for storage."""
-    if not value:
-        return ""
-    fernet = _get_encryptor()
-    return fernet.encrypt(value.encode()).decode()
-
-
-def _decrypt_value(encrypted: str) -> str:
-    """Decrypt a sensitive value from storage."""
-    if not encrypted:
-        return ""
-    try:
-        fernet = _get_encryptor()
-        return fernet.decrypt(encrypted.encode()).decode()
-    except Exception:
-        # If decryption fails, value might be plaintext (migration)
-        return encrypted
 
 
 _IOL_TYPE_MAP = {
@@ -124,14 +89,14 @@ def _get_setting(db: Session, key: str, user_id: int | None = None) -> str:
         return ""
     # Decrypt sensitive values
     if key in SENSITIVE_KEYS:
-        return _decrypt_value(row.value)
+        return decrypt_value(row.value)
     return row.value
 
 
 def _set_setting(db: Session, key: str, value: str, user_id: int | None = None):
     scoped_key = f"{user_id}:{key}" if user_id is not None else key
     # Encrypt sensitive values before storage
-    stored_value = _encrypt_value(value) if key in SENSITIVE_KEYS else value
+    stored_value = encrypt_value(value) if key in SENSITIVE_KEYS else value
     row = db.query(Setting).filter(Setting.key == scoped_key).first()
     if row:
         row.value = stored_value
@@ -169,7 +134,7 @@ def get_settings(
     for r in rows:
         key = r.key[len(prefix) :]
         if key in SENSITIVE_KEYS:
-            result[key] = _decrypt_value(r.value)
+            result[key] = decrypt_value(r.value)
         else:
             result[key] = r.value
     creds = _get_user_creds(db, target_user_id)

--- a/backend/app/seed_demo_data.py
+++ b/backend/app/seed_demo_data.py
@@ -13,6 +13,7 @@ from sqlalchemy.orm import Session
 from app.database import SessionLocal
 from app.models import Account, Card, Category, Expense, ScheduledExpense, User
 from app.seed import _apply_base_hierarchy_for_user
+from app.services.encryption import tokenize_description
 
 # ─── Merchant pools per category ─────────────────────────────────────────────
 
@@ -373,9 +374,12 @@ def get_or_create_cards(db: Session, user_id: int) -> list[Card]:
         card = Card(
             user_id=user_id,
             card_name=card_name,
+            card_name_search=tokenize_description(card_name),
             bank=bank,
+            bank_search=tokenize_description(bank),
             card_type=card_type,
             holder=first_name,
+            holder_search=tokenize_description(first_name),
         )
         db.add(card)
     db.commit()
@@ -479,6 +483,7 @@ def seed_demo_expenses(db: Session, user_id: int, count: int = 60):
         expense = Expense(
             date=exp_date,
             description=merchant,
+            description_search=tokenize_description(merchant),
             amount=amount,
             category_id=cat.id if cat else None,
             currency="ARS",

--- a/backend/app/services/encryption.py
+++ b/backend/app/services/encryption.py
@@ -66,11 +66,16 @@ def tokenize_description(text: str) -> str:
 
 
 def is_encrypted(value: str) -> bool:
-    """Check if a value is already Fernet-encrypted."""
+    """Check if a value looks like it's Fernet-encrypted.
+
+    Checks if value starts with Fernet token prefix 'gAAAAAB' which indicates
+    it was encrypted with Fernet. This is more robust than trying to decrypt
+    which may fail if the key has changed.
+
+    Note: Comparison is case-insensitive to handle tokenized/lowercased values.
+    """
     if not value:
         return False
-    try:
-        get_fernet().decrypt(value.encode())
-        return True
-    except Exception:
-        return False
+    # Fernet tokens always start with 'gAAAAAB' (version byte + timestamp)
+    # Use case-insensitive comparison to handle tokenized values
+    return value.upper().startswith("GAAAAAB")

--- a/backend/app/services/encryption.py
+++ b/backend/app/services/encryption.py
@@ -83,3 +83,34 @@ def is_encrypted(value: str) -> bool:
     # Fernet tokens always start with 'gAAAAAB' (version byte + timestamp)
     # Use case-insensitive comparison to handle tokenized values
     return value.upper().startswith("GAAAAAB")
+
+
+def verify_key_works() -> bool:
+    """Verify the current SECRET_KEY can encrypt and decrypt."""
+    try:
+        test = "key_verification_test"
+        encrypted = encrypt_value(test)
+        decrypted = decrypt_value(encrypted)
+        return decrypted == test
+    except Exception:
+        return False
+
+
+def needs_migration() -> bool:
+    """Check if any encrypted fields contain plaintext data."""
+    from app.database import SessionLocal
+    from sqlalchemy import text
+
+    db = SessionLocal()
+    try:
+        # Quick check: if any user has plaintext full_name
+        result = db.execute(
+            text(
+                "SELECT COUNT(*) FROM users WHERE full_name IS NOT NULL AND full_name NOT LIKE 'gAAAAAB%'"
+            )
+        ).scalar()
+        return result > 0
+    except Exception:
+        return True  # If check fails, run migration to be safe
+    finally:
+        db.close()

--- a/backend/app/services/encryption.py
+++ b/backend/app/services/encryption.py
@@ -1,10 +1,13 @@
 import base64
 import hashlib
 import hmac
+import logging
 import os
 import unicodedata
 
 from cryptography.fernet import Fernet
+
+logger = logging.getLogger(__name__)
 
 _fernet_instance = None
 
@@ -29,13 +32,14 @@ def encrypt_value(value: str) -> str:
 
 
 def decrypt_value(value: str) -> str:
-    """Decrypt a Fernet-encrypted value. Falls back to plaintext if decryption fails."""
+    """Decrypt a Fernet-encrypted value. Falls back to '[encrypted]' if decryption fails."""
     if not value:
         return value
     try:
         return get_fernet().decrypt(value.encode()).decode()
-    except Exception:
-        return value
+    except Exception as e:
+        logger.warning(f"Decryption failed for value starting with '{value[:30]}...': {e}")
+        return "[encrypted]"
 
 
 def compute_hmac(value: str) -> str:

--- a/backend/app/services/encryption.py
+++ b/backend/app/services/encryption.py
@@ -98,8 +98,9 @@ def verify_key_works() -> bool:
 
 def needs_migration() -> bool:
     """Check if any encrypted fields contain plaintext data."""
-    from app.database import SessionLocal
     from sqlalchemy import text
+
+    from app.database import SessionLocal
 
     db = SessionLocal()
     try:

--- a/backend/app/services/encryption.py
+++ b/backend/app/services/encryption.py
@@ -1,0 +1,76 @@
+import base64
+import hashlib
+import hmac
+import os
+import unicodedata
+
+from cryptography.fernet import Fernet
+
+_fernet_instance = None
+
+
+def get_fernet() -> Fernet:
+    """Singleton Fernet instance derived from SECRET_KEY."""
+    global _fernet_instance
+    if _fernet_instance is None:
+        secret = os.getenv("SECRET_KEY", "")
+        if len(secret) < 32:
+            raise RuntimeError("SECRET_KEY must be at least 32 characters")
+        key = hashlib.sha256(secret.encode()).digest()
+        _fernet_instance = Fernet(base64.urlsafe_b64encode(key))
+    return _fernet_instance
+
+
+def encrypt_value(value: str) -> str:
+    """Encrypt a string value using Fernet."""
+    if not value:
+        return value
+    return get_fernet().encrypt(value.encode()).decode()
+
+
+def decrypt_value(value: str) -> str:
+    """Decrypt a Fernet-encrypted value. Falls back to plaintext if decryption fails."""
+    if not value:
+        return value
+    try:
+        return get_fernet().decrypt(value.encode()).decode()
+    except Exception:
+        return value
+
+
+def compute_hmac(value: str) -> str:
+    """Compute HMAC-SHA256 for lookup columns."""
+    if not value:
+        return value
+    secret = os.getenv("SECRET_KEY", "")
+    return hmac.new(secret.encode(), value.encode(), hashlib.sha256).hexdigest()
+
+
+def tokenize_description(text: str) -> str:
+    """Tokenize description for search.
+
+    Converts 'Farmacía $1500 medicamentos' → 'farmacia 1500 medicamentos'
+
+    - Lowercase
+    - Remove accents (NFD decomposition)
+    - Keep only alphanumeric + spaces
+    - Collapse multiple spaces
+    """
+    if not text:
+        return text
+    text = text.lower()
+    text = unicodedata.normalize("NFD", text)
+    text = "".join(c for c in text if unicodedata.category(c) != "Mn")
+    text = "".join(c if c.isalnum() or c.isspace() else " " for c in text)
+    return " ".join(text.split())
+
+
+def is_encrypted(value: str) -> bool:
+    """Check if a value is already Fernet-encrypted."""
+    if not value:
+        return False
+    try:
+        get_fernet().decrypt(value.encode())
+        return True
+    except Exception:
+        return False

--- a/backend/app/services/import_utils.py
+++ b/backend/app/services/import_utils.py
@@ -12,6 +12,7 @@ from sqlalchemy.orm import Session
 
 from app.models import Expense
 from app.services.date_utils import add_months
+from app.services.encryption import tokenize_description
 
 
 def _strip_installment_suffix(desc: str) -> str:
@@ -146,7 +147,7 @@ def _is_duplicate(
             db.query(Expense)
             .filter(
                 Expense.amount == amount,
-                func.lower(Expense.description) == description.lower(),
+                func.lower(Expense.description_search) == tokenize_description(description),
                 Expense.installment_number == installment_number,
                 Expense.installment_total == installment_total,
                 Expense.date >= month_start,
@@ -169,7 +170,7 @@ def _is_duplicate(
     q = db.query(Expense).filter(
         Expense.date == exp_date,
         Expense.amount == amount,
-        func.lower(Expense.description) == description.lower(),
+        func.lower(Expense.description_search) == tokenize_description(description),
     )
     if installment_number is not None:
         q = q.filter(Expense.installment_number == installment_number)
@@ -226,7 +227,7 @@ def _is_scheduled_duplicate(
         ScheduledExpense.scheduled_date == scheduled_date,
         ScheduledExpense.installment_number == installment_number,
         ScheduledExpense.installment_total == installment_total,
-        func.lower(ScheduledExpense.description) == description.lower(),
+        func.lower(ScheduledExpense.description_search) == tokenize_description(description),
         ScheduledExpense.status == "PENDING",
     )
     if installment_group_id:

--- a/backend/app/tasks/budgets.py
+++ b/backend/app/tasks/budgets.py
@@ -133,7 +133,7 @@ def check_budget_alerts():
         year, month = today.year, today.month
         month_key = f"{year}-{month:02d}"
 
-        users = db.query(User).filter(User.telegram_chat_id.isnot(None)).all()
+        users = db.query(User).filter(User.telegram_chat_hash.isnot(None)).all()
 
         alerts_sent = 0
         for user in users:

--- a/backend/app/tasks/budgets.py
+++ b/backend/app/tasks/budgets.py
@@ -194,7 +194,7 @@ def check_budget_alerts():
                 db.add(notification)
                 alerts_sent += 1
 
-                if user.telegram_chat_id:
+                if user.telegram_chat_id and user.telegram_chat_id != "[encrypted]":
                     _send_group_telegram_alert(
                         user.telegram_chat_id,
                         group.name,
@@ -251,7 +251,7 @@ def check_budget_alerts():
                 db.add(notification)
                 alerts_sent += 1
 
-                if user.telegram_chat_id:
+                if user.telegram_chat_id and user.telegram_chat_id != "[encrypted]":
                     _send_telegram_alert(
                         user.telegram_chat_id,
                         cat.name,

--- a/backend/app/tasks/weekly_summary.py
+++ b/backend/app/tasks/weekly_summary.py
@@ -248,7 +248,7 @@ def send_weekly_reports():
             return
 
         # Get all users with Telegram connected
-        users = db.query(User).filter(User.telegram_chat_id.isnot(None)).all()
+        users = db.query(User).filter(User.telegram_chat_hash.isnot(None)).all()
 
         sent_count = 0
         for user in users:

--- a/backend/app/tasks/weekly_summary.py
+++ b/backend/app/tasks/weekly_summary.py
@@ -295,11 +295,12 @@ def send_weekly_reports():
                 # Send via Telegram
                 from app.telegram_bot import send_photo_to_chat
 
-                if send_photo_to_chat(user.telegram_chat_id, png_bytes, caption):
-                    sent_count += 1
-                    logger.info(f"[WEEKLY REPORT] Sent report to user {user.id}")
-                else:
-                    logger.warning(f"[WEEKLY REPORT] Failed to send report to user {user.id}")
+                if user.telegram_chat_id and user.telegram_chat_id != "[encrypted]":
+                    if send_photo_to_chat(user.telegram_chat_id, png_bytes, caption):
+                        sent_count += 1
+                        logger.info(f"[WEEKLY REPORT] Sent report to user {user.id}")
+                    else:
+                        logger.warning(f"[WEEKLY REPORT] Failed to send report to user {user.id}")
 
             except Exception as e:
                 logger.error(f"[WEEKLY REPORT] Error sending to user {user.id}: {e}")

--- a/backend/app/telegram_bot.py
+++ b/backend/app/telegram_bot.py
@@ -290,6 +290,7 @@ def _save_expense(
         expense = Expense(
             date=expense_date,
             description=_normalize_text(parsed.get("description", "")),
+            description_search=tokenize_description(_normalize_text(parsed.get("description", ""))),
             amount=installment_amount,
             currency=parsed.get("currency", "ARS"),
             category_id=category_id,
@@ -1291,8 +1292,8 @@ async def handle_card_type(update: Update, context: ContextTypes.DEFAULT_TYPE) -
             db_card.query(Card)
             .filter(
                 Card.user_id == context.user_data["user_id"],
-                func.lower(Card.card_name) == card.lower(),
-                func.lower(Card.bank) == bank.lower(),
+                func.lower(Card.card_name_search) == tokenize_description(card),
+                func.lower(Card.bank_search) == tokenize_description(bank),
             )
             .first()
         )
@@ -1954,6 +1955,7 @@ def _save_expense_from_context(context, db):
                 amount=expense.amount,
                 currency=expense.currency,
                 description=expense.description,
+                description_search=tokenize_description(expense.description),
                 card_id=expense.card_id,
                 account_id=expense.account_id,
                 category_id=expense.category_id,
@@ -2037,8 +2039,8 @@ async def handle_card_manual(update: Update, context: ContextTypes.DEFAULT_TYPE)
             db_card.query(Card)
             .filter(
                 Card.user_id == context.user_data["user_id"],
-                func.lower(Card.card_name) == card_name.lower(),
-                func.lower(Card.bank) == bank.lower() if bank else True,
+                func.lower(Card.card_name_search) == tokenize_description(card_name),
+                func.lower(Card.bank_search) == tokenize_description(bank) if bank else True,
             )
             .first()
         )

--- a/backend/app/telegram_bot.py
+++ b/backend/app/telegram_bot.py
@@ -671,7 +671,9 @@ def _saved_text(expense: "Expense", payment_label: str) -> str:
 def _get_user_by_chat_id(chat_id: str) -> User | None:
     db = SessionLocal()
     try:
-        return db.query(User).filter(User.telegram_chat_id == chat_id).first()
+        from app.services.encryption import compute_hmac
+        chat_hash = compute_hmac(chat_id)
+        return db.query(User).filter(User.telegram_chat_hash == chat_hash).first()
     finally:
         db.close()
 
@@ -800,7 +802,9 @@ async def start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     chat_id = str(update.effective_chat.id)
     db = SessionLocal()
     try:
-        user = db.query(User).filter(User.telegram_chat_id == chat_id).first()
+        from app.services.encryption import compute_hmac
+        chat_hash = compute_hmac(chat_id)
+        user = db.query(User).filter(User.telegram_chat_hash == chat_hash).first()
         if user:
             await update.message.reply_text(
                 f"¡Hola de nuevo, <b>{user.full_name}</b>! 🎉 ¿Qué gastaste hoy?",
@@ -829,6 +833,8 @@ async def handle_auth(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int
             await update.message.reply_text("Clave incorrecta. Intentá de nuevo.")
             return WAITING_AUTH
         user.telegram_chat_id = chat_id
+        from app.services.encryption import compute_hmac
+        user.telegram_chat_hash = compute_hmac(chat_id)
         user.telegram_key = None  # Invalidate key after use
         db.commit()
         db.refresh(user)
@@ -1618,7 +1624,9 @@ async def handle_card_create_name(update: Update, context: ContextTypes.DEFAULT_
     db = SessionLocal()
     try:
         chat_id = str(update.effective_chat.id)
-        user = db.query(User).filter(User.telegram_chat_id == chat_id).first()
+        from app.services.encryption import compute_hmac
+        chat_hash = compute_hmac(chat_id)
+        user = db.query(User).filter(User.telegram_chat_hash == chat_hash).first()
         user_full_name = user.full_name if user else ""
     finally:
         db.close()
@@ -1681,7 +1689,9 @@ async def handle_card_create_confirm(update: Update, context: ContextTypes.DEFAU
     chat_id = str(update.effective_chat.id)
     db = SessionLocal()
     try:
-        user = db.query(User).filter(User.telegram_chat_id == chat_id).first()
+        from app.services.encryption import compute_hmac
+        chat_hash = compute_hmac(chat_id)
+        user = db.query(User).filter(User.telegram_chat_hash == chat_hash).first()
         if not user:
             await query.message.reply_text("❌ Error: usuario no encontrado.")
             return ConversationHandler.END

--- a/backend/app/telegram_bot.py
+++ b/backend/app/telegram_bot.py
@@ -673,6 +673,7 @@ def _get_user_by_chat_id(chat_id: str) -> User | None:
     db = SessionLocal()
     try:
         from app.services.encryption import compute_hmac
+
         chat_hash = compute_hmac(chat_id)
         return db.query(User).filter(User.telegram_chat_hash == chat_hash).first()
     finally:
@@ -804,6 +805,7 @@ async def start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     db = SessionLocal()
     try:
         from app.services.encryption import compute_hmac
+
         chat_hash = compute_hmac(chat_id)
         user = db.query(User).filter(User.telegram_chat_hash == chat_hash).first()
         if user:
@@ -835,6 +837,7 @@ async def handle_auth(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int
             return WAITING_AUTH
         user.telegram_chat_id = chat_id
         from app.services.encryption import compute_hmac
+
         user.telegram_chat_hash = compute_hmac(chat_id)
         user.telegram_key = None  # Invalidate key after use
         db.commit()
@@ -1626,6 +1629,7 @@ async def handle_card_create_name(update: Update, context: ContextTypes.DEFAULT_
     try:
         chat_id = str(update.effective_chat.id)
         from app.services.encryption import compute_hmac
+
         chat_hash = compute_hmac(chat_id)
         user = db.query(User).filter(User.telegram_chat_hash == chat_hash).first()
         user_full_name = user.full_name if user else ""
@@ -1691,6 +1695,7 @@ async def handle_card_create_confirm(update: Update, context: ContextTypes.DEFAU
     db = SessionLocal()
     try:
         from app.services.encryption import compute_hmac
+
         chat_hash = compute_hmac(chat_id)
         user = db.query(User).filter(User.telegram_chat_hash == chat_hash).first()
         if not user:

--- a/backend/app/telegram_bot.py
+++ b/backend/app/telegram_bot.py
@@ -24,6 +24,7 @@ from app.database import SessionLocal
 from app.models import Account, Card, Category, Expense, User
 from app.prompts import CARD_EXTRACT_PROMPT, EXPENSE_PARSE_PROMPT
 from app.services.categorization import auto_categorize, llm_categorize
+from app.services.encryption import tokenize_description
 from app.services.import_utils import _normalize_text
 
 logger = logging.getLogger(__name__)
@@ -1712,8 +1713,8 @@ async def handle_card_create_confirm(update: Update, context: ContextTypes.DEFAU
             db.query(Card)
             .filter(
                 Card.user_id == user_id,
-                func.lower(func.trim(Card.card_name)) == card_name.lower(),
-                func.lower(func.trim(Card.bank)) == bank.lower(),
+                func.lower(Card.card_name_search) == card_name.lower(),
+                func.lower(Card.bank_search) == bank.lower(),
             )
             .first()
         )
@@ -1726,8 +1727,11 @@ async def handle_card_create_confirm(update: Update, context: ContextTypes.DEFAU
 
         new_card = Card(
             card_name=card_name,
+            card_name_search=tokenize_description(card_name),
             bank=bank,
+            bank_search=tokenize_description(bank),
             holder=holder,
+            holder_search=tokenize_description(holder),
             card_type=card_type,
             user_id=user_id,
         )

--- a/backend/app/types/encrypted.py
+++ b/backend/app/types/encrypted.py
@@ -1,0 +1,23 @@
+from sqlalchemy.types import String, TypeDecorator
+
+from app.services.encryption import decrypt_value, encrypt_value
+
+
+class EncryptedType(TypeDecorator):
+    """SQLAlchemy type that transparently encrypts/decrypts values.
+
+    Usage:
+        class MyModel(Base):
+            secret_field = Column(EncryptedType, nullable=True)
+    """
+
+    impl = String
+    cache_ok = True
+
+    def process_bind_param(self, value, dialect):
+        """Encrypt before writing to DB."""
+        return encrypt_value(value) if value else value
+
+    def process_result_value(self, value, dialect):
+        """Decrypt when reading from DB."""
+        return decrypt_value(value) if value else value

--- a/backend/main.py
+++ b/backend/main.py
@@ -44,7 +44,19 @@ from app.services.auth import get_password_hash
 async def lifespan(application: FastAPI):
     # Create tables if they don't exist
     Base.metadata.create_all(bind=engine)
-    
+
+    # Validate SECRET_KEY length
+    secret_key = os.getenv("SECRET_KEY", "")
+    if len(secret_key) < 32:
+        raise RuntimeError(
+            "SECRET_KEY must be at least 32 characters. "
+            'Generate one with: python -c "import secrets; print(secrets.token_urlsafe(64))"'
+        )
+
+    # Run encryption migration for existing plaintext data
+    from scripts.migrate_encrypt_fields import migrate_plaintext_data
+    migrate_plaintext_data()
+
     db = SessionLocal()
     if db.query(Category).count() == 0:
         _apply_base_hierarchy(db)

--- a/backend/main.py
+++ b/backend/main.py
@@ -53,9 +53,17 @@ async def lifespan(application: FastAPI):
             'Generate one with: python -c "import secrets; print(secrets.token_urlsafe(64))"'
         )
 
-    # Run encryption migration for existing plaintext data
-    from scripts.migrate_encrypt_fields import migrate_plaintext_data
-    migrate_plaintext_data()
+    # Verify SECRET_KEY can encrypt/decrypt (fail fast)
+    from app.services.encryption import verify_key_works
+    if not verify_key_works():
+        logger.error("SECRET_KEY cannot encrypt/decrypt! Check that the key hasn't changed.")
+        raise RuntimeError("SECRET_KEY is invalid - cannot encrypt/decrypt data. Aborting.")
+
+    # Run encryption migration for existing plaintext data (only if needed)
+    from app.services.encryption import needs_migration
+    if needs_migration():
+        from scripts.migrate_encrypt_fields import migrate_plaintext_data
+        migrate_plaintext_data()
 
     db = SessionLocal()
     if db.query(Category).count() == 0:

--- a/backend/scripts/deploy_prod.py
+++ b/backend/scripts/deploy_prod.py
@@ -31,7 +31,9 @@ def run_command(cmd: str, check: bool = True, capture: bool = False) -> subproce
 
 def main():
     parser = argparse.ArgumentParser(description="Deploy to production")
-    parser.add_argument("--dry-run", action="store_true", help="Show what would be done without executing")
+    parser.add_argument(
+        "--dry-run", action="store_true", help="Show what would be done without executing"
+    )
     parser.add_argument("--skip-restart", action="store_true", help="Skip service restart")
     args = parser.parse_args()
 
@@ -42,12 +44,22 @@ def main():
     if args.dry_run:
         print("\n[DRY RUN] No changes will be made.\n")
 
-    # Step 1: Run migration
-    print("\n[Step 1] Running database migration...")
+    # Step 1: Run migrations
+    print("\n[Step 1] Running database migrations...")
     if args.dry_run:
-        print("  Would run: podman-compose run --rm --no-deps backend python -m scripts.migrate_add_reset_token")
+        print(
+            "  Would run: podman-compose run --rm --no-deps backend python -m scripts.migrate_add_reset_token"
+        )
+        print(
+            "  Would run: podman-compose run --rm --no-deps backend python -m scripts.migrate_db_structure"
+        )
     else:
-        run_command("cd /home/chelo/creditCardAnalyzer && podman-compose run --rm --no-deps backend python -m scripts.migrate_add_reset_token")
+        run_command(
+            "cd /home/chelo/creditCardAnalyzer && podman-compose run --rm --no-deps backend python -m scripts.migrate_add_reset_token"
+        )
+        run_command(
+            "cd /home/chelo/creditCardAnalyzer && podman-compose run --rm --no-deps backend python -m scripts.migrate_db_structure"
+        )
 
     # Step 2: Restart backend
     if not args.skip_restart:
@@ -71,7 +83,11 @@ def main():
         print("  Would verify API health endpoint")
     else:
         # Quick health check
-        result = run_command("curl -s -o /dev/null -w '%{http_code}' http://localhost:8000/docs", check=False, capture=True)
+        result = run_command(
+            "curl -s -o /dev/null -w '%{http_code}' http://localhost:8000/docs",
+            check=False,
+            capture=True,
+        )
         if result.stdout.strip() == "200":
             print("  Backend is healthy!")
         else:

--- a/backend/scripts/deploy_prod.sh
+++ b/backend/scripts/deploy_prod.sh
@@ -23,13 +23,15 @@ done
 
 # Step 1: Database migration
 echo ""
-echo "[Step 1/3] Running database migration..."
+echo "[Step 1/3] Running database migrations..."
 if [ "$DRY_RUN" = true ]; then
   echo "  Would run: podman-compose run --rm --no-deps backend python -m scripts.migrate_add_reset_token"
   echo "  Would run: podman-compose run --rm --no-deps backend python -m scripts.migrate_remove_haberes"
+  echo "  Would run: podman-compose run --rm --no-deps backend python -m scripts.migrate_db_structure"
 else
   podman-compose run --rm --no-deps backend python -m scripts.migrate_add_reset_token
   podman-compose run --rm --no-deps backend python -m scripts.migrate_remove_haberes
+  podman-compose run --rm --no-deps backend python -m scripts.migrate_db_structure
 fi
 
 # Step 2: Restart services

--- a/backend/scripts/dry_run_migration.py
+++ b/backend/scripts/dry_run_migration.py
@@ -18,7 +18,7 @@ import sys
 sys.path.insert(0, ".")
 
 from app.database import SessionLocal
-from app.models import AuditLog, Card, Expense, Investment, MonthlyReport, User
+from app.models import AuditLog, Card, Expense, Investment, MonthlyReport, ScheduledExpense, User
 from app.services.encryption import (
     decrypt_value,
     encrypt_value,
@@ -33,6 +33,7 @@ ENCRYPTED_FIELDS = {
     User: ["full_name", "telegram_chat_id", "mfa_secret"],
     Card: ["card_name", "bank", "holder"],
     Expense: ["description", "notes"],
+    ScheduledExpense: ["description"],
     Investment: ["notes"],
     AuditLog: ["ip_address", "user_agent"],
     MonthlyReport: ["report_data"],
@@ -41,6 +42,7 @@ ENCRYPTED_FIELDS = {
 SEARCH_FIELDS = {
     Card: ["card_name_search", "bank_search", "holder_search"],
     Expense: ["description_search"],
+    ScheduledExpense: ["description_search"],
 }
 
 

--- a/backend/scripts/dry_run_migration.py
+++ b/backend/scripts/dry_run_migration.py
@@ -1,0 +1,148 @@
+"""
+Dry-run migration: encrypt, verify, rollback.
+Usage: python scripts/dry_run_migration.py
+
+Tests:
+1. Encrypt all fields (User, Card, Expense, etc.)
+2. Verify all encrypted fields can be decrypted
+3. Verify Card search columns work (ilike queries)
+4. Verify Expense search columns work (ilike queries)
+5. Rollback transaction (no changes saved)
+
+Output: Status: PASS or FAIL + verbose details
+"""
+
+import logging
+import sys
+
+sys.path.insert(0, ".")
+
+from app.database import SessionLocal
+from app.models import AuditLog, Card, Expense, Investment, MonthlyReport, User
+from app.services.encryption import (
+    decrypt_value,
+    encrypt_value,
+    is_encrypted,
+    tokenize_description,
+)
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+ENCRYPTED_FIELDS = {
+    User: ["full_name", "telegram_chat_id", "mfa_secret"],
+    Card: ["card_name", "bank", "holder"],
+    Expense: ["description", "notes"],
+    Investment: ["notes"],
+    AuditLog: ["ip_address", "user_agent"],
+    MonthlyReport: ["report_data"],
+}
+
+SEARCH_FIELDS = {
+    Card: ["card_name_search", "bank_search", "holder_search"],
+    Expense: ["description_search"],
+}
+
+
+def main():
+    db = SessionLocal()
+    db.begin()  # Start transaction
+
+    stats = {
+        "tables": 0,
+        "encrypted": 0,
+        "verified": 0,
+        "failed": 0,
+        "search_verified": 0,
+        "search_failed": 0,
+    }
+    failed_rows = []
+
+    try:
+        # Test encryption on all fields
+        for model, fields in ENCRYPTED_FIELDS.items():
+            stats["tables"] += 1
+            rows = db.query(model).all()
+
+            for row in rows:
+                for field in fields:
+                    value = getattr(row, field)
+                    if value and not is_encrypted(value):
+                        stats["encrypted"] += 1
+
+                        # Verify can encrypt and decrypt
+                        encrypted = encrypt_value(value)
+                        decrypted = decrypt_value(encrypted)
+                        if decrypted == value:
+                            stats["verified"] += 1
+                        else:
+                            stats["failed"] += 1
+                            failed_rows.append({
+                                "table": model.__tablename__,
+                                "id": row.id,
+                                "field": field,
+                                "error": "decrypt mismatch",
+                            })
+
+        # Test Card search columns
+        for model, fields in SEARCH_FIELDS.items():
+            rows = db.query(model).all()
+            for row in rows:
+                for field in fields:
+                    source_field = field.replace("_search", "")
+                    source_value = getattr(row, source_field)
+                    if source_value:
+                        # Generate search token
+                        if is_encrypted(source_value):
+                            plaintext = decrypt_value(source_value)
+                        else:
+                            plaintext = source_value
+                        search_value = tokenize_description(plaintext)
+
+                        if search_value:
+                            stats["search_verified"] += 1
+
+                            # Test ilike query
+                            result = db.query(model).filter(
+                                getattr(model, field).ilike(f"%{search_value[:5]}%")
+                            ).first()
+                            if not result:
+                                stats["search_failed"] += 1
+                                failed_rows.append({
+                                    "table": model.__tablename__,
+                                    "id": row.id,
+                                    "field": field,
+                                    "error": "search query failed",
+                                })
+
+        # Rollback (no changes saved)
+        db.rollback()
+
+        # Print summary
+        status = "PASS" if stats["failed"] == 0 and stats["search_failed"] == 0 else "FAIL"
+        print(f"Status: {status}")
+        print(f"Tables: {stats['tables']}")
+        print(f"Encrypted: {stats['encrypted']}")
+        print(f"Verified: {stats['verified']}")
+        print(f"Failed: {stats['failed']}")
+        print(f"Search verified: {stats['search_verified']}")
+        print(f"Search failed: {stats['search_failed']}")
+
+        if failed_rows:
+            print("\nFailed rows:")
+            for row in failed_rows:
+                print(f"  {row['table']}:{row['id']}.{row['field']} - {row['error']}")
+
+        return 0 if status == "PASS" else 1
+
+    except Exception as e:
+        db.rollback()
+        print(f"Status: FAIL")
+        print(f"Error: {e}")
+        return 1
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/scripts/dry_run_migration.py
+++ b/backend/scripts/dry_run_migration.py
@@ -77,12 +77,14 @@ def main():
                             stats["verified"] += 1
                         else:
                             stats["failed"] += 1
-                            failed_rows.append({
-                                "table": model.__tablename__,
-                                "id": row.id,
-                                "field": field,
-                                "error": "decrypt mismatch",
-                            })
+                            failed_rows.append(
+                                {
+                                    "table": model.__tablename__,
+                                    "id": row.id,
+                                    "field": field,
+                                    "error": "decrypt mismatch",
+                                }
+                            )
 
         # Test Card search columns
         for model, fields in SEARCH_FIELDS.items():
@@ -103,17 +105,21 @@ def main():
                             stats["search_verified"] += 1
 
                             # Test ilike query
-                            result = db.query(model).filter(
-                                getattr(model, field).ilike(f"%{search_value[:5]}%")
-                            ).first()
+                            result = (
+                                db.query(model)
+                                .filter(getattr(model, field).ilike(f"%{search_value[:5]}%"))
+                                .first()
+                            )
                             if not result:
                                 stats["search_failed"] += 1
-                                failed_rows.append({
-                                    "table": model.__tablename__,
-                                    "id": row.id,
-                                    "field": field,
-                                    "error": "search query failed",
-                                })
+                                failed_rows.append(
+                                    {
+                                        "table": model.__tablename__,
+                                        "id": row.id,
+                                        "field": field,
+                                        "error": "search query failed",
+                                    }
+                                )
 
         # Rollback (no changes saved)
         db.rollback()

--- a/backend/scripts/migrate_add_budgets.py
+++ b/backend/scripts/migrate_add_budgets.py
@@ -44,7 +44,8 @@ def main():
         if dialect == "postgresql":
             # ─── 1. Create budgets table ─────────────────────────────
             print("\n[1/5] Creating budgets table...")
-            conn.execute(text("""
+            conn.execute(
+                text("""
                 CREATE TABLE IF NOT EXISTS budgets (
                     id SERIAL PRIMARY KEY,
                     user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
@@ -56,12 +57,14 @@ def main():
                     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                     updated_at TIMESTAMP
                 )
-            """))
+            """)
+            )
             print("  budgets table OK")
 
             # ─── 2. Create budget_groups table ────────────────────────
             print("\n[2/5] Creating budget_groups table...")
-            conn.execute(text("""
+            conn.execute(
+                text("""
                 CREATE TABLE IF NOT EXISTS budget_groups (
                     id SERIAL PRIMARY KEY,
                     user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
@@ -74,12 +77,14 @@ def main():
                     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                     updated_at TIMESTAMP
                 )
-            """))
+            """)
+            )
             print("  budget_groups table OK")
 
             # ─── 3. Create budget_events table ────────────────────────
             print("\n[3/5] Creating budget_events table...")
-            conn.execute(text("""
+            conn.execute(
+                text("""
                 CREATE TABLE IF NOT EXISTS budget_events (
                     id SERIAL PRIMARY KEY,
                     user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
@@ -93,22 +98,27 @@ def main():
                     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                     updated_at TIMESTAMP
                 )
-            """))
+            """)
+            )
             print("  budget_events table OK")
 
             # ─── 4. Add budget_group column to categories ─────────────
             print("\n[4/5] Adding budget_group column to categories...")
-            has_column = conn.execute(text("""
+            has_column = conn.execute(
+                text("""
                 SELECT EXISTS (
                     SELECT 1 FROM information_schema.columns
                     WHERE table_name = 'categories' AND column_name = 'budget_group'
                 )
-            """)).scalar()
+            """)
+            ).scalar()
 
             if not has_column:
-                conn.execute(text("""
+                conn.execute(
+                    text("""
                     ALTER TABLE categories ADD COLUMN budget_group VARCHAR(20) DEFAULT 'necesidades'
-                """))
+                """)
+                )
                 print("  budget_group column added")
             else:
                 print("  budget_group column already exists")
@@ -116,29 +126,45 @@ def main():
             # ─── 5. Create indexes ────────────────────────────────────
             print("\n[5/5] Creating indexes...")
             conn.execute(text("CREATE INDEX IF NOT EXISTS ix_budgets_user_id ON budgets (user_id)"))
-            conn.execute(text("CREATE INDEX IF NOT EXISTS ix_budgets_category_id ON budgets (category_id)"))
-            conn.execute(text("""
+            conn.execute(
+                text("CREATE INDEX IF NOT EXISTS ix_budgets_category_id ON budgets (category_id)")
+            )
+            conn.execute(
+                text("""
                 CREATE UNIQUE INDEX IF NOT EXISTS uq_budget_user_cat
                 ON budgets (user_id, category_id)
-            """))
-            conn.execute(text("CREATE INDEX IF NOT EXISTS ix_budget_groups_user_id ON budget_groups (user_id)"))
-            conn.execute(text("""
+            """)
+            )
+            conn.execute(
+                text(
+                    "CREATE INDEX IF NOT EXISTS ix_budget_groups_user_id ON budget_groups (user_id)"
+                )
+            )
+            conn.execute(
+                text("""
                 CREATE UNIQUE INDEX IF NOT EXISTS uq_budget_group_user_name
                 ON budget_groups (user_id, name)
-            """))
-            conn.execute(text("CREATE INDEX IF NOT EXISTS ix_budget_events_user_id ON budget_events (user_id)"))
+            """)
+            )
+            conn.execute(
+                text(
+                    "CREATE INDEX IF NOT EXISTS ix_budget_events_user_id ON budget_events (user_id)"
+                )
+            )
             print("  All indexes OK")
 
             # ─── Verification ─────────────────────────────────────────
             print("\n[Verification] Checking all tables and columns...")
             tables = ["budgets", "budget_groups", "budget_events"]
             for table in tables:
-                exists = conn.execute(text(f"""
+                exists = conn.execute(
+                    text(f"""
                     SELECT EXISTS (
                         SELECT 1 FROM information_schema.tables
                         WHERE table_schema = 'public' AND table_name = '{table}'
                     )
-                """)).scalar()
+                """)
+                ).scalar()
                 if exists:
                     print(f"  ✓ {table} exists")
                 else:
@@ -146,12 +172,14 @@ def main():
                     raise RuntimeError(f"Table {table} was not created")
 
             # Check budget_group column
-            has_bg = conn.execute(text("""
+            has_bg = conn.execute(
+                text("""
                 SELECT EXISTS (
                     SELECT 1 FROM information_schema.columns
                     WHERE table_name = 'categories' AND column_name = 'budget_group'
                 )
-            """)).scalar()
+            """)
+            ).scalar()
             if has_bg:
                 print("  ✓ categories.budget_group exists")
             else:
@@ -161,7 +189,8 @@ def main():
             # ─── 6. Auto-assign categories to macro groups ────────────────
             print("\n[6/6] Auto-assigning categories to macro groups...")
             try:
-                conn.execute(text("""
+                conn.execute(
+                    text("""
                     UPDATE categories SET budget_group = 'gustos'
                     WHERE budget_group = 'necesidades'
                     AND LOWER(name) LIKE ANY(ARRAY[
@@ -174,8 +203,10 @@ def main():
                         '%viajes%', '%hotel%', '%aerolínea%', '%turismo%',
                         '%mascotas%', '%vacaciones%'
                     ])
-                """))
-                conn.execute(text("""
+                """)
+                )
+                conn.execute(
+                    text("""
                     UPDATE categories SET budget_group = 'ahorro'
                     WHERE budget_group = 'necesidades'
                     AND LOWER(name) LIKE ANY(ARRAY[
@@ -183,7 +214,8 @@ def main():
                         '%plazo fijo%', '%fci%', '%bonos%', '%acciones%',
                         '%dólar%', '%crypto%'
                     ])
-                """))
+                """)
+                )
                 conn.commit()
                 print("  Categories auto-assigned to groups")
             except Exception as e:
@@ -195,9 +227,11 @@ def main():
             if not ahorro_enabled:
                 try:
                     with engine.begin() as conn2:
-                        conn2.execute(text(
-                            "UPDATE budget_groups SET is_active = false WHERE name = 'ahorro' AND is_active = true"
-                        ))
+                        conn2.execute(
+                            text(
+                                "UPDATE budget_groups SET is_active = false WHERE name = 'ahorro' AND is_active = true"
+                            )
+                        )
                     print("  Ahorro group deactivated (BUDGET_AHORRO_ENABLED=false)")
                 except Exception as e:
                     print(f"  Warning: Ahorro deactivation failed ({e}), skipping")
@@ -208,11 +242,13 @@ def main():
             print("\n[8/8] Adding budget_event_id to expenses...")
             try:
                 with engine.begin() as conn2:
-                    conn2.execute(text("""
+                    conn2.execute(
+                        text("""
                         ALTER TABLE expenses 
                         ADD COLUMN IF NOT EXISTS budget_event_id INTEGER 
                         REFERENCES budget_events(id) ON DELETE SET NULL
-                    """))
+                    """)
+                    )
                 print("  budget_event_id column added to expenses")
             except Exception as e:
                 print(f"  Warning: budget_event_id already exists or failed ({e}), skipping")

--- a/backend/scripts/migrate_add_card_account_link.py
+++ b/backend/scripts/migrate_add_card_account_link.py
@@ -39,46 +39,56 @@ def main():
             conn.execute(text("SET search_path TO public"))
 
             # Check if column already exists
-            has_column = conn.execute(text("""
+            has_column = conn.execute(
+                text("""
                 SELECT EXISTS (
                     SELECT 1 FROM information_schema.columns
                     WHERE table_name = 'cards' AND column_name = 'linked_account_id'
                 )
-            """)).scalar()
+            """)
+            ).scalar()
 
             if has_column:
                 print("Column linked_account_id already exists. Skipping.")
             else:
                 print("Adding linked_account_id column to cards...")
-                conn.execute(text("""
+                conn.execute(
+                    text("""
                     ALTER TABLE cards ADD COLUMN linked_account_id INTEGER
                     REFERENCES accounts(id) ON DELETE SET NULL
-                """))
+                """)
+                )
                 print("  ✓ Column added")
 
             # Ensure index exists
-            has_index = conn.execute(text("""
+            has_index = conn.execute(
+                text("""
                 SELECT EXISTS (
                     SELECT 1 FROM pg_indexes
                     WHERE tablename = 'cards' AND indexname = 'ix_cards_linked_account_id'
                 )
-            """)).scalar()
+            """)
+            ).scalar()
 
             if not has_index:
                 print("Creating index ix_cards_linked_account_id...")
-                conn.execute(text("""
+                conn.execute(
+                    text("""
                     CREATE INDEX ix_cards_linked_account_id ON cards (linked_account_id)
-                """))
+                """)
+                )
                 print("  ✓ Index created")
             else:
                 print("Index ix_cards_linked_account_id already exists. Skipping.")
 
             # Verify
-            verify = conn.execute(text("""
+            verify = conn.execute(
+                text("""
                 SELECT c.column_name, c.is_nullable
                 FROM information_schema.columns c
                 WHERE c.table_name = 'cards' AND c.column_name = 'linked_account_id'
-            """)).fetchone()
+            """)
+            ).fetchone()
 
             if verify:
                 print(f"\nVerification passed:")

--- a/backend/scripts/migrate_add_category_suggestions.py
+++ b/backend/scripts/migrate_add_category_suggestions.py
@@ -32,7 +32,9 @@ def migrate():
 
         # Create indexes
         conn.execute(
-            text("CREATE INDEX IF NOT EXISTS ix_category_suggestions_user_id ON category_suggestions(user_id)")
+            text(
+                "CREATE INDEX IF NOT EXISTS ix_category_suggestions_user_id ON category_suggestions(user_id)"
+            )
         )
         conn.execute(
             text(
@@ -40,7 +42,9 @@ def migrate():
             )
         )
         conn.execute(
-            text("CREATE INDEX IF NOT EXISTS ix_category_suggestions_status ON category_suggestions(status)")
+            text(
+                "CREATE INDEX IF NOT EXISTS ix_category_suggestions_status ON category_suggestions(status)"
+            )
         )
 
         print("✅ category_suggestions table created successfully")

--- a/backend/scripts/migrate_add_monthly_reports.py
+++ b/backend/scripts/migrate_add_monthly_reports.py
@@ -38,23 +38,27 @@ def main():
             conn.execute(text("SET search_path TO public"))
 
             # Check if table already exists
-            exists = conn.execute(text("""
+            exists = conn.execute(
+                text("""
                 SELECT EXISTS (
                     SELECT 1 FROM information_schema.tables
                     WHERE table_schema = 'public' AND table_name = 'monthly_reports'
                 )
-            """)).scalar()
+            """)
+            ).scalar()
 
             if exists:
                 print("Table already exists. Checking for columns...")
 
                 # Ensure png_data column exists
-                has_png = conn.execute(text("""
+                has_png = conn.execute(
+                    text("""
                     SELECT EXISTS (
                         SELECT 1 FROM information_schema.columns
                         WHERE table_name = 'monthly_reports' AND column_name = 'png_data'
                     )
-                """)).scalar()
+                """)
+                ).scalar()
                 if not has_png:
                     print("Adding png_data column...")
                     conn.execute(text("ALTER TABLE monthly_reports ADD COLUMN png_data BYTEA"))
@@ -63,12 +67,14 @@ def main():
                     print("png_data column already exists.")
 
                 # Ensure pdf_data column exists
-                has_pdf = conn.execute(text("""
+                has_pdf = conn.execute(
+                    text("""
                     SELECT EXISTS (
                         SELECT 1 FROM information_schema.columns
                         WHERE table_name = 'monthly_reports' AND column_name = 'pdf_data'
                     )
-                """)).scalar()
+                """)
+                ).scalar()
                 if not has_pdf:
                     print("Adding pdf_data column...")
                     conn.execute(text("ALTER TABLE monthly_reports ADD COLUMN pdf_data BYTEA"))
@@ -77,27 +83,37 @@ def main():
                     print("pdf_data column already exists.")
 
                 # Ensure status column exists
-                has_status = conn.execute(text("""
+                has_status = conn.execute(
+                    text("""
                     SELECT EXISTS (
                         SELECT 1 FROM information_schema.columns
                         WHERE table_name = 'monthly_reports' AND column_name = 'status'
                     )
-                """)).scalar()
+                """)
+                ).scalar()
                 if not has_status:
                     print("Adding status column...")
-                    conn.execute(text("ALTER TABLE monthly_reports ADD COLUMN status VARCHAR(20) DEFAULT 'READY'"))
-                    conn.execute(text("UPDATE monthly_reports SET status = 'READY' WHERE status IS NULL"))
+                    conn.execute(
+                        text(
+                            "ALTER TABLE monthly_reports ADD COLUMN status VARCHAR(20) DEFAULT 'READY'"
+                        )
+                    )
+                    conn.execute(
+                        text("UPDATE monthly_reports SET status = 'READY' WHERE status IS NULL")
+                    )
                     print("status column added!")
                 else:
                     print("status column already exists.")
 
                 # Ensure error_message column exists
-                has_error = conn.execute(text("""
+                has_error = conn.execute(
+                    text("""
                     SELECT EXISTS (
                         SELECT 1 FROM information_schema.columns
                         WHERE table_name = 'monthly_reports' AND column_name = 'error_message'
                     )
-                """)).scalar()
+                """)
+                ).scalar()
                 if not has_error:
                     print("Adding error_message column...")
                     conn.execute(text("ALTER TABLE monthly_reports ADD COLUMN error_message TEXT"))
@@ -106,7 +122,8 @@ def main():
                     print("error_message column already exists.")
             else:
                 print("Creating monthly_reports table...")
-                conn.execute(text("""
+                conn.execute(
+                    text("""
                     CREATE TABLE IF NOT EXISTS monthly_reports (
                         id SERIAL PRIMARY KEY,
                         user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
@@ -119,13 +136,16 @@ def main():
                         created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                         generated_at TIMESTAMP
                     )
-                """))
+                """)
+                )
 
                 print("Creating index on user_id and month...")
-                conn.execute(text("""
+                conn.execute(
+                    text("""
                     CREATE UNIQUE INDEX IF NOT EXISTS ix_monthly_reports_user_month
                     ON monthly_reports (user_id, month)
-                """))
+                """)
+                )
 
                 print("Migration complete!")
         else:

--- a/backend/scripts/migrate_add_reset_token.py
+++ b/backend/scripts/migrate_add_reset_token.py
@@ -35,32 +35,40 @@ def main():
 
         if dialect == "postgresql":
             # Check if columns already exist
-            exists = conn.execute(text("""
+            exists = conn.execute(
+                text("""
                 SELECT EXISTS (
                     SELECT 1 FROM information_schema.columns
                     WHERE table_name = 'users' AND column_name = 'reset_token'
                 )
-            """)).scalar()
+            """)
+            ).scalar()
 
             if exists:
                 print("Columns already exist. Skipping.")
             else:
                 print("Adding reset_token column...")
-                conn.execute(text("""
+                conn.execute(
+                    text("""
                     ALTER TABLE users
                     ADD COLUMN reset_token VARCHAR(64) UNIQUE
-                """))
+                """)
+                )
 
                 print("Adding reset_token_expires column...")
-                conn.execute(text("""
+                conn.execute(
+                    text("""
                     ALTER TABLE users
                     ADD COLUMN reset_token_expires TIMESTAMP
-                """))
+                """)
+                )
 
                 print("Creating index on reset_token...")
-                conn.execute(text("""
+                conn.execute(
+                    text("""
                     CREATE INDEX ix_users_reset_token ON users (reset_token)
-                """))
+                """)
+                )
 
                 print("Migration complete!")
         else:

--- a/backend/scripts/migrate_db_structure.py
+++ b/backend/scripts/migrate_db_structure.py
@@ -325,6 +325,37 @@ def step7_encryption_columns(engine):
         # monthly_reports.report_data: TEXT (already TEXT)
 
 
+def step8_card_search_columns(engine):
+    """Add search columns for encrypted Card fields."""
+    print("\n[Step 8/8] Adding Card search columns...")
+
+    with engine.begin() as conn:
+        dialect = engine.dialect.name
+
+        if dialect != "postgresql":
+            print("  Skipping — only supported on PostgreSQL.")
+            return
+
+        for column in ['card_name_search', 'bank_search', 'holder_search']:
+            exists = conn.execute(text("""
+                SELECT EXISTS (
+                    SELECT 1 FROM information_schema.columns
+                    WHERE table_name = 'cards' AND column_name = :col
+                )
+            """), {"col": column}).scalar()
+
+            if exists:
+                print(f"  {column} already exists. Skipping.")
+            else:
+                conn.execute(text(
+                    f"ALTER TABLE cards ADD COLUMN {column} VARCHAR"
+                ))
+                conn.execute(text(
+                    f"CREATE INDEX ix_cards_{column} ON cards ({column})"
+                ))
+                print(f"  Added {column} VARCHAR with index.")
+
+
 def main():
     engine = get_engine()
 
@@ -339,6 +370,7 @@ def main():
     step5_onboarding_completed(engine)
     step6_whats_new_seen(engine)
     step7_encryption_columns(engine)
+    step8_card_search_columns(engine)
 
     print("\n" + "=" * 60)
     print("Migration complete!")

--- a/backend/scripts/migrate_db_structure.py
+++ b/backend/scripts/migrate_db_structure.py
@@ -247,6 +247,84 @@ def step6_whats_new_seen(engine):
             print("  Added whats_new_seen BOOLEAN DEFAULT FALSE.")
 
 
+def step7_encryption_columns(engine):
+    """Add columns needed for field-level encryption."""
+    print("\n[Step 7/7] Adding encryption-related columns...")
+
+    with engine.begin() as conn:
+        dialect = engine.dialect.name
+
+        if dialect != "postgresql":
+            print("  Skipping — only supported on PostgreSQL.")
+            return
+
+        # Add telegram_chat_hash to users
+        exists = conn.execute(text("""
+            SELECT EXISTS (
+                SELECT 1 FROM information_schema.columns
+                WHERE table_name = 'users' AND column_name = 'telegram_chat_hash'
+            )
+        """)).scalar()
+
+        if exists:
+            print("  telegram_chat_hash already exists. Skipping.")
+        else:
+            conn.execute(text(
+                "ALTER TABLE users ADD COLUMN telegram_chat_hash VARCHAR(64)"
+            ))
+            conn.execute(text(
+                "CREATE UNIQUE INDEX ix_users_telegram_chat_hash ON users (telegram_chat_hash) WHERE telegram_chat_hash IS NOT NULL"
+            ))
+            print("  Added telegram_chat_hash VARCHAR(64) with unique index.")
+
+        # Add description_search to expenses
+        exists = conn.execute(text("""
+            SELECT EXISTS (
+                SELECT 1 FROM information_schema.columns
+                WHERE table_name = 'expenses' AND column_name = 'description_search'
+            )
+        """)).scalar()
+
+        if exists:
+            print("  description_search already exists. Skipping.")
+        else:
+            conn.execute(text(
+                "ALTER TABLE expenses ADD COLUMN description_search VARCHAR"
+            ))
+            conn.execute(text(
+                "CREATE INDEX ix_expenses_description_search ON expenses (description_search)"
+            ))
+            print("  Added description_search VARCHAR with index.")
+
+        # Expand column sizes for encrypted data
+        print("  Expanding column sizes for encrypted data...")
+
+        # audit_logs.ip_address: VARCHAR(45) -> TEXT
+        conn.execute(text(
+            "ALTER TABLE audit_logs ALTER COLUMN ip_address TYPE TEXT"
+        ))
+        print("    audit_logs.ip_address -> TEXT")
+
+        # audit_logs.user_agent: VARCHAR(500) -> TEXT
+        conn.execute(text(
+            "ALTER TABLE audit_logs ALTER COLUMN user_agent TYPE TEXT"
+        ))
+        print("    audit_logs.user_agent -> TEXT")
+
+        # users.mfa_secret: VARCHAR(32) -> TEXT
+        conn.execute(text(
+            "ALTER TABLE users ALTER COLUMN mfa_secret TYPE TEXT"
+        ))
+        print("    users.mfa_secret -> TEXT")
+
+        # users.telegram_chat_id: TEXT (already TEXT, but let's be safe)
+        # users.full_name: TEXT (already TEXT)
+        # cards columns: TEXT (already TEXT)
+        # expenses columns: TEXT (already TEXT)
+        # investments.notes: TEXT (already TEXT)
+        # monthly_reports.report_data: TEXT (already TEXT)
+
+
 def main():
     engine = get_engine()
 
@@ -260,6 +338,7 @@ def main():
     step4_indexes(engine)
     step5_onboarding_completed(engine)
     step6_whats_new_seen(engine)
+    step7_encryption_columns(engine)
 
     print("\n" + "=" * 60)
     print("Migration complete!")

--- a/backend/scripts/migrate_db_structure.py
+++ b/backend/scripts/migrate_db_structure.py
@@ -53,11 +53,13 @@ def step1_unique_constraint(engine):
             if _constraint_exists(conn, "uq_group_member"):
                 print("  Constraint uq_group_member already exists. Skipping.")
             else:
-                conn.execute(text("""
+                conn.execute(
+                    text("""
                     ALTER TABLE group_members
                     ADD CONSTRAINT uq_group_member
                     UNIQUE (group_id, user_id)
-                """))
+                """)
+                )
                 print("  Added UNIQUE(group_id, user_id) constraint.")
         else:
             print("  Skipping — only supported on PostgreSQL.")
@@ -72,12 +74,14 @@ def step2_card_closing_card_id(engine):
 
         # Check if column already exists
         if dialect == "postgresql":
-            exists = conn.execute(text("""
+            exists = conn.execute(
+                text("""
                 SELECT EXISTS (
                     SELECT 1 FROM information_schema.columns
                     WHERE table_name = 'card_closings' AND column_name = 'card_id'
                 )
-            """)).scalar()
+            """)
+            ).scalar()
         else:
             exists = False
 
@@ -88,7 +92,8 @@ def step2_card_closing_card_id(engine):
             print("  Added card_id column.")
 
         # Backfill: match card_closings to cards by (user_id, card_name, bank)
-        result = conn.execute(text("""
+        result = conn.execute(
+            text("""
             UPDATE card_closings cc
             SET card_id = c.id
             FROM cards c
@@ -96,17 +101,20 @@ def step2_card_closing_card_id(engine):
             AND cc.user_id = c.user_id
             AND LOWER(TRIM(cc.card)) = LOWER(TRIM(c.card_name))
             AND LOWER(TRIM(COALESCE(cc.bank, ''))) = LOWER(TRIM(COALESCE(c.bank, '')))
-        """))
+        """)
+        )
         print(f"  Backfilled {result.rowcount} card_closings with card_id.")
 
         # Add FK constraint
         if dialect == "postgresql":
             try:
-                conn.execute(text("""
+                conn.execute(
+                    text("""
                     ALTER TABLE card_closings
                     ADD CONSTRAINT fk_card_closings_card_id
                     FOREIGN KEY (card_id) REFERENCES cards(id)
-                """))
+                """)
+                )
                 print("  Added FK constraint.")
             except Exception as e:
                 print(f"  FK constraint warning: {e}")
@@ -123,23 +131,27 @@ def step3_nullable_user_id(engine):
 
         for table in tables:
             # Backfill NULL user_id with first seed user
-            result = conn.execute(text(f"""
+            result = conn.execute(
+                text(f"""
                 UPDATE {table}
                 SET user_id = (
                     SELECT id FROM users ORDER BY id LIMIT 1
                 )
                 WHERE user_id IS NULL
-            """))
+            """)
+            )
             if result.rowcount > 0:
                 print(f"  {table}: backfilled {result.rowcount} rows with seed user_id.")
 
             # Set NOT NULL
             if dialect == "postgresql":
                 try:
-                    conn.execute(text(f"""
+                    conn.execute(
+                        text(f"""
                         ALTER TABLE {table}
                         ALTER COLUMN user_id SET NOT NULL
-                    """))
+                    """)
+                    )
                     print(f"  {table}.user_id → NOT NULL.")
                 except Exception as e:
                     print(f"  {table}: could not set NOT NULL — {e}")
@@ -203,21 +215,23 @@ def step5_onboarding_completed(engine):
         dialect = engine.dialect.name
 
         if dialect == "postgresql":
-            exists = conn.execute(text("""
+            exists = conn.execute(
+                text("""
                 SELECT EXISTS (
                     SELECT 1 FROM information_schema.columns
                     WHERE table_name = 'users' AND column_name = 'onboarding_completed'
                 )
-            """)).scalar()
+            """)
+            ).scalar()
         else:
             exists = False
 
         if exists:
             print("  onboarding_completed already exists. Skipping.")
         else:
-            conn.execute(text(
-                "ALTER TABLE users ADD COLUMN onboarding_completed BOOLEAN DEFAULT FALSE"
-            ))
+            conn.execute(
+                text("ALTER TABLE users ADD COLUMN onboarding_completed BOOLEAN DEFAULT FALSE")
+            )
             print("  Added onboarding_completed BOOLEAN DEFAULT FALSE.")
 
 
@@ -229,21 +243,21 @@ def step6_whats_new_seen(engine):
         dialect = engine.dialect.name
 
         if dialect == "postgresql":
-            exists = conn.execute(text("""
+            exists = conn.execute(
+                text("""
                 SELECT EXISTS (
                     SELECT 1 FROM information_schema.columns
                     WHERE table_name = 'users' AND column_name = 'whats_new_seen'
                 )
-            """)).scalar()
+            """)
+            ).scalar()
         else:
             exists = False
 
         if exists:
             print("  whats_new_seen already exists. Skipping.")
         else:
-            conn.execute(text(
-                "ALTER TABLE users ADD COLUMN whats_new_seen BOOLEAN DEFAULT FALSE"
-            ))
+            conn.execute(text("ALTER TABLE users ADD COLUMN whats_new_seen BOOLEAN DEFAULT FALSE"))
             print("  Added whats_new_seen BOOLEAN DEFAULT FALSE.")
 
 
@@ -259,62 +273,58 @@ def step7_encryption_columns(engine):
             return
 
         # Add telegram_chat_hash to users
-        exists = conn.execute(text("""
+        exists = conn.execute(
+            text("""
             SELECT EXISTS (
                 SELECT 1 FROM information_schema.columns
                 WHERE table_name = 'users' AND column_name = 'telegram_chat_hash'
             )
-        """)).scalar()
+        """)
+        ).scalar()
 
         if exists:
             print("  telegram_chat_hash already exists. Skipping.")
         else:
-            conn.execute(text(
-                "ALTER TABLE users ADD COLUMN telegram_chat_hash VARCHAR(64)"
-            ))
-            conn.execute(text(
-                "CREATE UNIQUE INDEX ix_users_telegram_chat_hash ON users (telegram_chat_hash) WHERE telegram_chat_hash IS NOT NULL"
-            ))
+            conn.execute(text("ALTER TABLE users ADD COLUMN telegram_chat_hash VARCHAR(64)"))
+            conn.execute(
+                text(
+                    "CREATE UNIQUE INDEX ix_users_telegram_chat_hash ON users (telegram_chat_hash) WHERE telegram_chat_hash IS NOT NULL"
+                )
+            )
             print("  Added telegram_chat_hash VARCHAR(64) with unique index.")
 
         # Add description_search to expenses
-        exists = conn.execute(text("""
+        exists = conn.execute(
+            text("""
             SELECT EXISTS (
                 SELECT 1 FROM information_schema.columns
                 WHERE table_name = 'expenses' AND column_name = 'description_search'
             )
-        """)).scalar()
+        """)
+        ).scalar()
 
         if exists:
             print("  description_search already exists. Skipping.")
         else:
-            conn.execute(text(
-                "ALTER TABLE expenses ADD COLUMN description_search VARCHAR"
-            ))
-            conn.execute(text(
-                "CREATE INDEX ix_expenses_description_search ON expenses (description_search)"
-            ))
+            conn.execute(text("ALTER TABLE expenses ADD COLUMN description_search VARCHAR"))
+            conn.execute(
+                text("CREATE INDEX ix_expenses_description_search ON expenses (description_search)")
+            )
             print("  Added description_search VARCHAR with index.")
 
         # Expand column sizes for encrypted data
         print("  Expanding column sizes for encrypted data...")
 
         # audit_logs.ip_address: VARCHAR(45) -> TEXT
-        conn.execute(text(
-            "ALTER TABLE audit_logs ALTER COLUMN ip_address TYPE TEXT"
-        ))
+        conn.execute(text("ALTER TABLE audit_logs ALTER COLUMN ip_address TYPE TEXT"))
         print("    audit_logs.ip_address -> TEXT")
 
         # audit_logs.user_agent: VARCHAR(500) -> TEXT
-        conn.execute(text(
-            "ALTER TABLE audit_logs ALTER COLUMN user_agent TYPE TEXT"
-        ))
+        conn.execute(text("ALTER TABLE audit_logs ALTER COLUMN user_agent TYPE TEXT"))
         print("    audit_logs.user_agent -> TEXT")
 
         # users.mfa_secret: VARCHAR(32) -> TEXT
-        conn.execute(text(
-            "ALTER TABLE users ALTER COLUMN mfa_secret TYPE TEXT"
-        ))
+        conn.execute(text("ALTER TABLE users ALTER COLUMN mfa_secret TYPE TEXT"))
         print("    users.mfa_secret -> TEXT")
 
         # users.telegram_chat_id: TEXT (already TEXT, but let's be safe)
@@ -336,24 +346,57 @@ def step8_card_search_columns(engine):
             print("  Skipping — only supported on PostgreSQL.")
             return
 
-        for column in ['card_name_search', 'bank_search', 'holder_search']:
-            exists = conn.execute(text("""
+        for column in ["card_name_search", "bank_search", "holder_search"]:
+            exists = conn.execute(
+                text("""
                 SELECT EXISTS (
                     SELECT 1 FROM information_schema.columns
                     WHERE table_name = 'cards' AND column_name = :col
                 )
-            """), {"col": column}).scalar()
+            """),
+                {"col": column},
+            ).scalar()
 
             if exists:
                 print(f"  {column} already exists. Skipping.")
             else:
-                conn.execute(text(
-                    f"ALTER TABLE cards ADD COLUMN {column} VARCHAR"
-                ))
-                conn.execute(text(
-                    f"CREATE INDEX ix_cards_{column} ON cards ({column})"
-                ))
+                conn.execute(text(f"ALTER TABLE cards ADD COLUMN {column} VARCHAR"))
+                conn.execute(text(f"CREATE INDEX ix_cards_{column} ON cards ({column})"))
                 print(f"  Added {column} VARCHAR with index.")
+
+
+def step9_scheduled_expense_search_columns(engine):
+    """Add search columns for encrypted ScheduledExpense fields."""
+    print("\n[Step 9/9] Adding ScheduledExpense search columns...")
+
+    with engine.begin() as conn:
+        dialect = engine.dialect.name
+
+        if dialect != "postgresql":
+            print("  Skipping — only supported on PostgreSQL.")
+            return
+
+        exists = conn.execute(
+            text("""
+            SELECT EXISTS (
+                SELECT 1 FROM information_schema.columns
+                WHERE table_name = 'scheduled_expenses' AND column_name = 'description_search'
+            )
+        """)
+        ).scalar()
+
+        if exists:
+            print("  description_search already exists. Skipping.")
+        else:
+            conn.execute(
+                text("ALTER TABLE scheduled_expenses ADD COLUMN description_search VARCHAR")
+            )
+            conn.execute(
+                text(
+                    "CREATE INDEX ix_scheduled_expenses_description_search ON scheduled_expenses (description_search)"
+                )
+            )
+            print("  Added description_search VARCHAR with index.")
 
 
 def main():
@@ -371,6 +414,7 @@ def main():
     step6_whats_new_seen(engine)
     step7_encryption_columns(engine)
     step8_card_search_columns(engine)
+    step9_scheduled_expense_search_columns(engine)
 
     print("\n" + "=" * 60)
     print("Migration complete!")

--- a/backend/scripts/migrate_encrypt_fields.py
+++ b/backend/scripts/migrate_encrypt_fields.py
@@ -55,6 +55,7 @@ def _migrate_users(db):
             # Generate telegram_chat_hash if missing
             if user.telegram_chat_id and not user.telegram_chat_hash:
                 from app.services.encryption import decrypt_value
+
                 # Get the plaintext value (already decrypted by ORM)
                 original_value = user.telegram_chat_id
                 user.telegram_chat_hash = compute_hmac(original_value)
@@ -98,6 +99,7 @@ def _migrate_cards(db):
             ):
                 # Already encrypted but missing or encrypted search token
                 from app.services.encryption import decrypt_value
+
                 card.card_name_search = tokenize_description(decrypt_value(card.card_name))
                 changed = True
 
@@ -106,10 +108,9 @@ def _migrate_cards(db):
                 card.bank = card.bank  # Touch to trigger update
                 card.bank_search = tokenize_description(card.bank)
                 changed = True
-            elif card.bank and (
-                not card.bank_search or is_encrypted(card.bank_search)
-            ):
+            elif card.bank and (not card.bank_search or is_encrypted(card.bank_search)):
                 from app.services.encryption import decrypt_value
+
                 card.bank_search = tokenize_description(decrypt_value(card.bank))
                 changed = True
 
@@ -118,10 +119,9 @@ def _migrate_cards(db):
                 card.holder = card.holder  # Touch to trigger update
                 card.holder_search = tokenize_description(card.holder)
                 changed = True
-            elif card.holder and (
-                not card.holder_search or is_encrypted(card.holder_search)
-            ):
+            elif card.holder and (not card.holder_search or is_encrypted(card.holder_search)):
                 from app.services.encryption import decrypt_value
+
                 card.holder_search = tokenize_description(decrypt_value(card.holder))
                 changed = True
 
@@ -268,6 +268,45 @@ def _migrate_monthly_reports(db):
     logger.info(f"  Migrated {migrated} monthly reports")
 
 
+def _migrate_scheduled_expenses(db):
+    """Encrypt scheduled expense fields and generate search tokens."""
+    from app.models import ScheduledExpense
+
+    logger.info("Migrating scheduled_expenses table...")
+    offset = 0
+    migrated = 0
+
+    while True:
+        expenses = db.query(ScheduledExpense).offset(offset).limit(BATCH_SIZE).all()
+        if not expenses:
+            break
+
+        for expense in expenses:
+            changed = False
+
+            if expense.description and not is_encrypted(expense.description):
+                expense.description = expense.description
+                expense.description_search = tokenize_description(expense.description)
+                changed = True
+            elif expense.description and (
+                not expense.description_search or is_encrypted(expense.description_search)
+            ):
+                from app.services.encryption import decrypt_value
+
+                expense.description_search = tokenize_description(
+                    decrypt_value(expense.description)
+                )
+                changed = True
+
+            if changed:
+                migrated += 1
+
+        db.commit()
+        offset += BATCH_SIZE
+
+    logger.info(f"  Migrated {migrated} scheduled expenses")
+
+
 def migrate_plaintext_data():
     """Main migration function. Idempotent - safe to run multiple times."""
     db = SessionLocal()
@@ -280,6 +319,7 @@ def migrate_plaintext_data():
         _migrate_investments(db)
         _migrate_audit_logs(db)
         _migrate_monthly_reports(db)
+        _migrate_scheduled_expenses(db)
 
         logger.info("Encryption migration completed successfully!")
     except Exception as e:

--- a/backend/scripts/migrate_encrypt_fields.py
+++ b/backend/scripts/migrate_encrypt_fields.py
@@ -45,26 +45,24 @@ def _migrate_users(db):
             changed = False
 
             # Encrypt full_name if plaintext
+            # Note: EncryptedType handles encryption automatically when writing
+            # We just need to check if the value in DB is already encrypted
             if user.full_name and not is_encrypted(user.full_name):
-                user.full_name = encrypt_value(user.full_name)
+                # Value is plaintext, mark for re-save (EncryptedType will encrypt)
+                user.full_name = user.full_name  # Touch to trigger update
                 changed = True
 
-            # Encrypt telegram_chat_id if plaintext and generate hash
-            if user.telegram_chat_id and not is_encrypted(user.telegram_chat_id):
-                original_value = user.telegram_chat_id
-                user.telegram_chat_id = encrypt_value(original_value)
-                user.telegram_chat_hash = compute_hmac(original_value)
-                changed = True
-            elif user.telegram_chat_id and not user.telegram_chat_hash:
-                # Already encrypted but missing hash - decrypt and recompute
+            # Generate telegram_chat_hash if missing
+            if user.telegram_chat_id and not user.telegram_chat_hash:
                 from app.services.encryption import decrypt_value
-                original_value = decrypt_value(user.telegram_chat_id)
+                # Get the plaintext value (already decrypted by ORM)
+                original_value = user.telegram_chat_id
                 user.telegram_chat_hash = compute_hmac(original_value)
                 changed = True
 
             # Encrypt mfa_secret if plaintext
             if user.mfa_secret and not is_encrypted(user.mfa_secret):
-                user.mfa_secret = encrypt_value(user.mfa_secret)
+                user.mfa_secret = user.mfa_secret  # Touch to trigger update
                 changed = True
 
             if changed:
@@ -90,16 +88,18 @@ def _migrate_cards(db):
         for card in cards:
             changed = False
 
+            # Note: EncryptedType handles encryption automatically
+            # We just need to touch the field to trigger update
             if card.card_name and not is_encrypted(card.card_name):
-                card.card_name = encrypt_value(card.card_name)
+                card.card_name = card.card_name  # Touch to trigger update
                 changed = True
 
             if card.bank and not is_encrypted(card.bank):
-                card.bank = encrypt_value(card.bank)
+                card.bank = card.bank  # Touch to trigger update
                 changed = True
 
             if card.holder and not is_encrypted(card.holder):
-                card.holder = encrypt_value(card.holder)
+                card.holder = card.holder  # Touch to trigger update
                 changed = True
 
             if changed:
@@ -125,20 +125,27 @@ def _migrate_expenses(db):
         for expense in expenses:
             changed = False
 
+            # Note: EncryptedType handles encryption automatically
+            # We just need to touch the field to trigger update
             if expense.description and not is_encrypted(expense.description):
+                # Value is plaintext, get it before ORM encrypts
                 original_value = expense.description
-                expense.description = encrypt_value(original_value)
+                # Touch to trigger update (EncryptedType will encrypt)
+                expense.description = original_value
+                # Generate search tokens from plaintext
                 expense.description_search = tokenize_description(original_value)
                 changed = True
-            elif expense.description and not expense.description_search:
+            elif expense.description and (
+                not expense.description_search or is_encrypted(expense.description_search)
+            ):
                 # Already encrypted but missing search tokens
-                from app.services.encryption import decrypt_value
-                original_value = decrypt_value(expense.description)
-                expense.description_search = tokenize_description(original_value)
+                # or search tokens are encrypted (need to regenerate)
+                # ORM already decrypted it, so we can use the value directly
+                expense.description_search = tokenize_description(expense.description)
                 changed = True
 
             if expense.notes and not is_encrypted(expense.notes):
-                expense.notes = encrypt_value(expense.notes)
+                expense.notes = expense.notes  # Touch to trigger update
                 changed = True
 
             if changed:
@@ -164,8 +171,9 @@ def _migrate_investments(db):
         for inv in investments:
             changed = False
 
+            # Note: EncryptedType handles encryption automatically
             if inv.notes and not is_encrypted(inv.notes):
-                inv.notes = encrypt_value(inv.notes)
+                inv.notes = inv.notes  # Touch to trigger update
                 changed = True
 
             if changed:
@@ -191,12 +199,13 @@ def _migrate_audit_logs(db):
         for log in logs:
             changed = False
 
+            # Note: EncryptedType handles encryption automatically
             if log.ip_address and not is_encrypted(log.ip_address):
-                log.ip_address = encrypt_value(log.ip_address)
+                log.ip_address = log.ip_address  # Touch to trigger update
                 changed = True
 
             if log.user_agent and not is_encrypted(log.user_agent):
-                log.user_agent = encrypt_value(log.user_agent)
+                log.user_agent = log.user_agent  # Touch to trigger update
                 changed = True
 
             if changed:
@@ -222,8 +231,9 @@ def _migrate_monthly_reports(db):
         for report in reports:
             changed = False
 
+            # Note: EncryptedType handles encryption automatically
             if report.report_data and not is_encrypted(report.report_data):
-                report.report_data = encrypt_value(report.report_data)
+                report.report_data = report.report_data  # Touch to trigger update
                 changed = True
 
             if changed:

--- a/backend/scripts/migrate_encrypt_fields.py
+++ b/backend/scripts/migrate_encrypt_fields.py
@@ -75,7 +75,7 @@ def _migrate_users(db):
 
 
 def _migrate_cards(db):
-    """Encrypt card fields."""
+    """Encrypt card fields and generate search tokens."""
     logger.info("Migrating cards table...")
     offset = 0
     migrated = 0
@@ -88,18 +88,41 @@ def _migrate_cards(db):
         for card in cards:
             changed = False
 
-            # Note: EncryptedType handles encryption automatically
-            # We just need to touch the field to trigger update
+            # Encrypt card_name and generate search token
             if card.card_name and not is_encrypted(card.card_name):
                 card.card_name = card.card_name  # Touch to trigger update
+                card.card_name_search = tokenize_description(card.card_name)
+                changed = True
+            elif card.card_name and (
+                not card.card_name_search or is_encrypted(card.card_name_search)
+            ):
+                # Already encrypted but missing or encrypted search token
+                from app.services.encryption import decrypt_value
+                card.card_name_search = tokenize_description(decrypt_value(card.card_name))
                 changed = True
 
+            # Encrypt bank and generate search token
             if card.bank and not is_encrypted(card.bank):
                 card.bank = card.bank  # Touch to trigger update
+                card.bank_search = tokenize_description(card.bank)
+                changed = True
+            elif card.bank and (
+                not card.bank_search or is_encrypted(card.bank_search)
+            ):
+                from app.services.encryption import decrypt_value
+                card.bank_search = tokenize_description(decrypt_value(card.bank))
                 changed = True
 
+            # Encrypt holder and generate search token
             if card.holder and not is_encrypted(card.holder):
                 card.holder = card.holder  # Touch to trigger update
+                card.holder_search = tokenize_description(card.holder)
+                changed = True
+            elif card.holder and (
+                not card.holder_search or is_encrypted(card.holder_search)
+            ):
+                from app.services.encryption import decrypt_value
+                card.holder_search = tokenize_description(decrypt_value(card.holder))
                 changed = True
 
             if changed:

--- a/backend/scripts/migrate_encrypt_fields.py
+++ b/backend/scripts/migrate_encrypt_fields.py
@@ -1,0 +1,261 @@
+"""Migration script to encrypt existing plaintext data.
+
+This script:
+1. Encrypts plaintext fields in users, cards, expenses, investments, audit_logs, monthly_reports
+2. Generates HMAC hashes for telegram_chat_id lookups
+3. Generates search tokens for expense descriptions
+
+Idempotent: safe to run multiple times (skips already-encrypted rows).
+"""
+
+import logging
+import sys
+import os
+
+# Add parent directory to path for imports
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from app.database import SessionLocal
+from app.models import AuditLog, Card, Expense, Investment, MonthlyReport, User
+from app.services.encryption import (
+    compute_hmac,
+    encrypt_value,
+    is_encrypted,
+    tokenize_description,
+)
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+BATCH_SIZE = 100
+
+
+def _migrate_users(db):
+    """Encrypt user fields and generate telegram_chat_hash."""
+    logger.info("Migrating users table...")
+    offset = 0
+    migrated = 0
+
+    while True:
+        users = db.query(User).offset(offset).limit(BATCH_SIZE).all()
+        if not users:
+            break
+
+        for user in users:
+            changed = False
+
+            # Encrypt full_name if plaintext
+            if user.full_name and not is_encrypted(user.full_name):
+                user.full_name = encrypt_value(user.full_name)
+                changed = True
+
+            # Encrypt telegram_chat_id if plaintext and generate hash
+            if user.telegram_chat_id and not is_encrypted(user.telegram_chat_id):
+                original_value = user.telegram_chat_id
+                user.telegram_chat_id = encrypt_value(original_value)
+                user.telegram_chat_hash = compute_hmac(original_value)
+                changed = True
+            elif user.telegram_chat_id and not user.telegram_chat_hash:
+                # Already encrypted but missing hash - decrypt and recompute
+                from app.services.encryption import decrypt_value
+                original_value = decrypt_value(user.telegram_chat_id)
+                user.telegram_chat_hash = compute_hmac(original_value)
+                changed = True
+
+            # Encrypt mfa_secret if plaintext
+            if user.mfa_secret and not is_encrypted(user.mfa_secret):
+                user.mfa_secret = encrypt_value(user.mfa_secret)
+                changed = True
+
+            if changed:
+                migrated += 1
+
+        db.commit()
+        offset += BATCH_SIZE
+
+    logger.info(f"  Migrated {migrated} users")
+
+
+def _migrate_cards(db):
+    """Encrypt card fields."""
+    logger.info("Migrating cards table...")
+    offset = 0
+    migrated = 0
+
+    while True:
+        cards = db.query(Card).offset(offset).limit(BATCH_SIZE).all()
+        if not cards:
+            break
+
+        for card in cards:
+            changed = False
+
+            if card.card_name and not is_encrypted(card.card_name):
+                card.card_name = encrypt_value(card.card_name)
+                changed = True
+
+            if card.bank and not is_encrypted(card.bank):
+                card.bank = encrypt_value(card.bank)
+                changed = True
+
+            if card.holder and not is_encrypted(card.holder):
+                card.holder = encrypt_value(card.holder)
+                changed = True
+
+            if changed:
+                migrated += 1
+
+        db.commit()
+        offset += BATCH_SIZE
+
+    logger.info(f"  Migrated {migrated} cards")
+
+
+def _migrate_expenses(db):
+    """Encrypt expense fields and generate description_search."""
+    logger.info("Migrating expenses table...")
+    offset = 0
+    migrated = 0
+
+    while True:
+        expenses = db.query(Expense).offset(offset).limit(BATCH_SIZE).all()
+        if not expenses:
+            break
+
+        for expense in expenses:
+            changed = False
+
+            if expense.description and not is_encrypted(expense.description):
+                original_value = expense.description
+                expense.description = encrypt_value(original_value)
+                expense.description_search = tokenize_description(original_value)
+                changed = True
+            elif expense.description and not expense.description_search:
+                # Already encrypted but missing search tokens
+                from app.services.encryption import decrypt_value
+                original_value = decrypt_value(expense.description)
+                expense.description_search = tokenize_description(original_value)
+                changed = True
+
+            if expense.notes and not is_encrypted(expense.notes):
+                expense.notes = encrypt_value(expense.notes)
+                changed = True
+
+            if changed:
+                migrated += 1
+
+        db.commit()
+        offset += BATCH_SIZE
+
+    logger.info(f"  Migrated {migrated} expenses")
+
+
+def _migrate_investments(db):
+    """Encrypt investment notes."""
+    logger.info("Migrating investments table...")
+    offset = 0
+    migrated = 0
+
+    while True:
+        investments = db.query(Investment).offset(offset).limit(BATCH_SIZE).all()
+        if not investments:
+            break
+
+        for inv in investments:
+            changed = False
+
+            if inv.notes and not is_encrypted(inv.notes):
+                inv.notes = encrypt_value(inv.notes)
+                changed = True
+
+            if changed:
+                migrated += 1
+
+        db.commit()
+        offset += BATCH_SIZE
+
+    logger.info(f"  Migrated {migrated} investments")
+
+
+def _migrate_audit_logs(db):
+    """Encrypt audit log fields."""
+    logger.info("Migrating audit_logs table...")
+    offset = 0
+    migrated = 0
+
+    while True:
+        logs = db.query(AuditLog).offset(offset).limit(BATCH_SIZE).all()
+        if not logs:
+            break
+
+        for log in logs:
+            changed = False
+
+            if log.ip_address and not is_encrypted(log.ip_address):
+                log.ip_address = encrypt_value(log.ip_address)
+                changed = True
+
+            if log.user_agent and not is_encrypted(log.user_agent):
+                log.user_agent = encrypt_value(log.user_agent)
+                changed = True
+
+            if changed:
+                migrated += 1
+
+        db.commit()
+        offset += BATCH_SIZE
+
+    logger.info(f"  Migrated {migrated} audit logs")
+
+
+def _migrate_monthly_reports(db):
+    """Encrypt monthly report data."""
+    logger.info("Migrating monthly_reports table...")
+    offset = 0
+    migrated = 0
+
+    while True:
+        reports = db.query(MonthlyReport).offset(offset).limit(BATCH_SIZE).all()
+        if not reports:
+            break
+
+        for report in reports:
+            changed = False
+
+            if report.report_data and not is_encrypted(report.report_data):
+                report.report_data = encrypt_value(report.report_data)
+                changed = True
+
+            if changed:
+                migrated += 1
+
+        db.commit()
+        offset += BATCH_SIZE
+
+    logger.info(f"  Migrated {migrated} monthly reports")
+
+
+def migrate_plaintext_data():
+    """Main migration function. Idempotent - safe to run multiple times."""
+    db = SessionLocal()
+    try:
+        logger.info("Starting encryption migration...")
+
+        _migrate_users(db)
+        _migrate_cards(db)
+        _migrate_expenses(db)
+        _migrate_investments(db)
+        _migrate_audit_logs(db)
+        _migrate_monthly_reports(db)
+
+        logger.info("Encryption migration completed successfully!")
+    except Exception as e:
+        logger.error(f"Migration failed: {e}")
+        db.rollback()
+        raise
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    migrate_plaintext_data()

--- a/backend/scripts/migrate_encrypt_settings.py
+++ b/backend/scripts/migrate_encrypt_settings.py
@@ -43,11 +43,7 @@ def migrate():
 
         for key_suffix in SENSITIVE_KEYS:
             # Find all settings with this key suffix
-            rows = (
-                db.query(Setting)
-                .filter(Setting.key.like(f"%:{key_suffix}"))
-                .all()
-            )
+            rows = db.query(Setting).filter(Setting.key.like(f"%:{key_suffix}")).all()
 
             for row in rows:
                 if not row.value or _is_already_encrypted(row.value):

--- a/backend/scripts/migrate_security_columns.py
+++ b/backend/scripts/migrate_security_columns.py
@@ -53,12 +53,7 @@ def table_exists(conn, table: str) -> bool:
 
 def index_exists(conn, index_name: str) -> bool:
     result = conn.execute(
-        text(
-            "SELECT EXISTS ("
-            "  SELECT 1 FROM pg_indexes"
-            "  WHERE indexname = :name"
-            ")"
-        ),
+        text("SELECT EXISTS (  SELECT 1 FROM pg_indexes  WHERE indexname = :name)"),
         {"name": index_name},
     )
     return result.scalar()
@@ -128,7 +123,9 @@ def main():
         ).scalar()
         if unverified > 0:
             print(f"  Auto-verifying {unverified} existing users...")
-            conn.execute(text("UPDATE users SET email_verified = true WHERE email_verified = false"))
+            conn.execute(
+                text("UPDATE users SET email_verified = true WHERE email_verified = false")
+            )
 
         # Idempotency guard: only flag users if no one is flagged yet (first run)
         already_flagged = conn.execute(
@@ -142,7 +139,9 @@ def main():
                 )
             ).scalar()
             if needs_password_change > 0:
-                print(f"  Flagging {needs_password_change} users for forced password change...")  # lgtm[py/clear-text-logging-sensitive-information]
+                print(
+                    f"  Flagging {needs_password_change} users for forced password change..."
+                )  # lgtm[py/clear-text-logging-sensitive-information]
                 conn.execute(
                     text(
                         "UPDATE users SET force_password_change = true"

--- a/backend/scripts/verify_encryption.py
+++ b/backend/scripts/verify_encryption.py
@@ -1,0 +1,85 @@
+"""
+Verify all encrypted fields can be decrypted.
+Usage: python scripts/verify_encryption.py
+
+Output: Status: PASS or FAIL + verbose details
+"""
+
+import logging
+import sys
+
+sys.path.insert(0, ".")
+
+from app.database import SessionLocal
+from app.models import AuditLog, Card, Expense, Investment, MonthlyReport, User
+from app.services.encryption import decrypt_value, is_encrypted
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+ENCRYPTED_FIELDS = {
+    User: ["full_name", "telegram_chat_id", "mfa_secret"],
+    Card: ["card_name", "bank", "holder"],
+    Expense: ["description", "notes"],
+    Investment: ["notes"],
+    AuditLog: ["ip_address", "user_agent"],
+    MonthlyReport: ["report_data"],
+}
+
+SEARCH_FIELDS = {
+    Card: ["card_name_search", "bank_search", "holder_search"],
+    Expense: ["description_search"],
+}
+
+
+def main():
+    db = SessionLocal()
+    stats = {"total": 0, "verified": 0, "failed": 0, "search_ok": 0, "search_missing": 0}
+    failed_rows = []
+
+    # Verify encrypted fields
+    for model, fields in ENCRYPTED_FIELDS.items():
+        rows = db.query(model).all()
+        for row in rows:
+            for field in fields:
+                value = getattr(row, field)
+                stats["total"] += 1
+                if value and is_encrypted(value):
+                    decrypted = decrypt_value(value)
+                    if decrypted == "[encrypted]":
+                        stats["failed"] += 1
+                        failed_rows.append(f"{model.__tablename__}:{row.id}.{field}")
+                    else:
+                        stats["verified"] += 1
+
+    # Verify search columns
+    for model, fields in SEARCH_FIELDS.items():
+        rows = db.query(model).all()
+        for row in rows:
+            for field in fields:
+                value = getattr(row, field)
+                if value:
+                    stats["search_ok"] += 1
+                else:
+                    stats["search_missing"] += 1
+
+    db.close()
+
+    status = "PASS" if stats["failed"] == 0 else "FAIL"
+    print(f"Status: {status}")
+    print(f"Total: {stats['total']}")
+    print(f"Verified: {stats['verified']}")
+    print(f"Failed: {stats['failed']}")
+    print(f"Search OK: {stats['search_ok']}")
+    print(f"Search missing: {stats['search_missing']}")
+
+    if failed_rows:
+        print("\nFailed rows:")
+        for row in failed_rows:
+            print(f"  {row}")
+
+    return 0 if status == "PASS" else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/scripts/verify_encryption.py
+++ b/backend/scripts/verify_encryption.py
@@ -11,7 +11,7 @@ import sys
 sys.path.insert(0, ".")
 
 from app.database import SessionLocal
-from app.models import AuditLog, Card, Expense, Investment, MonthlyReport, User
+from app.models import AuditLog, Card, Expense, Investment, MonthlyReport, ScheduledExpense, User
 from app.services.encryption import decrypt_value, is_encrypted
 
 logging.basicConfig(level=logging.INFO)
@@ -21,6 +21,7 @@ ENCRYPTED_FIELDS = {
     User: ["full_name", "telegram_chat_id", "mfa_secret"],
     Card: ["card_name", "bank", "holder"],
     Expense: ["description", "notes"],
+    ScheduledExpense: ["description"],
     Investment: ["notes"],
     AuditLog: ["ip_address", "user_agent"],
     MonthlyReport: ["report_data"],
@@ -29,6 +30,7 @@ ENCRYPTED_FIELDS = {
 SEARCH_FIELDS = {
     Card: ["card_name_search", "bank_search", "holder_search"],
     Expense: ["description_search"],
+    ScheduledExpense: ["description_search"],
 }
 
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,51 @@
+"""Test fixtures for integration tests."""
+
+import os
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+# Use separate test database
+TEST_DATABASE_URL = os.getenv(
+    "TEST_DATABASE_URL",
+    "postgresql://expenses_user:expenses_secure_pass_2026@localhost:5433/expenses_test",
+)
+
+
+@pytest.fixture(scope="session")
+def engine():
+    """Create test database engine."""
+    return create_engine(TEST_DATABASE_URL)
+
+
+@pytest.fixture(scope="function")
+def db(engine):
+    """Create test database session with rollback."""
+    connection = engine.connect()
+    transaction = connection.begin()
+    Session = sessionmaker(bind=connection)
+    session = Session()
+
+    yield session
+
+    session.close()
+    transaction.rollback()
+    connection.close()
+
+
+@pytest.fixture
+def test_user(db):
+    """Create a test user."""
+    from app.models import User
+    from app.services.auth import get_password_hash
+
+    user = User(
+        email="test@example.com",
+        full_name="Test, User",
+        hashed_password=get_password_hash("testpassword"),
+        email_verified=True,
+    )
+    db.add(user)
+    db.flush()
+    return user

--- a/backend/tests/test_encryption.py
+++ b/backend/tests/test_encryption.py
@@ -45,10 +45,10 @@ class TestEncryption(unittest.TestCase):
         self.assertIsNone(decrypt_value(None))
 
     def test_decrypt_plaintext_fallback(self):
-        """Decryption of plaintext returns plaintext (migration support)."""
+        """Decryption of plaintext returns '[encrypted]' placeholder."""
         plaintext = "not-encrypted-data"
         result = decrypt_value(plaintext)
-        self.assertEqual(result, plaintext)
+        self.assertEqual(result, "[encrypted]")
 
     def test_encrypt_deterministic(self):
         """Same input produces same ciphertext (Fernet with same key)."""
@@ -203,6 +203,72 @@ class TestMigrationLogic(unittest.TestCase):
         encrypted = encrypt_value("secret-data")
         self.assertTrue(is_encrypted(encrypted))
         self.assertFalse(is_encrypted("plain-data"))
+
+
+class TestCardSearchColumns(unittest.TestCase):
+    """Test Card search column tokenization."""
+
+    def test_tokenize_card_name(self):
+        """tokenize_description works for card names."""
+        assert tokenize_description("Visa Signature") == "visa signature"
+        assert tokenize_description("Mastercard Gold") == "mastercard gold"
+        assert tokenize_description("American Express") == "american express"
+
+    def test_tokenize_bank(self):
+        """tokenize_description works for bank names."""
+        assert tokenize_description("Banco Nación") == "banco nacion"
+        assert tokenize_description("BBVA Argentina") == "bbva argentina"
+        assert tokenize_description("Banco Santander") == "banco santander"
+
+    def test_tokenize_holder(self):
+        """tokenize_description works for holder names."""
+        assert tokenize_description("Mendoza, Marcelo") == "mendoza marcelo"
+        assert tokenize_description("Pérez, José") == "perez jose"
+        assert tokenize_description("García López") == "garcia lopez"
+
+    def test_card_search_roundtrip(self):
+        """Encrypt card, generate search token, verify search works."""
+        card_name = "Visa Signature"
+        encrypted = encrypt_value(card_name)
+        search = tokenize_description(card_name)
+
+        # Verify encryption
+        self.assertTrue(is_encrypted(encrypted))
+        self.assertEqual(decrypt_value(encrypted), card_name)
+
+        # Verify search
+        self.assertEqual(search, "visa signature")
+        self.assertIn("visa", search)
+        self.assertIn("signature", search)
+
+    def test_bank_search_roundtrip(self):
+        """Encrypt bank, generate search token, verify search works."""
+        bank = "Banco Nación"
+        encrypted = encrypt_value(bank)
+        search = tokenize_description(bank)
+
+        # Verify encryption
+        self.assertTrue(is_encrypted(encrypted))
+        self.assertEqual(decrypt_value(encrypted), bank)
+
+        # Verify search
+        self.assertEqual(search, "banco nacion")
+        self.assertIn("banco", search)
+        self.assertIn("nacion", search)
+
+
+class TestDecryptFallback(unittest.TestCase):
+    """Test decrypt_value fallback behavior."""
+
+    def test_decrypt_returns_encrypted_placeholder_on_failure(self):
+        """Decrypt returns '[encrypted]' for invalid data."""
+        result = decrypt_value("not-encrypted-data")
+        self.assertEqual(result, "[encrypted]")
+
+    def test_decrypt_returns_empty_for_none(self):
+        """Decrypt returns None for None input."""
+        self.assertIsNone(decrypt_value(None))
+        self.assertEqual(decrypt_value(""), "")
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_encryption.py
+++ b/backend/tests/test_encryption.py
@@ -76,6 +76,14 @@ class TestEncryption(unittest.TestCase):
         """is_encrypted returns False for None."""
         self.assertFalse(is_encrypted(None))
 
+    def test_is_encrypted_fernet_prefix(self):
+        """is_encrypted detects Fernet token prefix."""
+        # Fernet tokens start with 'gAAAAAB'
+        self.assertTrue(is_encrypted("gAAAAABqZ3jJ-1GzGpLcQ3a"))
+        self.assertTrue(is_encrypted("gaaaaabqZ3jJ-1GzGpLcQ3a"))  # Case-insensitive
+        self.assertFalse(is_encrypted("not-encrypted"))
+        self.assertFalse(is_encrypted("gAAAA"))  # Too short
+
 
 class TestHMAC(unittest.TestCase):
     """Test HMAC computation."""

--- a/backend/tests/test_encryption.py
+++ b/backend/tests/test_encryption.py
@@ -1,0 +1,201 @@
+"""Unit tests for the encryption module."""
+
+import os
+import unittest
+from unittest.mock import patch
+
+# Set SECRET_KEY before importing encryption module
+os.environ["SECRET_KEY"] = "test-secret-key-that-is-at-least-32-chars-long-for-testing"
+
+from app.services.encryption import (
+    compute_hmac,
+    decrypt_value,
+    encrypt_value,
+    is_encrypted,
+    tokenize_description,
+)
+
+
+class TestEncryption(unittest.TestCase):
+    """Test Fernet encryption/decryption."""
+
+    def test_encrypt_decrypt_roundtrip(self):
+        """Encrypt then decrypt returns original value."""
+        original = "Hello, World! 123"
+        encrypted = encrypt_value(original)
+        decrypted = decrypt_value(encrypted)
+        self.assertEqual(decrypted, original)
+
+    def test_encrypt_returns_different_value(self):
+        """Encrypted value is different from original."""
+        original = "Sensitive data"
+        encrypted = encrypt_value(original)
+        self.assertNotEqual(encrypted, original)
+
+    def test_encrypt_empty_string(self):
+        """Encrypting empty string returns empty string."""
+        self.assertEqual(encrypt_value(""), "")
+
+    def test_decrypt_empty_string(self):
+        """Decrypting empty string returns empty string."""
+        self.assertEqual(decrypt_value(""), "")
+
+    def test_decrypt_none(self):
+        """Decrypting None returns None."""
+        self.assertIsNone(decrypt_value(None))
+
+    def test_decrypt_plaintext_fallback(self):
+        """Decryption of plaintext returns plaintext (migration support)."""
+        plaintext = "not-encrypted-data"
+        result = decrypt_value(plaintext)
+        self.assertEqual(result, plaintext)
+
+    def test_encrypt_deterministic(self):
+        """Same input produces same ciphertext (Fernet with same key)."""
+        original = "test-value"
+        encrypted1 = encrypt_value(original)
+        encrypted2 = encrypt_value(original)
+        # Fernet uses random IV, so ciphertext will be different
+        # but both should decrypt to same value
+        self.assertEqual(decrypt_value(encrypted1), decrypt_value(encrypted2))
+
+    def test_is_encrypted_true(self):
+        """is_encrypted returns True for encrypted values."""
+        encrypted = encrypt_value("test")
+        self.assertTrue(is_encrypted(encrypted))
+
+    def test_is_encrypted_false(self):
+        """is_encrypted returns False for plaintext."""
+        self.assertFalse(is_encrypted("plaintext"))
+
+    def test_is_encrypted_empty(self):
+        """is_encrypted returns False for empty string."""
+        self.assertFalse(is_encrypted(""))
+
+    def test_is_encrypted_none(self):
+        """is_encrypted returns False for None."""
+        self.assertFalse(is_encrypted(None))
+
+
+class TestHMAC(unittest.TestCase):
+    """Test HMAC computation."""
+
+    def test_hmac_deterministic(self):
+        """Same input produces same HMAC."""
+        hmac1 = compute_hmac("test-value")
+        hmac2 = compute_hmac("test-value")
+        self.assertEqual(hmac1, hmac2)
+
+    def test_hmac_different_inputs(self):
+        """Different inputs produce different HMACs."""
+        hmac1 = compute_hmac("value1")
+        hmac2 = compute_hmac("value2")
+        self.assertNotEqual(hmac1, hmac2)
+
+    def test_hmac_length(self):
+        """HMAC is 64 hex characters (SHA-256)."""
+        hmac_value = compute_hmac("test")
+        self.assertEqual(len(hmac_value), 64)
+
+    def test_hmac_empty_string(self):
+        """Computing HMAC of empty string returns empty string."""
+        self.assertEqual(compute_hmac(""), "")
+
+    def test_hmac_none(self):
+        """Computing HMAC of None returns None."""
+        self.assertIsNone(compute_hmac(None))
+
+
+class TestTokenization(unittest.TestCase):
+    """Test description tokenization."""
+
+    def test_basic_tokenization(self):
+        """Basic lowercase and cleanup."""
+        result = tokenize_description("Farmacity $1500 medicamentos")
+        self.assertEqual(result, "farmacity 1500 medicamentos")
+
+    def test_accent_removal(self):
+        """Accents are removed."""
+        result = tokenize_description("Farmacía medicamentos")
+        self.assertEqual(result, "farmacia medicamentos")
+
+    def test_special_characters(self):
+        """Special characters replaced with spaces."""
+        result = tokenize_description("Netflix USD 5.99")
+        self.assertEqual(result, "netflix usd 5 99")
+
+    def test_multiple_spaces_collapsed(self):
+        """Multiple spaces collapsed to single space."""
+        result = tokenize_description("  hello   world  ")
+        self.assertEqual(result, "hello world")
+
+    def test_empty_string(self):
+        """Empty string returns empty string."""
+        self.assertEqual(tokenize_description(""), "")
+
+    def test_none(self):
+        """None returns None."""
+        self.assertIsNone(tokenize_description(None))
+
+    def test_spanish_text(self):
+        """Spanish text with accents and special chars."""
+        result = tokenize_description("Almuerzo con José María - $8.500")
+        self.assertEqual(result, "almuerzo con jose maria 8 500")
+
+    def test_mixed_case(self):
+        """Mixed case normalized to lowercase."""
+        result = tokenize_description("UBER Eats Delivery")
+        self.assertEqual(result, "uber eats delivery")
+
+
+class TestEncryptionTypeDecorator(unittest.TestCase):
+    """Test SQLAlchemy EncryptedType decorator."""
+
+    def test_encrypted_type_import(self):
+        """EncryptedType can be imported."""
+        from app.types.encrypted import EncryptedType
+        self.assertIsNotNone(EncryptedType)
+
+    def test_encrypted_type_bind_param(self):
+        """EncryptedType encrypts on bind."""
+        from app.types.encrypted import EncryptedType
+        enc_type = EncryptedType()
+        encrypted = enc_type.process_bind_param("test-value", None)
+        self.assertNotEqual(encrypted, "test-value")
+        self.assertTrue(is_encrypted(encrypted))
+
+    def test_encrypted_type_result_value(self):
+        """EncryptedType decrypts on result."""
+        from app.types.encrypted import EncryptedType
+        enc_type = EncryptedType()
+        encrypted = encrypt_value("test-value")
+        decrypted = enc_type.process_result_value(encrypted, None)
+        self.assertEqual(decrypted, "test-value")
+
+    def test_encrypted_type_none_bind(self):
+        """EncryptedType handles None on bind."""
+        from app.types.encrypted import EncryptedType
+        enc_type = EncryptedType()
+        result = enc_type.process_bind_param(None, None)
+        self.assertIsNone(result)
+
+    def test_encrypted_type_none_result(self):
+        """EncryptedType handles None on result."""
+        from app.types.encrypted import EncryptedType
+        enc_type = EncryptedType()
+        result = enc_type.process_result_value(None, None)
+        self.assertIsNone(result)
+
+
+class TestMigrationLogic(unittest.TestCase):
+    """Test migration script logic."""
+
+    def test_is_encrypted_for_migration(self):
+        """is_encrypted correctly identifies encrypted vs plaintext."""
+        encrypted = encrypt_value("secret-data")
+        self.assertTrue(is_encrypted(encrypted))
+        self.assertFalse(is_encrypted("plain-data"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_encryption_integration.py
+++ b/backend/tests/test_encryption_integration.py
@@ -1,0 +1,182 @@
+"""Integration tests for encryption with real PostgreSQL."""
+
+import pytest
+from datetime import date
+
+from app.models import Card, Expense, User
+from app.services.encryption import (
+    compute_hmac,
+    decrypt_value,
+    encrypt_value,
+    is_encrypted,
+    tokenize_description,
+)
+
+
+class TestUserEncryption:
+    def test_create_user_encrypts_full_name(self, db, test_user):
+        """Full name is encrypted in database."""
+        db.refresh(test_user)
+        # Check raw database value is encrypted
+        from sqlalchemy import text
+
+        result = db.execute(
+            text("SELECT full_name FROM users WHERE id = :id"), {"id": test_user.id}
+        ).fetchone()
+        assert is_encrypted(result[0])
+
+    def test_user_returns_decrypted_name(self, db, test_user):
+        """User object returns decrypted full_name."""
+        db.refresh(test_user)
+        assert test_user.full_name == "Test, User"
+        assert not is_encrypted(test_user.full_name)
+
+
+class TestCardEncryption:
+    def test_create_card_generates_search_tokens(self, db, test_user):
+        """Card creation generates search tokens."""
+        card = Card(
+            card_name="Visa Signature",
+            card_name_search=tokenize_description("Visa Signature"),
+            bank="Banco Nación",
+            bank_search=tokenize_description("Banco Nación"),
+            holder="Test, User",
+            holder_search=tokenize_description("Test, User"),
+            card_type="credito",
+            user_id=test_user.id,
+        )
+        db.add(card)
+        db.flush()
+
+        assert card.card_name_search == "visa signature"
+        assert card.bank_search == "banco nacion"
+        assert card.holder_search == "test user"
+
+    def test_filter_by_bank_works(self, db, test_user):
+        """Filter by bank works with search columns."""
+        card = Card(
+            card_name="Visa",
+            card_name_search="visa",
+            bank="Banco Nación",
+            bank_search="banco nacion",
+            holder="Test",
+            holder_search="test",
+            card_type="credito",
+            user_id=test_user.id,
+        )
+        db.add(card)
+        db.flush()
+
+        result = (
+            db.query(Card).filter(Card.bank_search.ilike("%banco%")).first()
+        )
+        assert result is not None
+        assert result.id == card.id
+
+    def test_filter_by_holder_works(self, db, test_user):
+        """Filter by holder works with search columns."""
+        card = Card(
+            card_name="Mastercard",
+            card_name_search="mastercard",
+            bank="BBVA",
+            bank_search="bbva",
+            holder="Marcelo",
+            holder_search="marcelo",
+            card_type="credito",
+            user_id=test_user.id,
+        )
+        db.add(card)
+        db.flush()
+
+        result = (
+            db.query(Card).filter(Card.holder_search.ilike("%marcelo%")).first()
+        )
+        assert result is not None
+        assert result.id == card.id
+
+
+class TestExpenseEncryption:
+    def test_create_expense_encrypts_description(self, db, test_user):
+        """Expense description is encrypted."""
+        expense = Expense(
+            date=date.today(),
+            description="Test expense",
+            description_search="test expense",
+            amount=100.0,
+            user_id=test_user.id,
+        )
+        db.add(expense)
+        db.flush()
+
+        # Check raw database
+        from sqlalchemy import text
+
+        result = db.execute(
+            text("SELECT description FROM expenses WHERE id = :id"), {"id": expense.id}
+        ).fetchone()
+        assert is_encrypted(result[0])
+
+    def test_expense_returns_decrypted_description(self, db, test_user):
+        """Expense object returns decrypted description."""
+        expense = Expense(
+            date=date.today(),
+            description="Farmacity medicamentos",
+            description_search="farmacity medicamentos",
+            amount=100.0,
+            user_id=test_user.id,
+        )
+        db.add(expense)
+        db.flush()
+
+        db.refresh(expense)
+        assert expense.description == "Farmacity medicamentos"
+        assert not is_encrypted(expense.description)
+
+    def test_search_expenses_works(self, db, test_user):
+        """Search expenses works with encrypted fields."""
+        expense = Expense(
+            date=date.today(),
+            description="Farmacity medicamentos",
+            description_search="farmacity medicamentos",
+            amount=100.0,
+            user_id=test_user.id,
+        )
+        db.add(expense)
+        db.flush()
+
+        result = (
+            db.query(Expense)
+            .filter(Expense.description_search.ilike("%farmacia%"))
+            .first()
+        )
+        assert result is not None
+        assert result.id == expense.id
+
+
+class TestTelegramBotLookup:
+    def test_bot_finds_user_by_chat_hash(self, db, test_user):
+        """Bot finds user by telegram_chat_hash."""
+        chat_id = "123456789"
+        test_user.telegram_chat_id = chat_id
+        test_user.telegram_chat_hash = compute_hmac(chat_id)
+        db.flush()
+
+        result = (
+            db.query(User)
+            .filter(User.telegram_chat_hash == compute_hmac(chat_id))
+            .first()
+        )
+        assert result is not None
+        assert result.id == test_user.id
+
+
+class TestDecryptFallback:
+    def test_decrypt_returns_encrypted_placeholder_on_failure(self):
+        """Decrypt returns '[encrypted]' for invalid data."""
+        result = decrypt_value("not-encrypted-data")
+        assert result == "[encrypted]"
+
+    def test_decrypt_returns_empty_for_none(self):
+        """Decrypt returns None for None input."""
+        assert decrypt_value(None) is None
+        assert decrypt_value("") == ""

--- a/docs/Key-Management.md
+++ b/docs/Key-Management.md
@@ -1,0 +1,101 @@
+# Key Management
+
+## SECRET_KEY
+
+The `SECRET_KEY` is used for:
+1. **JWT signing** (authentication)
+2. **Fernet encryption** (data at rest via AES-128-CBC)
+3. **HMAC computation** (Telegram bot lookups)
+
+## Critical Rules
+
+1. **NEVER change SECRET_KEY after deployment** - all encrypted data becomes irrecoverable
+2. **NEVER commit SECRET_KEY to git** - use Podman secrets or environment variables
+3. **Back up SECRET_KEY immediately** - store in a secure location
+
+## How to Get the Current SECRET_KEY
+
+```bash
+# From Podman secret (production)
+podman secret inspect creditcard_backend_prod_secret_key --show-secret
+
+# From Podman secret (development)
+podman secret inspect creditcard_backend_dev_secret_key --show-secret
+
+# From .env file
+grep SECRET_KEY .env
+```
+
+## Backup Procedure
+
+1. Copy the SECRET_KEY value
+2. Store in **at least 2** of these locations:
+   - Password manager (1Password, Bitwarden, etc.)
+   - Sealed envelope in physical safe
+   - Encrypted USB drive in secure location
+   - Hardware security module (HSM)
+3. Document the location in your emergency procedures
+4. Test that you can retrieve the backup
+
+## What Happens If SECRET_KEY Is Lost
+
+| Data | Impact |
+|------|--------|
+| User names | Permanently lost (shows "[encrypted]") |
+| Card names/banks | Permanently lost |
+| Expense descriptions | Permanently lost |
+| MFA secrets | Permanently lost (users locked out of MFA) |
+| Telegram links | Permanently broken |
+| JWT tokens | All users logged out |
+
+**Recovery:** Users must re-enter ALL data. MFA must be re-setup. Telegram must be re-linked.
+
+## What Happens If SECRET_KEY Changes
+
+| Component | Impact |
+|-----------|--------|
+| Encrypted fields | Cannot decrypt (shows "[encrypted]") |
+| HMAC hashes | Telegram lookups fail |
+| JWT tokens | All users logged out |
+| New data | Encrypted with new key (mixed old/new) |
+
+**There is NO automatic recovery from a key change.**
+
+## Key Rotation (Not Currently Supported)
+
+If key rotation is needed in the future:
+1. Implement dual-key support (decrypt with old, encrypt with new)
+2. Re-encrypt all data with new key
+3. Update all HMAC hashes
+4. Remove old key after verification
+
+## Verification
+
+After deployment, verify the key works:
+```bash
+# The app does this automatically on startup
+# If it fails, the app won't start
+```
+
+Manual verification:
+```python
+from app.services.encryption import verify_key_works
+assert verify_key_works(), "SECRET_KEY is invalid!"
+```
+
+## Current Keys (DO NOT COMMIT THIS FILE WITH REAL VALUES)
+
+| Environment | Location | Status |
+|-------------|----------|--------|
+| Development | Podman secret `creditcard_backend_dev_secret_key` | Active |
+| Production | `/opt/creditcardanalyzer/.env` | Active |
+
+## Emergency Recovery
+
+If SECRET_KEY is compromised:
+1. **Immediately** generate a new SECRET_KEY
+2. **Accept** that all encrypted data is lost
+3. Deploy with new key
+4. Notify users to re-enter data
+5. Have users re-setup MFA
+6. Have users re-link Telegram

--- a/docs/Roadmap.md
+++ b/docs/Roadmap.md
@@ -27,6 +27,7 @@
 | 21 | Recurring expenses tracking | ⏳ Backlog | Medium | - | - | Mark expenses as recurring, auto-suggest duplicates, manage subscriptions |
 | 22 | Savings goals | ⏳ Backlog | Low | - | #8 | Create, track, and visualize savings targets with progress indicators |
 | 23 | Bill reminders | ⏳ Backlog | Low | - | #21 | Upcoming bill notifications via Telegram and dashboard alerts |
+| 24 | Field-level encryption | ✅ Done | High | - | - | Encrypt sensitive user data (PII, financial) at rest using Fernet (AES-128-CBC). Protects against database breaches. Includes Card search columns, HMAC for Telegram lookups, dry-run migration, verification scripts, CI/CD integration with automatic rollback |
 
 ## Backlog Details
 
@@ -150,3 +151,15 @@ Generate a monthly summary report with:
 - Mark bill as paid (auto-creates expense if desired)
 - Calendar view of monthly bills
 - Estimated total bill spending per month
+
+### Field-level Encryption ✅
+- Application-level encryption using Fernet (AES-128-CBC) derived from SECRET_KEY
+- Encrypted fields: User (full_name, telegram_chat_id, mfa_secret), Card (card_name, bank, holder), Expense (description, notes), Investment (notes), AuditLog (ip_address, user_agent), MonthlyReport (report_data)
+- Card search columns (card_name_search, bank_search, holder_search) for ilike filtering
+- Expense search column (description_search) for text search
+- HMAC-SHA256 hash for Telegram bot lookups (O(1) index seek)
+- Automatic migration on startup (idempotent)
+- Dry-run migration script (encrypt → verify Card search → rollback)
+- Encryption verification script (verify all fields decrypt)
+- CI/CD integration with automatic database rollback if verification fails
+- 38 unit tests passing

--- a/docs/Security.md
+++ b/docs/Security.md
@@ -1,0 +1,168 @@
+# Security
+
+## Field-Level Encryption
+
+Oikonomia implements application-level field encryption to protect sensitive user data. Even if an administrator has direct database access, they cannot read the encrypted fields without the `SECRET_KEY`.
+
+### What's Encrypted
+
+| Model | Field | Why Encrypted |
+|-------|-------|---------------|
+| `User` | `full_name` | PII - User's real name |
+| `User` | `telegram_chat_id` | PII - Telegram identifier |
+| `User` | `mfa_secret` | Security - TOTP secret key |
+| `Card` | `card_name` | Financial - Card brand (Visa, etc.) |
+| `Card` | `bank` | Financial - Bank name |
+| `Card` | `holder` | PII - Cardholder name |
+| `Expense` | `description` | Financial - Merchant/transaction details |
+| `Expense` | `notes` | Financial - User notes |
+| `Investment` | `notes` | Financial - Investment notes |
+| `AuditLog` | `ip_address` | PII - User's IP address |
+| `AuditLog` | `user_agent` | PII - Browser/device info |
+| `MonthlyReport` | `report_data` | Financial - Report JSON |
+
+### What's NOT Encrypted (and why)
+
+| Field | Reason |
+|-------|--------|
+| `User.email` | Needed for login, unique constraint, lookups |
+| `User.telegram_key` | Temporary auth token, not PII |
+| `User.hashed_password` | Already bcrypt hashed |
+| `Expense.amount` | Needed for calculations/summaries |
+| `Expense.currency` | Not sensitive |
+| `Card.card_type` | Not sensitive (credito/debito) |
+
+### Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                      Application Layer                           │
+├─────────────────────────────────────────────────────────────────┤
+│  routers/auth.py  │  routers/cards.py  │  routers/expenses.py   │
+├─────────────────────────────────────────────────────────────────┤
+│                   SQLAlchemy Models                              │
+│  User.full_name   │  Card.holder       │  Expense.description   │
+│  (EncryptedType)  │  (EncryptedType)   │  (EncryptedType)       │
+├─────────────────────────────────────────────────────────────────┤
+│              EncryptedType (TypeDecorator)                       │
+│         Auto-encrypt on write, auto-decrypt on read              │
+├─────────────────────────────────────────────────────────────────┤
+│              encryption.py (Fernet wrapper)                      │
+│    SECRET_KEY → SHA-256 → Fernet key → AES-128-CBC              │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### How It Works
+
+**Encryption (writing to DB):**
+```python
+# User saves "Farmacity $1500"
+expense.description = "Farmacity $1500 medicamentos"
+
+# EncryptedType.process_bind_param() encrypts automatically
+# Stored in DB: gAAAAABqZ3jJ-1GzGpLcQ3aZhNOdG5EN0V2hRzbqNolmyIfMrp...
+```
+
+**Decryption (reading from DB):**
+```python
+# Read from DB: gAAAAABqZ3jJ-1GzGpLcQ3aZhNOdG5EN0V2hRzbqNolmyIfMrp...
+expense.description  # Returns: "Farmacity $1500 medicamentos"
+
+# EncryptedType.process_result_value() decrypts automatically
+```
+
+### Search on Encrypted Fields
+
+Encrypted fields cannot be searched with SQL `LIKE` or `WHERE`. For searchable fields, we maintain a separate plaintext search column:
+
+```
+Expense {
+    description: EncryptedType     # "Farmacity $1500 medicamentos"
+    description_search: String     # "farmacity 1500 medicamentos" (tokenized)
+}
+```
+
+**How search works:**
+```python
+# User searches "farmacia"
+# 1. Query: SELECT * WHERE description_search LIKE '%farmacia%'
+# 2. For each result: decrypt(description) → show to user
+```
+
+**Tokenization:**
+- Lowercase
+- Remove accents (é → e)
+- Keep only alphanumeric + spaces
+- Collapse multiple spaces
+
+### Telegram Bot Lookup (HMAC)
+
+The bot needs fast user lookups by `telegram_chat_id`. Since the field is encrypted, we maintain a separate HMAC hash column:
+
+```
+User {
+    telegram_chat_id: EncryptedType  # Encrypted
+    telegram_chat_hash: String       # HMAC-SHA256 (plaintext, indexed)
+}
+```
+
+**Bot lookup flow:**
+```python
+# Bot receives message from chat_id "123456"
+chat_hash = compute_hmac("123456")  # HMAC-SHA256
+user = db.query(User).filter(User.telegram_chat_hash == chat_hash).first()
+# O(1) index seek → decrypt single row → respond
+```
+
+### Key Management
+
+**SECRET_KEY** is used for:
+1. Fernet encryption (AES-128-CBC)
+2. HMAC computation (SHA-256)
+3. JWT signing
+
+**Requirements:**
+- Minimum 32 characters
+- Validated at startup (app won't start if too short)
+- Stored in environment variable (`.env` or deployment config)
+
+**Generate a new key:**
+```bash
+python -c "import secrets; print(secrets.token_urlsafe(64))"
+```
+
+### Migration
+
+The migration script (`backend/scripts/migrate_encrypt_fields.py`) runs automatically on startup. It:
+
+1. Checks each field for plaintext values
+2. Encrypts plaintext values (EncryptedType handles this automatically)
+3. Generates HMAC hashes for telegram_chat_id
+4. Generates search tokens for description fields
+
+**Idempotent:** Safe to run multiple times (skips already-encrypted values).
+
+**Run manually:**
+```bash
+cd backend
+DATABASE_URL="..." SECRET_KEY="..." python scripts/migrate_encrypt_fields.py
+```
+
+### Security Considerations
+
+**What encryption protects against:**
+- Database dumps/exfiltration
+- SQL injection attacks
+- Administrator snooping (without SECRET_KEY)
+- Backup exposure
+
+**What encryption does NOT protect against:**
+- Application-level breaches (app has SECRET_KEY in memory)
+- Compromised server (attacker can read SECRET_KEY)
+- Social engineering (user shares their data)
+
+**Recommendations:**
+1. Rotate SECRET_KEY periodically (requires re-encrypting all data)
+2. Store SECRET_KEY in secure environment variables (not in code)
+3. Use different SECRET_KEYs for dev/staging/production
+4. Monitor audit logs for suspicious access patterns


### PR DESCRIPTION
## Summary

Implements application-level field encryption to protect sensitive user data at rest. Even if an administrator has direct database access, they cannot read the encrypted fields without the `SECRET_KEY`.

## Changes

### Phase 1: Fix Critical Bugs
- Add Card search columns (`card_name_search`, `bank_search`, `holder_search`) for ilike filtering
- Fix ilike filters in `expenses.py` (8 locations) and `dashboard.py` (6 locations)
- Fix duplicate checks in `cards.py` and `telegram_bot.py` to use search columns
- Add search token generation in `cards.py` and `telegram_bot.py`
- Fix `decrypt_value` to return `[encrypted]` placeholder on failure

### Phase 2: Update Migration Scripts
- Update `migrate_db_structure.py` with step 8 for Card search columns
- Update `migrate_encrypt_fields.py` to generate Card search tokens

### Phase 3: Create Safety Tools
- Create `dry_run_migration.py` - Encrypt, verify Card search, rollback
- Create `verify_encryption.py` - Verify all fields decrypt correctly

### Phase 4: Create Tests
- Create `conftest.py` for integration tests
- Create `test_encryption_integration.py` - Full API flow tests
- Update `test_encryption.py` with Card search tests and decrypt fallback
- All 38 unit tests passing

### Phase 5: Update CI/CD
- Update `deploy.yml` with dry-run and verify steps
- Add automatic database rollback if verification fails

## Encrypted Fields

| Model | Fields |
|-------|--------|
| User | full_name, telegram_chat_id, mfa_secret |
| Card | card_name, bank, holder |
| Expense | description, notes |
| Investment | notes |
| AuditLog | ip_address, user_agent |
| MonthlyReport | report_data |

## CI/CD Pipeline

```
backup-db → migrate (dry-run → verify → rollback if fail) → restart-and-verify
```

## Tests

- 38 unit tests passing
- Integration tests for Card search, Expense search, User encryption, Telegram bot lookup

## Documentation

- Added `docs/Security.md` with encryption approach documentation
- Updated `docs/Roadmap.md` with feature #24