### PR TITLE
fix: persist What's New dismiss preference server-side (#162)

### DIFF
--- a/src/backend/app/models.py
+++ b/src/backend/app/models.py
@@ -49,6 +49,8 @@ class User(Base):
     onboarding_completed = Column(Boolean, default=False)
     # Auto-detect recurring banner
     auto_detected_banner_dismissed_at = Column(DateTime, nullable=True)
+    # What's New dismissed version
+    whats_new_dismissed_version = Column(String(20), nullable=True)
     # Admin
     is_admin = Column(Boolean, default=False)
     is_blocked = Column(Boolean, default=False)

--- a/src/backend/app/routers/auth.py
+++ b/src/backend/app/routers/auth.py
@@ -667,6 +667,27 @@ def refresh_token(current_user: User = Depends(get_current_user)):
     return Token(access_token=create_access_token(current_user.id), token_type="bearer")
 
 
+class WhatsNewDismissRequest(BaseModel):
+    version: str
+
+
+@router.put(
+    "/me/whats-new-dismiss",
+    response_model=UserResponse,
+    summary="Dismiss What's New popup for a version",
+    description="Records that the user has dismissed the What's New popup for a specific version. This preference syncs across all devices.",
+)
+def dismiss_whats_new(
+    body: WhatsNewDismissRequest,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    current_user.whats_new_dismissed_version = body.version
+    db.commit()
+    db.refresh(current_user)
+    return current_user
+
+
 RESET_TOKEN_EXPIRY_MINUTES = 15
 
 

--- a/src/backend/app/schemas/auth.py
+++ b/src/backend/app/schemas/auth.py
@@ -45,6 +45,7 @@ class UserResponse(BaseModel):
     onboarding_completed: bool = False
     is_admin: bool = False
     is_blocked: bool = False
+    whats_new_dismissed_version: str | None = None
     model_config = {"from_attributes": True}
 
 

--- a/src/backend/scripts/migrate_db_structure.py
+++ b/src/backend/scripts/migrate_db_structure.py
@@ -614,6 +614,7 @@ def main():
     step12_admin_panel(engine)
     step13_platform_logs(engine)
     step14_recurring_expense_link(engine)
+    step15_whats_new_dismissed_version(engine)
 
     print("\n" + "=" * 60)
     print("Migration complete!")
@@ -841,6 +842,33 @@ def step14_recurring_expense_link(engine):
             ))
 
             print("  Added recurring_expense_id INTEGER with FK (RESTRICT) and index.")
+
+
+def step15_whats_new_dismissed_version(engine):
+    """Add whats_new_dismissed_version column to users table."""
+    print("\n[Step 15/15] Adding whats_new_dismissed_version to users...")
+
+    with engine.begin() as conn:
+        dialect = engine.dialect.name
+
+        if dialect != "postgresql":
+            print("  Skipping — only supported on PostgreSQL.")
+            return
+
+        exists = conn.execute(text("""
+            SELECT EXISTS (
+                SELECT 1 FROM information_schema.columns
+                WHERE table_name = 'users' AND column_name = 'whats_new_dismissed_version'
+            )
+        """)).scalar()
+
+        if exists:
+            print("  whats_new_dismissed_version already exists. Skipping.")
+        else:
+            conn.execute(
+                text("ALTER TABLE users ADD COLUMN whats_new_dismissed_version VARCHAR(20)")
+            )
+            print("  Added whats_new_dismissed_version VARCHAR(20).")
 
 
 if __name__ == "__main__":

--- a/src/frontend/src/App.tsx
+++ b/src/frontend/src/App.tsx
@@ -11,7 +11,7 @@ import { UploadProgressProvider } from "./context/UploadProgressContext";
 import { NotificationsProvider, useNotifications } from "./context/NotificationsContext";
 import { FamilyGroupProvider } from "./context/FamilyGroupContext";
 import { sidebarIcons } from "./components/SidebarIcons";
-import { getStoredToken, getMe, getAdminSlug } from "./api/client";
+import { getStoredToken, getMe, getAdminSlug, dismissWhatsNew } from "./api/client";
 import { ErrorBoundary } from "./components/ErrorBoundary";
 import { useUndoToast } from "./hooks/useUndoToast";
 import ImpersonationBanner from "./components/ImpersonationBanner";
