### PR TITLE
docs: Roadmap, README, and Guide updates for recurring expenses

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,35 @@ Personal finance management with intelligent bank statement import, AI auto-cate
 - **Telegram Bot**: Log expenses via Telegram (@NikoFin_bot) with natural language parsing
 - **Google OAuth**: Login with Google (same-window redirect)
 - **Onboarding Tour**: First-time guided walkthrough of all features
-- **User Guide**: Comprehensive 15-chapter guide at /guide
+- **User Guide**: Comprehensive 16-chapter guide at /guide
 - **Landing Page**: GNOME 50-inspired design with visual mockups
 - **Multi-Domain**: Landing page at oikonomia.ar, app at platform.oikonomia.ar
+
+## Recent Updates
+
+- **Gastos Programados y Mejoras Visuales**
+  - Unified Programados page with installments + recurring expenses
+  - Auto-detect subscriptions from transaction history
+  - Pause/resume/delete recurring expenses
+  - Telegram commands: /suscripciones, /pausar, /cancelar, /ver
+  - AI-powered category suggestions with inline approval
+  - Merchant preference learning (prioritizes user history over LLM)
+  - Email validation with DNS MX record verification
+  - Onboarding walkthrough with per-release feature announcements
+
+- **Budgets and Reports**
+  - Expense budgets with 50/30/20 macro groups
+  - Weekly Telegram reports
+  - Monthly analysis PNG reports
+  - Family groups
+
+- **Core Features**
+  - Smart Import (PDF/CSV/XLSX)
+  - AI auto-categorization
+  - Installment tracking
+  - Investment sync (IOL/PPI)
+  - Google OAuth
+  - Field-level encryption
 
 ## Onboarding
 

--- a/docs/Roadmap.md
+++ b/docs/Roadmap.md
@@ -26,7 +26,9 @@
 | 20 | Gestión automática de cuotas desde Telegram | ✅ Done | Medium | #128 | - | Cuando se registra un gasto con tarjeta de crédito, preguntar automáticamente si fue en cuotas. El monto total se divide por la cantidad de cuotas. Aplica para montos > $10.000 en crédito o categorías especiales (Viajes, Educación, Indumentaria). Flujo completo: división de monto, mensaje de confirmación con desglose, ScheduledExpenses con monto por cuota |
 | 21 | Recurring expenses tracking | ✅ Done | Medium | #135, #145 | - | Auto-detect subscriptions, unified Programados page with installments + recurring, pause/edit/delete, Telegram commands (/suscripciones, /pausar, /cancelar) |
 | 22 | Savings goals | ⏳ Backlog | Low | - | #8 | Create, track, and visualize savings targets with progress indicators |
-| 23 | Bill reminders | ⏳ Backlog | Low | - | #21 | Upcoming bill notifications via Telegram and dashboard alerts |
+| 23a | Auto-detect recurring expenses | ⏳ Backlog | Medium | - | #21 | Celery task to analyze expense history and detect recurring patterns (2+ occurrences, 10% tolerance). Auto-create RecurringExpense entries |
+| 23b | Bill reminder notifications | ⏳ Backlog | Medium | - | #23a | Daily Celery task to check upcoming charges. Send Telegram alerts and in-app notifications. Auto-advance next_charge_date |
+| 23c | Upcoming bills dashboard card | ⏳ Backlog | Low | - | #23b | Dashboard widget showing next 5 upcoming bills with merchant, amount, date, and days remaining |
 | 24 | Field-level encryption | ✅ Done | High | - | - | Encrypt sensitive user data (PII, financial) at rest using Fernet (AES-128-CBC). Protects against database breaches. Includes Card search columns, HMAC for Telegram lookups, dry-run migration, verification scripts, CI/CD integration with automatic rollback |
 | 25 | Email validation | ✅ Done | Low | #134 | - | Validate email format and domain existence. Block fake domains (test.com, mailinator.com, etc.). DNS MX record validation. Frontend + backend validation |
 | 26 | Merchant preference learning | ✅ Done | Medium | #137 | - | Track user category preferences per merchant. Prioritize user preferences over LLM suggestions. Include user history in LLM prompt |
