### PR TITLE
fix: remove access_type and prompt from GIS client to stop consent spam

### DIFF
--- a/docs/guides/oauth-configuration.md
+++ b/docs/guides/oauth-configuration.md
@@ -25,9 +25,7 @@ window.google.accounts.oauth2.initCodeClient({
   scope: "email profile openid", // Required: requested scopes
   ux_mode: "redirect",       // Required: "redirect" or "popup"
   redirect_uri: "...",       // Required: must match Google Cloud Console
-  access_type: "offline",    // Optional: request refresh token
-  prompt: "select_account",  // Optional: control consent behavior
-  state: "...",              // Optional: CSRF protection
+  // access_type and prompt are NOT set — see below
 });
 ```
 
@@ -44,39 +42,60 @@ window.google.accounts.oauth2.initCodeClient({
 
 | Value | Behavior | When to use |
 |-------|----------|-------------|
-| `"online"` (default) | No refresh token issued | When you don't need to access Google APIs after login |
-| `"offline"` | Refresh token issued | When you need to access Google APIs on behalf of the user |
+| `"online"` (default) | No refresh token issued | **Recommended for SSO** — when you don't need to access Google APIs after login |
+| `"offline"` | Refresh token issued | Only when you need to access Google APIs on behalf of the user (e.g., background sync) |
 
-**Important:** If you set `access_type: "offline"`, you MUST also set `prompt`. See below.
+**Important:** `access_type: "offline"` causes Google to show the consent screen on **every login** and send a "data sharing notification" email each time. Only use it if you actually need the refresh token for background access.
 
 ### `prompt` — Consent Behavior
 
 | Value | Behavior | When to use |
 |-------|----------|-------------|
-| (not set) | Google decides | Default, but may re-prompt with `offline` access |
-| `"select_account"` | Show account picker, skip consent on repeat visits | **Recommended for SSO** |
-| `"consent"` | Always show consent screen | When you need fresh consent every time |
+| (not set) | Google decides | **Recommended for SSO** — consent only on first login |
+| `"select_account"` | Show account picker every time | When you want to force account selection (adds friction) |
+| `"consent"` | Always show consent screen | When you need fresh consent every time (rare) |
 | `"none"` | No prompt (silent auth) | Background re-authentication |
 
-### The `offline` + Missing `prompt` Trap
+### Recommended Configuration for SSO
 
-**Problem:** If you set `access_type: "offline"` without setting `prompt`, Google may show the consent screen on every login. This is because Google wants to ensure the user is aware they're granting offline access.
-
-**Solution:** Always pair `access_type: "offline"` with `prompt: "select_account"`:
+For standard SSO (login only, no background Google API access):
 
 ```typescript
-// CORRECT
+// RECOMMENDED — consent only on first login, no refresh token
 initCodeClient({
-  // ...
+  client_id: "...",
+  scope: "email profile openid",
+  ux_mode: "redirect",
+  redirect_uri: "...",
+  // No access_type or prompt — Google uses default behavior
+});
+```
+
+This configuration:
+- Shows consent screen only on the first login
+- Does NOT send "data sharing notification" emails on repeat logins
+- Does NOT issue a refresh token (not needed for SSO)
+- Shows account picker only if user has multiple Google accounts
+
+### When to Use `access_type: "offline"`
+
+Only use `access_type: "offline"` if you need to access Google APIs on behalf of the user when they're not actively using the app (e.g., syncing Google Calendar, sending emails via Gmail API).
+
+If you use `access_type: "offline"`:
+- Google will show the consent screen on **every login**
+- Google will send a "data sharing notification" email on **every login**
+- You MUST implement token refresh logic to use the refresh token
+- You should set `prompt: "select_account"` to at least show the account picker
+
+```typescript
+// ONLY for background Google API access
+initCodeClient({
+  client_id: "...",
+  scope: "email profile openid",
+  ux_mode: "redirect",
+  redirect_uri: "...",
   access_type: "offline",
   prompt: "select_account",
-});
-
-// WRONG — consent screen shows every login
-initCodeClient({
-  // ...
-  access_type: "offline",
-  // prompt not set
 });
 ```
 
@@ -111,9 +130,9 @@ interface GoogleAccountsOauth2 {
 Before merging any OAuth-related PR:
 
 1. **First login:** Clear all Google cookies/cache. Click "Continuar con Google". Verify the consent screen appears and shows the correct scopes.
-2. **Repeat login:** Without clearing cookies, click "Continuar con Google" again. Verify the consent screen does NOT appear (if `prompt: "select_account"` is set).
-3. **Account picker:** Verify the account picker appears on repeat logins (if `prompt: "select_account"` is set).
-4. **Token storage:** Verify the refresh token is stored in the database (if `access_type: "offline"` is set).
+2. **Repeat login:** Without clearing cookies, click "Continuar con Google" again. Verify the consent screen does NOT appear.
+3. **No email:** Verify Google does NOT send a "data sharing notification" email on repeat logins.
+4. **Account picker:** If user has multiple Google accounts, verify the account picker appears (only if `prompt: "select_account"` is set).
 
 ## Automated Validation
 
@@ -130,8 +149,9 @@ This script checks:
 
 ## Common Pitfalls
 
-1. **Missing `prompt` with `offline` access** — Consent screen shows every login
-2. **TypeScript type missing parameter** — Can't set the parameter without a type error
-3. **Redirect URI mismatch** — Must exactly match Google Cloud Console (including trailing slash)
-4. **Scopes changed** — Changing scopes forces re-consent for all users
-5. **Google Cloud Console in "Testing" mode** — Consent screen always shows, refresh tokens expire after 7 days
+1. **Using `access_type: "offline"` without needing it** — Consent screen shows every login, Google sends notification emails every time
+2. **Missing `prompt` with `offline` access** — Consent screen shows every login without account picker
+3. **TypeScript type missing parameter** — Can't set the parameter without a type error
+4. **Redirect URI mismatch** — Must exactly match Google Cloud Console (including trailing slash)
+5. **Scopes changed** — Changing scopes forces re-consent for all users
+6. **Google Cloud Console in "Testing" mode** — Consent screen always shows, refresh tokens expire after 7 days

--- a/src/frontend/src/pages/LoginPage.tsx
+++ b/src/frontend/src/pages/LoginPage.tsx
@@ -176,8 +176,6 @@ function LoginForm({
       scope: "email profile openid",
       ux_mode: "redirect",
       redirect_uri: `${window.location.origin}/oauth/callback`,
-      access_type: "offline",
-      prompt: "select_account",
     });
   }, []);
 


### PR DESCRIPTION
## Problem

Google SSO shows the consent screen on **every login** and sends a "data sharing notification" email each time. This doesn't happen with other platforms.

## Root Cause

`access_type: "offline"` in the GIS `initCodeClient` call causes Google to treat each login as a new consent grant. The refresh token is issued every time, triggering the consent screen and notification email.

The refresh token was stored in the DB but **never used** — no benefit from offline access.

## Fix

Removed `access_type: "offline"` and `prompt: "select_account"` from the GIS client. Default behavior (no `access_type`/`prompt`):

- Consent screen only on **first login**
- No notification emails on repeat logins
- Account picker only if user has multiple Google accounts
- No refresh token issued (not needed for SSO)

## Files Changed

- `src/frontend/src/pages/LoginPage.tsx` — removed `access_type` and `prompt` from `initCodeClient`
- `docs/guides/oauth-configuration.md` — updated to reflect recommended configuration

## Testing

1. Clear Google cookies/cache
2. Click "Continuar con Google" → consent screen appears (first login)
3. Click "Continuar con Google" again → NO consent screen, NO notification email