@@ -46,6 +46,7 @@ const NovedadesPage = lazy(() => import("./pages/NovedadesPage"));
 const OnboardingWalkthrough = lazy(() => import("./components/OnboardingWalkthrough"));
 const WhatsNewModal = lazy(() => import("./components/WhatsNewModal"));
 const AdminPage = lazy(() => import("./pages/AdminPage"));
+import { LATEST_VERSION } from "./data/changes";
 
 const TABS = [
   {
@@ -296,7 +297,7 @@ function MainLayout() {
   }, []);
 
   // Check if we should show What's New modal (only on /)
-  // Shows every time on main page unless user opted out entirely
+  // Shows on main page unless user dismissed this specific version
   useEffect(() => {
     const checkWhatsNew = async () => {
       try {
@@ -304,8 +305,16 @@ function MainLayout() {
         const { SHOW_WHATS_NEW } = await import("./components/WhatsNewModal");
         if (!SHOW_WHATS_NEW) return;
 
-        const dontRemind = localStorage.getItem("whats_new_dont_remind") === "true";
-        if (dontRemind) return;
+        // Fast-path: localStorage fallback (instant, no network)
+        const dontRemindLocal = localStorage.getItem("whats_new_dont_remind_version");
+        if (dontRemindLocal === LATEST_VERSION) return;
+
+        // Backend check: skip if user already dismissed this version
+        if (currentUser?.whats_new_dismissed_version === LATEST_VERSION) {
+          // Sync localStorage so we don't need to check again
+          localStorage.setItem("whats_new_dont_remind_version", LATEST_VERSION);
+          return;
+        }
 
         setTimeout(() => setShowWhatsNew(true), 1500);
       } catch {
@@ -313,7 +322,7 @@ function MainLayout() {
       }
     };
     checkWhatsNew();
-  }, [location.pathname]);
+  }, [location.pathname, currentUser?.whats_new_dismissed_version]);
 
   useEffect(() => {
     const main = document.querySelector("main");
@@ -757,7 +766,10 @@ function MainLayout() {
                   onClose={(dontRemind) => {
                     setShowWhatsNew(false);
                     if (dontRemind) {
-                      localStorage.setItem("whats_new_dont_remind", "true");
+                      // Persist to backend (syncs across devices)
+                      dismissWhatsNew(LATEST_VERSION).catch(() => {});
+                      // Also set localStorage as fast-path fallback
+                      localStorage.setItem("whats_new_dont_remind_version", LATEST_VERSION);
                     }
                   }}
                 />

--- a/src/frontend/src/api/client.ts
+++ b/src/frontend/src/api/client.ts
@@ -97,6 +97,9 @@ export const getMe = () => api.get<User>("/auth/me").then((r) => r.data);
 export const markOnboardingCompleted = () =>
   api.put<User>("/auth/me/onboarding").then((r) => r.data);
 
+export const dismissWhatsNew = (version: string) =>
+  api.put<User>("/auth/me/whats-new-dismiss", { version }).then((r) => r.data);
+
 export const changePassword = (current_password: string, new_password: string) =>
   api.put("/auth/password", { current_password, new_password });
 

--- a/src/frontend/src/types/index.ts
+++ b/src/frontend/src/types/index.ts
@@ -95,6 +95,7 @@ export interface User {
   onboarding_completed?: boolean;
   is_admin?: boolean;
   is_blocked?: boolean;
+  whats_new_dismissed_version?: string | null;
 }
 
 export interface Category {


### PR DESCRIPTION
## Problem
The 'Do not show again' preference for the What's New popup was stored only in , which is device-specific. Users had to dismiss the popup on every device/browser.

## Solution
Persist the dismissed version server-side on the  model so it syncs across all devices.

### Changes
- **Backend**: Add  column to  model +  endpoint
- **Migration**:  adds the column to the chelo chelo table
- **Frontend**: Check backend preference against  on page load; call API on dismiss
- **Version-scoped**: The key is now a version string (e.g. `v1.2`) instead of a boolean, so new versions will re-show the popup
- **localStorage fallback**: Kept as fast-path cache to avoid flash before API response arrives

Fixes #162