@@ -147,14 +149,39 @@ Generate a monthly summary report with:
 - Monthly insights: "You saved $X towards your goals"
 - Integration with budgets: Budget under X to reach goal
 
-### Bill Reminders (Phase 1)
-- Link bill amounts to expenses ("Electricity $150 on 15th")
-- Dashboard: Upcoming bills card (next 5 bills with dates)
-- Telegram reminder: Day before due + configurable early alerts
-- Snooze reminder (+1, 3, 7 days)
-- Mark bill as paid (auto-creates expense if desired)
-- Calendar view of monthly bills
-- Estimated total bill spending per month
+### Auto-detect Recurring Expenses (23a)
+- Celery task runs daily at 03:00 UTC to analyze expense history
+- Detect recurring patterns: same merchant_key + similar amount (10% tolerance)
+- Minimum 2 occurrences within 90 days to qualify
+- Auto-create RecurringExpense entries with:
+  - merchant_key, description, amount (average)
+  - frequency (monthly default)
+  - next_charge_date (estimated from last occurrence)
+  - category_id, card_id (from most recent occurrence)
+- User can review and adjust auto-detected entries in Programados page
+
+### Bill Reminder Notifications (23b)
+- Daily Celery task at 09:00 UTC to check upcoming charges
+- Query: `WHERE is_active = True AND next_charge_date <= today + alert_days_before`
+- Send Telegram notification via `send_message_to_chat()`:
+  - "Tu pago de Netflix ($5.000) vence en 3 días"
+  - Include merchant, amount, date, card info
+- Send in-app notification via Notification model
+- Auto-advance next_charge_date after charge is detected:
+  - Monthly: +1 month
+  - Weekly: +1 week
+  - Yearly: +1 year
+- User-level preference: enable/disable reminders per recurring expense
+
+### Upcoming Bills Dashboard Card (23c)
+- Dashboard widget showing next 5 upcoming bills
+- Display: merchant name, amount, date, days remaining
+- Color-coded urgency:
+  - Green: 7+ days
+  - Yellow: 3-6 days
+  - Red: 0-2 days
+- Click to filter expenses by that merchant
+- Link to full Programados page
 
 ### Field-level Encryption ✅
 - Application-level encryption using Fernet (AES-128-CBC) derived from SECRET_KEY

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -37,6 +37,7 @@ const GuideAIAnalysisPage = lazy(() => import("./pages/GuideAIAnalysisPage"));
 const GuideFamilyGroupsPage = lazy(() => import("./pages/GuideFamilyGroupsPage"));
 const GuideInvestmentsPage = lazy(() => import("./pages/GuideInvestmentsPage"));
 const GuideCategoriesPage = lazy(() => import("./pages/GuideCategoriesPage"));
+const GuideRecurringPage = lazy(() => import("./pages/GuideRecurringPage"));
 const ChangesPage = lazy(() => import("./pages/ChangesPage"));
 const NovedadesPage = lazy(() => import("./pages/NovedadesPage"));
 const OnboardingWalkthrough = lazy(() => import("./components/OnboardingWalkthrough"));
@@ -173,6 +174,13 @@ export default function App() {
       return (
         <Suspense>
           <GuideCategoriesPage />
+        </Suspense>
+      );
+    }
+    if (location.pathname === "/guide/recurring") {
+      return (
+        <Suspense>
+          <GuideRecurringPage />
         </Suspense>
       );
     }
