### PR TITLE
feat: telegram bot improvements — debit detection, installments, account matching

### DIFF
--- a/Roadmap.md
+++ b/Roadmap.md
@@ -13,17 +13,19 @@
 | 7 | Weekly Telegram report | ✅ Done | Medium | #76 | PNG image report sent via Telegram bot. Includes weekly spent, accumulated monthly |
 | 8 | Income module | ⏳ Backlog | High | - | Track income, dashboard comparison vs last months |
 | 9 | Ticket scan | ⏳ Backlog | Medium | - | OCR receipt analysis, compare same items last month |
-| 10 | Expense budgets | ⏳ Backlog | Medium | - | Set spending limits per category |
+| 10 | Expense budgets | ✅ Done | Medium | - | Per-category budgets with 50/30/20 groups, events, auto-suggestion |
 | 11 | Make index.html interactive | ✅ Done | Medium | #73 | Click KPI cards to filter expenses, uncategorized warnings |
 | 12 | Billing period tracking | ❌ Not Done | Medium | #63 | Cancelled: Monthly filtering is sufficient |
 | 13 | Missing categories notification | ✅ Done | Medium | #73 | Real-time notifications for uncategorized expenses |
-| 14 | FCI, Plazos Fijos y Cauciones | ⏳ Backlog | Medium | - | Support for Fondos Comunes, Plazos Fijos, and Cauciones |
-| 15 | Recurring expenses tracking | ⏳ Backlog | Medium | - | Mark expenses as recurring, auto-suggest duplicates, manage subscriptions |
+| 14 | FCI, Plazos Fijos y Cauciones | 🔶 Partial | Medium | - | Broker sync imports FCI/Cauciones; missing: plazo fijo tracking, maturity alerts, specialized views |
+| 15 | Recurring expenses tracking | ✅ Done | Medium | - | Auto-detect subscriptions, pause/resume, upcoming charge alerts, Telegram commands |
 | 16 | Savings goals | ⏳ Backlog | Low | - | Create, track, and visualize savings targets with progress indicators |
-| 17 | Bill reminders | ⏳ Backlog | Low | - | Upcoming bill notifications via Telegram and dashboard alerts |
-| 18 | Income tracking (Phase 2) | ⏳ Backlog | High | - | Track salary, investments, other income sources with dashboard integration |
+| 17 | Bill reminders | 🔶 Partial | Low | - | Upcoming recurring alerts exist; missing: snooze, calendar view, mark-as-paid, dashboard card |
+| 18 | Income tracking (Phase 2) | 🔶 Partial | High | - | is_income field + dashboard breakdown exist; missing: income types, recurring income, dedicated UI |
 | 19 | Receipt OCR scanning (Phase 2) | ⏳ Backlog | Medium | - | Upload receipt photos, extract items and amounts with historical price tracking |
-| 20 | Data export & tax reports (Phase 2) | ⏳ Backlog | Medium | - | Export transactions in tax-friendly formats for Argentina tax filing |
+| 20 | Data export & tax reports (Phase 2) | 🔶 Partial | Medium | - | CSV export + monthly PNG reports exist; missing: Excel/PDF, AFIP tax categories |
+| 21 | Telegram bot improvements | ✅ Done | Medium | - | Debit card detection, installment parsing, account matching, cancel buttons |
+| 22 | WhatsApp Bot | ⏳ Backlog | High | - | WhatsApp Business API integration for expense logging (same features as Telegram bot) |
 
 ## Platform Focus
 
@@ -211,3 +213,21 @@ Generate a monthly summary report with:
 - Integration with existing investment portfolio
 - Separate tracking from stocks/ETFs
 - Maturity date alerts and reminders
