### PR TITLE
fix: Google SSO persistence + remove insecure implicit flow (#170, #174)

### DIFF
--- a/src/backend/app/models.py
+++ b/src/backend/app/models.py
@@ -60,6 +60,9 @@ class User(Base):
     whatsapp_phone = Column(EncryptedType, nullable=True)
     whatsapp_phone_hash = Column(String(64), nullable=True, unique=True, index=True)
     whatsapp_key = Column(String(12), nullable=True, unique=True, index=True)
+    # Google OAuth refresh token
+    google_refresh_token = Column(EncryptedType, nullable=True)
+    google_refresh_token_hmac = Column(String(64), nullable=True, index=True)
 
 
 class Group(Base):

--- a/src/backend/app/routers/auth.py
+++ b/src/backend/app/routers/auth.py
@@ -30,10 +30,10 @@ from app.services.auth import (
     exchange_google_code,
     get_current_user,
     get_password_hash,
-    verify_google_token,
     verify_password,
 )
 from app.services.email import send_password_reset_email, send_verification_email
+from app.services.encryption import compute_hmac
 from app.services.mfa import verify_totp
 from app.services.rate_limit import (
     check_rate_limit,
@@ -301,72 +301,6 @@ def resend_verification(body: ForgotPasswordRequest, db: Session = Depends(get_d
 
 
 @router.post(
-    "/oauth",
-    response_model=Token,
-    summary="Login or register via OAuth",
-    description="Authenticates or creates a user using a Google ID token. Links existing accounts when emails match.",
-)
-async def oauth_login(body: OAuthRequest, request: Request, db: Session = Depends(get_db)):
-    if body.provider != "google":
-        raise HTTPException(status_code=400, detail="Proveedor no soportado")
-    if not body.id_token:
-        raise HTTPException(status_code=400, detail="Falta id_token de Google")
-    google_data = await verify_google_token(body.id_token)
-    email = google_data.get("email", "").lower()
-    provider_id = google_data.get("sub")
-    full_name = google_data.get("name", "")
-    avatar_url = google_data.get("picture")
-
-    if not email:
-        raise HTTPException(status_code=400, detail="No se pudo obtener el email del proveedor")
-
-    user = (
-        db.query(User)
-        .filter(User.provider == body.provider, User.provider_id == provider_id)
-        .first()
-    )
-
-    if not user:
-        existing = db.query(User).filter(User.email == email).first()
-        if existing and existing.provider:
-            raise HTTPException(
-                status_code=409,
-                detail="Este email ya está vinculado a otra cuenta. Iniciá sesión con tu proveedor original.",
-            )
-        if existing and not existing.provider:
-            existing.provider = body.provider
-            existing.provider_id = provider_id
-            existing.avatar_url = avatar_url
-            existing.email_verified = True
-            if not existing.full_name:
-                existing.full_name = full_name
-            db.commit()
-            db.refresh(existing)
-            user = existing
-        else:
-            user = User(
-                email=email,
-                full_name=full_name,
-                provider=body.provider,
-                provider_id=provider_id,
-                avatar_url=avatar_url,
-                email_verified=True,
-            )
-            db.add(user)
-            db.commit()
-            db.refresh(user)
-            from app.seed import _apply_base_hierarchy_for_user
-
-            _apply_base_hierarchy_for_user(db, user.id)
-
-    if not user.is_active:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Usuario inactivo")
-
-    _log_audit(db, user.id, "oauth_login", request, details=body.provider)
-    return Token(access_token=create_access_token(user.id), token_type="bearer")
-
-
-@router.post(
     "/oauth/callback",
     response_model=Token,
     summary="Handle OAuth authorization code callback",
@@ -434,6 +368,12 @@ async def oauth_callback(
 
     if not user.is_active:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Usuario inactivo")
+
+    refresh_token = google_data.get("refresh_token")
+    if refresh_token:
+        user.google_refresh_token = refresh_token
+        user.google_refresh_token_hmac = compute_hmac(refresh_token)
+        db.commit()
 
     _log_audit(db, user.id, "oauth_login", request, details=f"{body.provider}_callback")
     return Token(access_token=create_access_token(user.id), token_type="bearer")

--- a/src/backend/app/schemas/auth.py
+++ b/src/backend/app/schemas/auth.py
@@ -50,7 +50,6 @@ class UserResponse(BaseModel):
 
 
 class OAuthRequest(BaseModel):
-    id_token: str | None = None
     code: str | None = None
     provider: str
 

--- a/src/backend/app/services/auth.py
+++ b/src/backend/app/services/auth.py
@@ -106,4 +106,6 @@ async def exchange_google_code(code: str, redirect_uri: str) -> dict:
         id_token = data.get("id_token")
         if not id_token:
             raise HTTPException(status_code=400, detail="No se recibió id_token de Google")
-        return await verify_google_token(id_token)
+        google_data = await verify_google_token(id_token)
+        google_data["refresh_token"] = data.get("refresh_token")
+        return google_data

--- a/src/frontend/src/App.tsx
+++ b/src/frontend/src/App.tsx
@@ -218,7 +218,10 @@ export default function App() {
   }
 
   // App: platform.oikonomia.ar (or localhost)
-  if (location.pathname === "/login") return <LoginPage />;
+  if (location.pathname === "/login" || location.pathname === "/register") {
+    if (getStoredToken()) return <Navigate to="/" replace />;
+    return <LoginPage />;
+  }
 
   if (location.pathname === "/privacy") {
     return (

--- a/src/frontend/src/api/client.ts
+++ b/src/frontend/src/api/client.ts
@@ -86,9 +86,6 @@ export const login = (email: string, password: string) =>
 export const register = (full_name: string, email: string, password: string) =>
   api.post<AuthToken>("/auth/register", { full_name, email, password }).then((r) => r.data);
 
-export const oauthLogin = (provider: string, idTokenOrCode: string) =>
-  api.post<AuthToken>("/auth/oauth", { provider, id_token: idTokenOrCode }).then((r) => r.data);
-
 export const oauthCallback = (provider: string, code: string) =>
   api.post<AuthToken>("/auth/oauth/callback", { provider, code }).then((r) => r.data);
 

--- a/src/frontend/src/env.d.ts
+++ b/src/frontend/src/env.d.ts
@@ -48,6 +48,7 @@ interface GoogleAccountsOauth2 {
     ux_mode: "popup" | "redirect";
     redirect_uri: string;
     state?: string;
+    access_type?: "online" | "offline";
   }): GoogleCodeClient;
 }
 

--- a/src/frontend/src/pages/LoginPage.tsx
+++ b/src/frontend/src/pages/LoginPage.tsx
@@ -176,6 +176,7 @@ function LoginForm({
       scope: "email profile openid",
       ux_mode: "redirect",
       redirect_uri: `${window.location.origin}/oauth/callback`,
+      access_type: "offline",
     });
   }, []);
 


### PR DESCRIPTION
## Issue #170: SSO de Google no persiste los permisos

### Root Cause
- The backend had a dead **implicit flow** endpoint (`POST /auth/oauth` accepting raw `id_token`) that the frontend never used. Google flagged it as an insecure OAuth flow.
- The GIS client was missing `access_type: "offline"`, so Google didn't issue a refresh token.
- `exchange_google_code()` discarded the `refresh_token` from Google's response.

### Changes
- **Removed** `POST /auth/oauth` implicit flow endpoint (only authorization code flow remains)
- **Added** `access_type: "offline"` to GIS `initCodeClient` so Google issues a refresh token
- **Added** `google_refresh_token` (encrypted) + `google_refresh_token_hmac` (indexed) fields to User model
- **Updated** `exchange_google_code()` to return the refresh token
- **Removed** unused `id_token` field from `OAuthRequest` schema
- **Removed** unused `oauthLogin()` from frontend API client

### Remaining (manual)
- Enable **Cross-Account Protection** in Google Cloud Console > Google Auth Platform > Security
- Run DB migration to add the new columns to the `users` table

---

## Issue #174: Landing page register/login buttons

### Root Cause
- `/login` route rendered `<LoginPage />` unconditionally (no auth check)
- No `/register` route existed — authenticated users accidentally landed in the app

### Changes
- Added auth guard: authenticated users visiting `/login` or `/register` are redirected to `/`