@@ -628,6 +636,7 @@ function MainLayout() {
                       <Route path="/guide/family-groups" element={<GuideFamilyGroupsPage />} />
                       <Route path="/guide/investments" element={<GuideInvestmentsPage />} />
                       <Route path="/guide/categories" element={<GuideCategoriesPage />} />
+                      <Route path="/guide/recurring" element={<GuideRecurringPage />} />
                       <Route path="/changes" element={<ChangesPage />} />
                       <Route path="/changes/:version" element={<ChangesPage />} />
                       <Route path="/novedades" element={<NovedadesPage />} />

--- a/frontend/src/pages/GuidePage.tsx
+++ b/frontend/src/pages/GuidePage.tsx
@@ -612,24 +612,40 @@ export default function GuidePage() {
             id="programados"
             title="Gastos programados"
             icon="list"
-            subtitle="Gastos futuros que se ejecutan automáticamente."
+            subtitle="Cuotas y gastos recurrentes en un solo lugar."
             expanded={expandedChapters.has("programados")}
             onToggle={() => toggleChapter("programados")}
           >
             <p className="text-sm text-[var(--text-secondary)] mb-3">
-              Los gastos programados son cuotas pendientes de compras en cuotas. Se ejecutan
-              automáticamente cuando llega la fecha.
+              La página Programados muestra todos tus gastos futuros: tanto cuotas pendientes como
+              gastos recurrentes (suscripciones). Se ejecutan automáticamente cuando llega la fecha.
             </p>
-            <h4 className="font-semibold text-[var(--text-primary)] mb-2">Flujo automático</h4>
+
+            <h4 className="font-semibold text-[var(--text-primary)] mb-2">Filtrar por tipo</h4>
+            <p className="text-sm text-[var(--text-secondary)] mb-3">
+              Usá las pestañas "Todos", "Cuotas" o "Recurrentes" para ver solo el tipo de gasto que
+              necesitás.
+            </p>
+
+            <h4 className="font-semibold text-[var(--text-primary)] mt-4 mb-2">Flujo automático</h4>
             <ul className="list-disc list-inside text-sm text-[var(--text-secondary)] space-y-1 mb-3">
               <li>Cada día a las 02:00 UTC, un proceso revisa cuotas con fecha ≤ hoy</li>
               <li>Las cuotas vencidas se convierten en gastos reales automáticamente</li>
               <li>Se mantiene el registro de cuotas pagadas y pendientes</li>
             </ul>
+
+            <h4 className="font-semibold text-[var(--text-primary)] mt-4 mb-2">
+              Gastos recurrentes (suscripciones)
+            </h4>
+            <p className="text-sm text-[var(--text-secondary)] mb-3">
+              La app detecta automáticamente gastos que se repiten mensualmente (como Netflix,
+              Spotify, etc.). Se muestran en la pestaña "Recurrentes" junto a las cuotas.
+            </p>
+
             <h4 className="font-semibold text-[var(--text-primary)] mt-4 mb-2">
               Acciones manuales
             </h4>
-            <ul className="list-disc list-inside text-sm text-[var(--text-secondary)] space-y-1">
+            <ul className="list-disc list-inside text-sm text-[var(--text-secondary)] space-y-1 mb-3">
               <li>
                 <strong>Ejecutar ahora:</strong> Registrar una cuota antes de la fecha programada
               </li>
@@ -640,8 +656,27 @@ export default function GuidePage() {
                 <strong>Editar:</strong> Modificar fecha, monto, descripción o categoría de una
                 cuota pendiente
               </li>
+              <li>
+                <strong>Pausar/Reanudar:</strong> Pausar temporalmente un gasto recurrente o
+                reactivarlo
+              </li>
+              <li>
+                <strong>Eliminar:</strong> Eliminar permanentemente un gasto recurrente
+              </li>
             </ul>
+
+            <Callout type="info">
+              También podés gestionar tus suscripciones desde Telegram con los comandos:
+              /suscripciones (ver), /pausar (pausar), /cancelar (eliminar).
+            </Callout>
           </Chapter>
+
+          <a
+            href="/guide/recurring"
+            className="inline-flex items-center gap-1 text-sm text-[var(--color-primary)] hover:underline mt-3"
+          >
+            📖 Guía completa de gastos recurrentes →
+          </a>
 
           <a
             href="/guide/ai-analysis"

--- a/frontend/src/pages/GuideRecurringPage.tsx
+++ b/frontend/src/pages/GuideRecurringPage.tsx
@@ -1,0 +1,347 @@
+import SymbolicIcon from "../components/SymbolicIcon";
+
+function Section({
+  id,
+  icon,
+  title,
+  children,
+}: {
+  id: string;
+  icon: React.ComponentProps<typeof SymbolicIcon>["name"];
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section id={id} className="mb-10">
+      <div className="flex items-center gap-3 mb-4">
+        <div className="w-10 h-10 rounded-xl bg-[var(--color-primary)]/10 flex items-center justify-center flex-shrink-0">
+          <SymbolicIcon name={icon} size={20} className="text-[var(--color-primary)]" />
+        </div>
+        <h2 className="text-xl font-bold text-[var(--text-primary)]">{title}</h2>
+      </div>
+      <div className="space-y-4 text-[var(--text-secondary)] leading-relaxed">{children}</div>
+    </section>
+  );
+}
+
+function Steps({ items }: { items: string[] }) {
+  return (
+    <ol className="space-y-2">
+      {items.map((item, i) => (
+        <li key={i} className="flex items-start gap-3">
+          <span className="flex-shrink-0 w-6 h-6 rounded-full bg-[var(--color-primary)]/10 text-[var(--color-primary)] flex items-center justify-center text-xs font-bold">
+            {i + 1}
+          </span>
+          <span className="text-sm text-[var(--text-secondary)] pt-0.5">{item}</span>
+        </li>
+      ))}
+    </ol>
+  );
+}
+
+export default function GuideRecurringPage() {
+  return (
+    <div className="min-h-screen bg-[var(--color-base)]">
+      {/* Header */}
+      <div className="border-b border-[var(--border-color)] bg-[var(--color-surface)]">
+        <div className="max-w-4xl mx-auto py-8 px-4">
+          <a
+            href="/guide"
+            className="inline-flex items-center gap-1 text-sm text-[var(--color-primary)] hover:underline mb-6"
+          >
+            ← Volver a la guía
+          </a>
+          <div className="flex items-center gap-3 mb-2">
+            <div className="w-12 h-12 rounded-xl bg-[var(--color-primary)]/10 flex items-center justify-center">
+              <SymbolicIcon name="list" size={26} className="text-[var(--color-primary)]" />
+            </div>
+            <div>
+              <h1 className="text-3xl font-bold text-[var(--text-primary)]">
+                Guía de Gastos Recurrentes
+              </h1>
+              <p className="text-[var(--text-secondary)]">
+                Gestiona tus suscripciones y gastos periódicos en un solo lugar
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Content */}
+      <div className="max-w-4xl mx-auto px-4 py-8">
+        {/* Quick Nav */}
+        <nav className="mb-8 p-4 rounded-xl border border-[var(--border-color)] bg-[var(--color-surface)]">
+          <p className="text-xs font-semibold text-[var(--text-secondary)] uppercase tracking-wide mb-2">
+            En esta guía
+          </p>
+          <div className="flex flex-wrap gap-2">
+            {[
+              { id: "que-es", label: "Qué es" },
+              { id: "deteccion", label: "Detección automática" },
+              { id: "ver", label: "Ver gastos recurrentes" },
+              { id: "pausar", label: "Pausar/Reanudar" },
+              { id: "editar", label: "Editar" },
+              { id: "eliminar", label: "Eliminar" },
+              { id: "alertas", label: "Alertas" },
+              { id: "telegram", label: "Telegram" },
+            ].map((nav) => (
+              <a
+                key={nav.id}
+                href={`#${nav.id}`}
+                className="px-3 py-1.5 rounded-full text-xs font-medium bg-[var(--color-base-alt)] text-[var(--text-secondary)] hover:bg-[var(--color-primary)]/10 hover:text-[var(--color-primary)] transition-colors"
+              >
+                {nav.label}
+              </a>
+            ))}
+          </div>
+        </nav>
+
+        {/* Section 1: What are recurring expenses */}
+        <Section id="que-es" icon="list" title="¿Qué son los gastos recurrentes?">
+          <p>
+            Los gastos recurrentes son <strong>pagos periódicos</strong> que realizás todos los
+            meses (o con otra frecuencia). Ejemplos: Netflix, Spotify, alquiler, servicios públicos,
+            gimnasio, etc.
+          </p>
+          <p>
+            A diferencia de las <strong>cuotas</strong> (que tienen un número finito de pagos), los
+            gastos recurrentes son <strong>indefinidos</strong> — continúan hasta que los cancelás.
+          </p>
+          <div className="p-4 rounded-xl bg-[var(--color-primary)]/5 border border-[var(--color-primary)]/20">
+            <p className="text-sm">
+              <strong>💡 Ejemplo:</strong> Si pagás Netflix $5.000 todos los 15 del mes, la app lo
+              detecta automáticamente y te avisa antes de cada cobro.
+            </p>
+          </div>
+        </Section>
+
+        {/* Section 2: Auto-detection */}
+        <Section id="deteccion" icon="sparkles" title="Detección automática">
+          <p>
+            La app analiza tu historial de gastos y detecta automáticamente patrones recurrentes.
+            Esto funciona así:
+          </p>
+          <div className="space-y-3">
+            <div className="p-3 rounded-lg border border-[var(--border-color)]">
+              <p className="text-sm font-semibold text-[var(--text-primary)] mb-1">
+                1️⃣ Análisis de historial
+              </p>
+              <p className="text-xs">
+                Un tarea diaria revisa tus gastos de los últimos 90 días buscando patrones.
+              </p>
+            </div>
+            <div className="p-3 rounded-lg border border-[var(--border-color)]">
+              <p className="text-sm font-semibold text-[var(--text-primary)] mb-1">
+                2️⃣ Criterios de detección
+              </p>
+              <p className="text-xs">
+                Se detecta un gasto recurrente si hay <strong>2+ ocurrencias</strong> del mismo
+                comercio con un monto similar (tolerancia de 10%).
+              </p>
+            </div>
+            <div className="p-3 rounded-lg border border-[var(--border-color)]">
+              <p className="text-sm font-semibold text-[var(--text-primary)] mb-1">
+                3️⃣ Creación automática
+              </p>
+              <p className="text-xs">
+                Se crea un registro de gasto recurrente con el comercio, monto promedio, categoría y
+                fecha estimada del próximo cobro.
+              </p>
+            </div>
+          </div>
+        </Section>
+
+        {/* Section 3: View recurring expenses */}
+        <Section id="ver" icon="list" title="Ver gastos recurrentes">
+          <p>
+            Todos tus gastos recurrentes se muestran en la página <strong>Programados</strong>,
+            junto a tus cuotas pendientes.
+          </p>
+          <Steps
+            items={[
+              'Hacé click en "Programados" en el menú lateral',
+              'Seleccioná la pestaña "Recurrentes" para ver solo gastos recurrentes',
+              "Cada entrada muestra: descripción, monto, categoría y fecha del próximo cobro",
+              'Usá la pestaña "Todos" para ver cuotas y gastos recurrentes juntos',
+            ]}
+          />
+          <div className="mt-3 p-3 rounded-lg border border-[var(--border-color)]">
+            <p className="text-xs font-semibold text-[var(--text-primary)] mb-1">Tarjetas KPI:</p>
+            <p className="text-xs text-[var(--text-secondary)]">
+              En la parte superior verás: cantidad de gastos recurrentes activos, monto total
+              mensual estimado, y carga del mes actual.
+            </p>
+          </div>
+        </Section>
+
+        {/* Section 4: Pause/Resume */}
+        <Section id="pausar" icon="list" title="Pausar y reanudar">
+          <p>
+            Si querés dejar de pagar temporalmente una suscripción (por ejemplo, durante unas
+            vacaciones), podés pausarla:
+          </p>
+          <Steps
+            items={[
+              "Entrá a Programados en el menú lateral",
+              'Seleccioná la pestaña "Recurrentes"',
+              "Hacé click en el gasto que querés pausar",
+              'Hacé click en "Pausar"',
+              "El gasto se marca como pausado y no se ejecuta automáticamente",
+            ]}
+          />
+          <p className="mt-3 text-sm">
+            <strong>Para reanudar:</strong> Hacé click en el gasto pausado y seleccioná "Reanudar".
+            El gasto vuelve a estar activo y se ejecutará en la próxima fecha programada.
+          </p>
+          <div className="mt-3 p-3 rounded-lg border border-[var(--border-color)]">
+            <p className="text-xs font-semibold text-[var(--text-primary)] mb-1">💡 Tip:</p>
+            <p className="text-xs text-[var(--text-secondary)]">
+              Podés ocultar los gastos pausados haciendo click en "Ocultar pausados" en la barra de
+              herramientas.
+            </p>
+          </div>
+        </Section>
+
+        {/* Section 5: Edit */}
+        <Section id="editar" icon="list" title="Editar un gasto recurrente">
+          <p>Podés modificar varios campos de un gasto recurrente:</p>
+          <Steps
+            items={[
+              "Hacé click en el gasto recurrente que querés editar",
+              'Hacé click en "Editar"',
+              "Modificá el monto (ej: si cambió el precio de Netflix)",
+              "Modificá la fecha del próximo cobro si es necesario",
+              "Cambiá la categoría o el medio de pago",
+              "Guardá los cambios",
+            ]}
+          />
+          <div className="mt-3 p-3 rounded-lg border border-[var(--border-color)]">
+            <p className="text-xs font-semibold text-[var(--text-primary)] mb-1">
+              Campos editables:
+            </p>
+            <ul className="list-disc ml-5 space-y-1 text-xs text-[var(--text-secondary)]">
+              <li>
+                <strong>Monto:</strong> El valor que se cobra cada período
+              </li>
+              <li>
+                <strong>Fecha próximo cobro:</strong> Cuándo se espera el próximo pago
+              </li>
+              <li>
+                <strong>Frecuencia:</strong> Mensual, semanal o anual
+              </li>
+              <li>
+                <strong>Días de alerta:</strong> Cuántos días antes querés recibir el aviso
+              </li>
+              <li>
+                <strong>Categoría:</strong> La categoría del gasto
+              </li>
+            </ul>
+          </div>
+        </Section>
+
+        {/* Section 6: Delete */}
+        <Section id="eliminar" icon="trash" title="Eliminar un gasto recurrente">
+          <p>
+            Si cancelaste una suscripción y no querés que aparezca más, podés eliminarla
+            permanentemente:
+          </p>
+          <Steps
+            items={[
+              "Hacé click en el gasto recurrente",
+              'Hacé click en "Eliminar"',
+              "Confirmá la eliminación",
+              "El gasto se elimina permanentemente del sistema",
+            ]}
+          />
+          <div className="mt-3 p-4 rounded-xl bg-[var(--color-warning)]/10 border border-[var(--color-warning)]/20">
+            <p className="text-sm">
+              <strong>⚠️ Importante:</strong> Esta acción es irreversible. Si solo querés dejar de
+              recibir alertas temporalmente, usá "Pausar" en lugar de "Eliminar".
+            </p>
+          </div>
+        </Section>
+
+        {/* Section 7: Alerts */}
+        <Section id="alertas" icon="bell" title="Alertas de cobro">
+          <p>
+            La app te avisa antes de cada cobro recurrente para que no te sorprendas con un débito
+            inesperado.
+          </p>
+          <div className="space-y-3">
+            <div className="p-3 rounded-lg border border-[var(--border-color)]">
+              <p className="text-sm font-semibold text-[var(--text-primary)] mb-1">
+                📅 Alerta predeterminada: 3 días antes
+              </p>
+              <p className="text-xs">
+                Por defecto, recibís una notificación 3 días antes de cada cobro. Podés cambiar esto
+                editando el gasto recurrente.
+              </p>
+            </div>
+            <div className="p-3 rounded-lg border border-[var(--border-color)]">
+              <p className="text-sm font-semibold text-[var(--text-primary)] mb-1">
+                🔔 Notificación por Telegram
+              </p>
+              <p className="text-xs">
+                Recibirás un mensaje como: "Tu pago de Netflix ($5.000) vence en 3 días"
+              </p>
+            </div>
+            <div className="p-3 rounded-lg border border-[var(--border-color)]">
+              <p className="text-sm font-semibold text-[var(--text-primary)] mb-1">
+                📱 Notificación en la app
+              </p>
+              <p className="text-xs">
+                También verás una notificación en el ícono de campana de la aplicación.
+              </p>
+            </div>
+          </div>
+        </Section>
+
+        {/* Section 8: Telegram */}
+        <Section id="telegram" icon="telegram" title="Gestión desde Telegram">
+          <p>
+            Podés gestionar tus gastos recurrentes directamente desde Telegram usando comandos
+            simples:
+          </p>
+          <div className="space-y-3">
+            <div className="p-3 rounded-lg border border-[var(--border-color)]">
+              <p className="text-sm font-semibold text-[var(--text-primary)] mb-1">
+                /suscripciones
+              </p>
+              <p className="text-xs">
+                Lista todos tus gastos recurrentes activos con monto, categoría y fecha del próximo
+                cobro.
+              </p>
+            </div>
+            <div className="p-3 rounded-lg border border-[var(--border-color)]">
+              <p className="text-sm font-semibold text-[var(--text-primary)] mb-1">/pausar</p>
+              <p className="text-xs">
+                Pausa un gasto recurrente. El bot te muestra la lista y elegís cuál pausar.
+              </p>
+            </div>
+            <div className="p-3 rounded-lg border border-[var(--border-color)]">
+              <p className="text-sm font-semibold text-[var(--text-primary)] mb-1">/cancelar</p>
+              <p className="text-xs">
+                Elimina permanentemente un gasto recurrente. El bot te pide confirmación antes de
+                eliminar.
+              </p>
+            </div>
+            <div className="p-3 rounded-lg border border-[var(--border-color)]">
+              <p className="text-sm font-semibold text-[var(--text-primary)] mb-1">/ver</p>
+              <p className="text-xs">
+                Muestra el detalle de un gasto recurrente específico (monto, categoría, historial de
+                pagos).
+              </p>
+            </div>
+          </div>
+          <div className="mt-3 p-3 rounded-lg border border-[var(--border-color)]">
+            <p className="text-xs font-semibold text-[var(--text-primary)] mb-1">💡 Tip:</p>
+            <p className="text-xs text-[var(--text-secondary)]">
+              También podés escribirle al bot en lenguaje natural: "¿Cuándo vence Netflix?" o "Pausá
+              Spotify".
+            </p>
+          </div>
+        </Section>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Changes

### docs/Roadmap.md
- Break down Item #23 (Bill reminders) into 3 sub-items:
  - 23a: Auto-detect recurring expenses (Celery task)
  - 23b: Bill reminder notifications (daily alerts)
  - 23c: Upcoming bills dashboard card
- Update Backlog Details with detailed descriptions

### README.md
- Add 'Recent Updates' section with bullet points
- Update guide count from 15 to 16 chapters

### GuideRecurringPage.tsx (NEW)
- New sub-guide for recurring expenses
- 8 sections: What is, Auto-detection, View, Pause/Resume, Edit, Delete, Alerts, Telegram
- Quick nav with anchor links

### App.tsx
- Add lazy import for GuideRecurringPage
- Add route /guide/recurring
- Add institutional route for oikonomia.ar

### GuidePage.tsx
- Expand 'programados' chapter with recurring expenses
- Add link to sub-guide /guide/recurring

Closes #147