+
+### WhatsApp Bot
+- **Effort**: High | **Freemium**: Premium feature
+- WhatsApp Business API integration via Meta Cloud API or Twilio
+- Same core features as Telegram bot:
+  - Natural language expense parsing (LLM-powered)
+  - Bank notification detection and parsing
+  - Installment handling (auto-detect from notifications)
+  - Account and card matching
+  - Category auto-categorization
+- Authentication flow: link WhatsApp number to Oikonomia account
+- Proactive messaging: weekly reports, budget alerts, recurring reminders
+- Media support: receipt photo upload → OCR → expense creation
+- Group chat support: log expenses from family WhatsApp group
+- **Implementation options**:
+  - Meta Cloud API (official, requires Business verification)
+  - Twilio WhatsApp API (easier setup, per-message cost)
+- **Challenges**: Message template approval, 24h session window, phone number verification

--- a/docs/Roadmap.md
+++ b/docs/Roadmap.md
@@ -17,7 +17,8 @@
 | 11 | Make index.html interactive | ✅ Done | Medium | #73 | - | Click KPI cards to filter expenses, uncategorized warnings |
 | 12 | Billing period tracking | ❌ Not Done | Medium | #63 | - | Cancelled: Monthly filtering is sufficient. Billing view adds complexity without enough value for expense analysis and saving plans |
 | 13 | Missing categories notification | ✅ Done | Medium | #73 | - | Real-time notifications for uncategorized expenses on save + login |
-| 14 | FCI, Plazos Fijos y Cauciones | ⏳ Backlog | Medium | - | - | Support for Fondos Comunes de Inversión, Plazos Fijos, and Cauciones in investments module |
+| 14 | FCI, Plazos Fijos y Cauciones | 🔶 Partial | Medium | - | - | Broker sync imports FCI/Cauciones from IOL/PPI; missing: plazo fijo tracking, maturity alerts, specialized views |
+| 14b | Telegram bot improvements | ✅ Done | Medium | - | - | Debit card detection from bank notifications, installment parsing (Cuota 3 de 12), account name matching, cancel buttons, improved /ayuda help |
 | 15 | Enable MFA for user accounts | ✅ Done | Medium | #94 | - | Multi-factor authentication (TOTP) for enhanced account security. QR code setup in UserPanel, MFA login step, enable/disable flow |
 | 16 | Integración caja de ahorro ↔ tarjeta débito | ✅ Done | Medium | #96 | - | Vincular cuentas de caja de ahorro con tarjetas débito. Bidireccional (desde tarjeta o desde cuenta). Solo caja_ahorro ↔ débito. Gastos con tarjeta vinculada se reflejan automáticamente en la cuenta |
 | 17 | Auto-categorización de gastos con IA | ✅ Done | Medium | #99 | - | Usar LLM para sugerir automáticamente la categoría correcta al cargar un gasto, basándose en la descripción, monto y historial del usuario |
@@ -27,12 +28,13 @@
 | 21 | Recurring expenses tracking | ✅ Done | Medium | #135, #145 | - | Auto-detect subscriptions, unified Programados page with installments + recurring, pause/edit/delete, Telegram commands (/suscripciones, /pausar, /cancelar) |
 | 22 | Savings goals | ⏳ Backlog | Low | - | #8 | Create, track, and visualize savings targets with progress indicators |
 | 23 | Auto-detect recurring expenses | ✅ Done | Medium | #150 | #21 | Celery task to analyze expense history and detect recurring patterns (2+ occurrences, 10% tolerance). Auto-create RecurringExpense entries with notification + banner + review modal in /programados |
