### PR TITLE
fix: detect Visa débito in messages + prevent recurrent re-suggestions (#161, #165)

### DIFF
--- a/src/backend/app/routers/recurring.py
+++ b/src/backend/app/routers/recurring.py
@@ -242,7 +242,7 @@ def delete_recurring(
     db: Session = Depends(get_db),
     current_user=Depends(get_current_user),
 ):
-    """Permanently delete a recurring expense."""
+    """Soft-delete a recurring expense (keeps record to prevent re-detection)."""
     rec = (
         db.query(RecurringExpense)
         .filter(
@@ -254,7 +254,7 @@ def delete_recurring(
     if not rec:
         raise HTTPException(status_code=404, detail="Gasto recurrente no encontrado")
 
-    db.delete(rec)
+    rec.is_active = False
     db.commit()
     return {"detail": "Recurrente eliminado"}
 

--- a/src/backend/app/tasks/detect_recurring.py
+++ b/src/backend/app/tasks/detect_recurring.py
@@ -32,7 +32,7 @@ def detect_recurring_expenses():
         total_notified = 0
 
         for user in users:
-            created, updated = _detect_for_user(user.id, db)
+            created, updated, skipped = _detect_for_user(user.id, db)
             total_created += created
             total_updated += updated
 
@@ -61,7 +61,7 @@ def detect_recurring_expenses():
         db.close()
 
 
-def _detect_for_user(user_id: int, db) -> tuple[int, int]:
+def _detect_for_user(user_id: int, db) -> tuple[int, int, int]:
     """Detect recurring patterns for a single user. Returns (created, updated)."""
     cutoff = datetime.now(BUE).date() - timedelta(days=LOOKBACK_DAYS)
 
@@ -77,7 +77,7 @@ def _detect_for_user(user_id: int, db) -> tuple[int, int]:
     )
 
     if not expenses:
-        return 0, 0
+        return 0, 0, 0
 
     # Group expenses by normalized merchant_key
     merchant_groups: dict[str, list[Expense]] = {}
@@ -89,6 +89,7 @@ def _detect_for_user(user_id: int, db) -> tuple[int, int]:
 
     created = 0
     updated = 0
+    skipped = 0
 
     for merchant_key, group in merchant_groups.items():
         if len(group) < MIN_OCCURRENCES:
@@ -120,18 +121,21 @@ def _detect_for_user(user_id: int, db) -> tuple[int, int]:
         account_counts = Counter(e.account_id for e in group if e.account_id)
         account_id = account_counts.most_common(1)[0][0] if account_counts else None
 
-        # Check if already tracked
+        # Check if already tracked (active or dismissed)
         existing = (
             db.query(RecurringExpense)
             .filter(
                 RecurringExpense.user_id == user_id,
                 RecurringExpense.merchant_key == merchant_key,
-                RecurringExpense.is_active == True,  # noqa: E712
             )
             .first()
         )
 
         if existing:
+            # If dismissed (inactive), skip — don't re-create
+            if not existing.is_active:
+                skipped += 1
+                continue
             existing.amount = round(avg_amount, 2)
             existing.last_seen_at = datetime.now(BUE)
             existing.next_charge_date = next_date
@@ -157,7 +161,7 @@ def _detect_for_user(user_id: int, db) -> tuple[int, int]:
             db.add(new)
             created += 1
 
-    return created, updated
+    return created, updated, skipped
 
 
 def _send_notification(user_id: int, count: int, db):

--- a/src/backend/app/telegram_bot.py
+++ b/src/backend/app/telegram_bot.py
@@ -135,6 +135,8 @@ def _is_bank_notification(text: str) -> bool:
 
 
 CARD_NAME_PATTERNS = [
+    r"\b(visa\s+(?:d[eé]bito|credito|cr[eé]dito))\b",
+    r"\b(mastercard\s+(?:d[eé]bito|credito|cr[eé]dito))\b",
     r"\b(visa|mastercard|naranja|amex|cabal|cmr|cordobesa|tarjeta naranja)\b",
 ]
 BANK_NAME_PATTERNS = [
@@ -268,8 +270,9 @@ def _match_card_from_notification(
             continue
         if bank and card.bank and card.bank.lower() != bank.lower():
             continue
-        # Check if card_name is a known franchise
-        if card.card_name.lower() in ["visa", "mastercard", "naranja", "amex", "cabal"]:
+        # Check if card_name contains a known franchise
+        card_lower = card.card_name.lower()
+        if any(card_lower.startswith(f) or f in card_lower for f in ["visa", "mastercard", "naranja", "amex", "cabal"]):
             return card
 
     # Pass 2: match by bank + type only (ignore card_name)
@@ -1227,7 +1230,16 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
             cards = db.query(Card).filter(Card.user_id == user_id).all()
             matched_card = None
             for card in cards:
-                if card.card_name.lower() == text_card_name.lower() and (
+                card_lower = card.card_name.lower()
+                text_lower = text_card_name.lower()
+                # Match if DB card starts with the extracted name or vice versa
+                # e.g. "visa" matches "visa debito", "visa debito" matches "visa"
+                name_match = (
+                    card_lower == text_lower
+                    or card_lower.startswith(text_lower)
+                    or text_lower.startswith(card_lower)
+                )
+                if name_match and (
                     not text_bank or (card.bank and card.bank.lower() == text_bank.lower())
                 ):
                     matched_card = card

--- a/src/backend/app/telegram_bot.py
+++ b/src/backend/app/telegram_bot.py
@@ -146,11 +146,12 @@ BANK_NAME_PATTERNS = [
 ]
 
 
-def _extract_card_from_text(text: str) -> tuple[str | None, str | None]:
-    """Try to extract card_name and bank from natural language text."""
+def _extract_card_from_text(text: str) -> tuple[str | None, str | None, str | None]:
+    """Try to extract card_name, bank, and card_type from natural language text."""
     lower = text.lower()
     card_name = None
     bank = None
+    card_type = None
     for p in CARD_NAME_PATTERNS:
         m = re.search(p, lower)
         if m:
@@ -161,7 +162,12 @@ def _extract_card_from_text(text: str) -> tuple[str | None, str | None]:
         if m:
             bank = m.group(1).title()
             break
-    return card_name, bank
+    # Extract card type (debito/credito) from the text
+    if re.search(r"\bd[eé]bito\b", lower):
+        card_type = "debito"
+    elif re.search(r"\bcredito|cr[eé]dito\b", lower):
+        card_type = "credito"
+    return card_name, bank, card_type
 
 
 ACCOUNT_TYPE_KEYWORDS = {
@@ -1212,7 +1218,7 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
     )
 
     # Clean description: strip card/bank keywords Gemini might have included
-    text_card_name, text_bank = _extract_card_from_text(text)
+    text_card_name, text_bank, text_card_type = _extract_card_from_text(text)
     if text_card_name and parsed.get("description"):
         desc = parsed["description"]
         # Remove card name and bank from description
@@ -1242,8 +1248,12 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
                     or card_lower.startswith(text_lower)
                     or text_lower.startswith(card_lower)
                 )
-                if name_match and (
-                    not text_bank or (card.bank and card.bank.lower() == text_bank.lower())
+                # Match card type if extracted (debito/credito)
+                type_match = not text_card_type or card.card_type == text_card_type
+                if (
+                    name_match
+                    and type_match
+                    and (not text_bank or (card.bank and card.bank.lower() == text_bank.lower()))
                 ):
                     matched_card = card
                     break

--- a/src/backend/app/telegram_bot.py
+++ b/src/backend/app/telegram_bot.py
@@ -272,7 +272,10 @@ def _match_card_from_notification(
             continue
         # Check if card_name contains a known franchise
         card_lower = card.card_name.lower()
-        if any(card_lower.startswith(f) or f in card_lower for f in ["visa", "mastercard", "naranja", "amex", "cabal"]):
+        if any(
+            card_lower.startswith(f) or f in card_lower
+            for f in ["visa", "mastercard", "naranja", "amex", "cabal"]
+        ):
             return card
 
     # Pass 2: match by bank + type only (ignore card_name)

--- a/src/backend/app/whatsapp_bot.py
+++ b/src/backend/app/whatsapp_bot.py
@@ -402,7 +402,16 @@ async def _handle_text_message(
             cards = db.query(Card).filter(Card.user_id == user_id).all()
             matched_card = None
             for card in cards:
-                if card.card_name.lower() == text_card_name.lower() and (
+                card_lower = card.card_name.lower()
+                text_lower = text_card_name.lower()
+                # Match if DB card starts with the extracted name or vice versa
+                # e.g. "visa" matches "visa debito", "visa debito" matches "visa"
+                name_match = (
+                    card_lower == text_lower
+                    or card_lower.startswith(text_lower)
+                    or text_lower.startswith(card_lower)
+                )
+                if name_match and (
                     not text_bank or (card.bank and card.bank.lower() == text_bank.lower())
                 ):
                     matched_card = card

--- a/src/backend/app/whatsapp_bot.py
+++ b/src/backend/app/whatsapp_bot.py
@@ -395,7 +395,7 @@ async def _handle_text_message(
         return
 
     # Try card matching from text
-    text_card_name, text_bank = _extract_card_from_text(text)
+    text_card_name, text_bank, text_card_type = _extract_card_from_text(text)
     if text_card_name:
         db = SessionLocal()
         try:
@@ -411,8 +411,12 @@ async def _handle_text_message(
                     or card_lower.startswith(text_lower)
                     or text_lower.startswith(card_lower)
                 )
-                if name_match and (
-                    not text_bank or (card.bank and card.bank.lower() == text_bank.lower())
+                # Match card type if extracted (debito/credito)
+                type_match = not text_card_type or card.card_type == text_card_type
+                if (
+                    name_match
+                    and type_match
+                    and (not text_bank or (card.bank and card.bank.lower() == text_bank.lower()))
                 ):
                     matched_card = card
                     break


### PR DESCRIPTION
## Issue #161: No detecta tarjetas Visa débito en mensajes

### Root Cause
The regex `CARD_NAME_PATTERNS` extracted just "Visa" from "visa debito", but the card matching used exact equality (`card.card_name.lower() == text_card_name.lower()`). If the DB card was "Visa debito", the match failed.

### Fix
- Updated `CARD_NAME_PATTERNS` to detect compound forms like "visa debito", "visa débito", "mastercard debito"
- Changed card matching from exact equality to `startswith()` so "visa" matches "visa debito" and vice versa
- Updated `_match_card_from_notification()` to check if card_name contains a known franchise
- Applied same fix to `whatsapp_bot.py`

## Issue #165: Recurrent expenses suggested repeatedly after deletion

### Root Cause
The delete endpoint did a hard delete (`db.delete(rec)`), but the detection task only checked for active records. When the row was hard-deleted, the detection task created a new one the next day.

### Fix
- Changed `delete_recurring` from hard delete to soft delete (`is_active=False`)
- Updated `detect_recurring` task to check for inactive (dismissed) records and skip them
- This prevents the cycle: delete → re-detect → re-suggest

## Files Changed
- `src/backend/app/telegram_bot.py` — Card detection patterns + matching logic
- `src/backend/app/whatsapp_bot.py` — Same card matching fix
- `src/backend/app/routers/recurring.py` — Soft delete instead of hard delete
- `src/backend/app/tasks/detect_recurring.py` — Check inactive records