-| 24 | Bill reminder notifications | ⏳ Backlog | Medium | - | #23 | Daily Celery task to check upcoming charges. Send Telegram alerts and in-app notifications. Auto-advance next_charge_date |
+| 24 | Bill reminder notifications | 🔶 Partial | Medium | - | #23 | Upcoming recurring alerts exist (3 days before, daily Celery task); missing: snooze, mark-as-paid, Telegram-specific reminders |
 | 25 | Upcoming bills dashboard card | ⏳ Backlog | Low | - | #24 | Dashboard widget showing next 5 upcoming bills with merchant, amount, date, and days remaining |
 | 26 | Field-level encryption | ✅ Done | High | #141, #149 | - | Encrypt sensitive user data (PII, financial) at rest using Fernet (AES-128-CBC). Protects against database breaches. Includes HMAC for duplicate detection, Account.name encryption, dry-run migration, verification scripts, CI/CD integration with automatic rollback. Search columns removed, replaced with application-level filtering |
 | 27 | Email validation | ✅ Done | Low | #134 | - | Validate email format and domain existence. Block fake domains (test.com, mailinator.com, etc.). DNS MX record validation. Frontend + backend validation |
 | 28 | Merchant preference learning | ✅ Done | Medium | #137 | - | Track user category preferences per merchant. Prioritize user preferences over LLM suggestions. Include user history in LLM prompt |
 | 29 | Admin panel | ✅ Done | High | #151 | - | Full admin panel at /x/{slug} (random UUID, SEO protected). User management, audit logs, monthly reports, system health. Impersonation with chat widget + transcript email. Block/unblock users, toggle admin, bulk notify. Cleanup tasks (90d logs, 45d messages). Re-auth modal on JWT expiry. Weekly reports timezone fix |
+| 30 | WhatsApp Bot | ⏳ Backlog | High | - | - | WhatsApp Business API integration for expense logging. Same features as Telegram bot: natural language parsing, bank notification detection, installment handling, account matching. Meta Cloud API or Twilio integration |
 
 ## Backlog Details
 
@@ -197,3 +199,32 @@ Generate a monthly summary report with:
 - Encryption verification script (verify all fields decrypt)
 - CI/CD integration with automatic database rollback if verification fails
 - 27 unit tests passing
+
+### Telegram Bot Improvements ✅
+- Debit card detection from bank notifications (débito automático, débito en cuenta, extracción cajero)
+- Installment parsing from bank notifications ("Cuota 3 de 12" → auto-populate, skip question)
+- card_last4 regex extraction from notification text + Pass 0 matching by last 4 digits
+- Account name matching from natural language ("transferencia galicia", "mercado pago", "efectivo")
+- Account fallback for debit notifications when no card matches
+- Cancel button (❌) on all conversation flows (payment, bank, card, account selection)
+- Improved /start flow: bot capabilities shown before auth, commands shown after connect
+- Enhanced /ayuda with full command list
+- Recurring expense auto-linking on expense save
+
+### WhatsApp Bot
+- **Effort**: High | **Freemium**: Premium feature
+- WhatsApp Business API integration via Meta Cloud API or Twilio
+- Same core features as Telegram bot:
+  - Natural language expense parsing (LLM-powered)
+  - Bank notification detection and parsing
+  - Installment handling (auto-detect from notifications)
+  - Account and card matching
+  - Category auto-categorization
+- Authentication flow: link WhatsApp number to Oikonomia account
+- Proactive messaging: weekly reports, budget alerts, recurring reminders
+- Media support: receipt photo upload → OCR → expense creation
+- Group chat support: log expenses from family WhatsApp group
+- **Implementation options**:
+  - Meta Cloud API (official, requires Business verification)
+  - Twilio WhatsApp API (easier setup, per-message cost)
+- **Challenges**: Message template approval, 24h session window, phone number verification


### PR DESCRIPTION
## Telegram Bot Improvements

### New Features
- **Debit card detection**: Parse debit notifications (debito automatico, debito en cuenta, extraccion cajero), match by last 4 digits, fallback to account matching for debit
- **Installment parsing**: LLM extracts installment info from bank notifications (Cuota 3 de 12), auto-populates context, shows in confirmation message
- **Account matching**: Match accounts from natural language (transferencia galicia, mercado pago, efectivo), skip payment selection when matched
- **Cancel buttons**: Cancelar on all conversation flows (payment, bank, card, account selection)
- **Improved UX**: Better /start flow, enhanced /ayuda with full command list

### Changes
- prompts.py: Added card_last4, installment_number, installment_total to BANK_NOTIFICATION_PARSE_PROMPT with debit examples
- telegram_bot.py: New _match_account_from_text(), Pass 0 last4 matching, debit account fallback, installment auto-populate

### Roadmaps
- Updated feature statuses (budgets done, recurring done, FCI/bill reminders/income/export partial)
- Added Telegram bot improvements as done
- Added WhatsApp Bot to backlog