### PR TITLE
fix: detect Visa Débito in bank notifications + Human in the Loop (#161)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -33,6 +33,7 @@
 - [ ] `docs/Features.md` updated (if new feature)
 
 ## Testing
+- [ ] Changes were explained before implementation (Human in the Loop)
 - [ ] `npm run typecheck` passes (frontend)
 - [ ] `npm run lint` passes (frontend)
 - [ ] `ruff check app/` passes (backend)

--- a/.github/workflows/issue-status.yml
+++ b/.github/workflows/issue-status.yml
@@ -7,7 +7,7 @@ on:
 permissions:
   contents: read
   pull-requests: write
-  projects: write
+  repository-projects: write
 
 env:
   PROJECT_ID: PVT_kwHOAxRXjs4Bh4Pj

--- a/src/backend/app/prompts.py
+++ b/src/backend/app/prompts.py
@@ -168,17 +168,19 @@ Extraé del siguiente mensaje de notificación bancaria:
 - "date": fecha en formato "YYYY-MM-DD". Si no se menciona fecha, usá hoy.
 - "currency": "ARS" si es pesos o no se menciona, "USD" si es dólares.
 - "card_type": "credito" si es compra con tarjeta de crédito, "debito" si es débito directo o transferencia.
+- "card_name": nombre completo de la tarjeta si se menciona (ej: "Visa Débito", "Mastercard Crédito", "Visa", "Mastercard"). Si no se menciona, null.
 - "bank": nombre del banco emisor si se menciona, sino null.
 - "card_last4": últimos 4 dígitos de la tarjeta si se mencionan (ej: "****4521" → "4521"), sino null.
 - "installment_number": número de cuota actual si se menciona (ej: 3 si dice "3 de 12" o "cuota 3"), sino null.
 - "installment_total": cantidad total de cuotas si se menciona (ej: 12 si dice "3 de 12" o "6 cuotas"), sino null.
 
 Ejemplos de entrada → salida:
-"Compra aprobada Visa ****4521 $15.200 Supermercado Coto" → {{"amount": 15200.0, "description": "Supermercado Coto", "date": "{today}", "currency": "ARS", "card_type": "credito", "bank": null, "card_last4": "4521", "installment_number": null, "installment_total": null}}
-"Débito en cuenta Galicia por $8.500 Netflix" → {{"amount": 8500.0, "description": "Netflix", "date": "{today}", "currency": "ARS", "card_type": "debito", "bank": "Galicia", "card_last4": null, "installment_number": null, "installment_total": null}}
-"Se debitó $15.000 de tu cuenta Galicia - Pago Tarjeta Visa" → {{"amount": 15000.0, "description": "Pago Tarjeta Visa", "date": "{today}", "currency": "ARS", "card_type": "debito", "bank": "Galicia", "card_last4": null, "installment_number": null, "installment_total": null}}
-"Resumen Visa Galicia - Cuota 3 de 12 de $15.000 Netflix" → {{"amount": 15000.0, "description": "Netflix", "date": "{today}", "currency": "ARS", "card_type": "credito", "bank": "Galicia", "card_last4": null, "installment_number": 3, "installment_total": 12}}
-"Compra 6 cuotas $24.000 Fravega" → {{"amount": 24000.0, "description": "Fravega", "date": "{today}", "currency": "ARS", "card_type": "credito", "bank": null, "card_last4": null, "installment_number": 1, "installment_total": 6}}
-"Compra débito automático Mastercard ****9876 $3.200 Spotify" → {{"amount": 3200.0, "description": "Spotify", "date": "{today}", "currency": "ARS", "card_type": "debito", "bank": null, "card_last4": "9876", "installment_number": null, "installment_total": null}}
+"Compra aprobada Visa ****4521 $15.200 Supermercado Coto" → {{"amount": 15200.0, "description": "Supermercado Coto", "date": "{today}", "currency": "ARS", "card_type": "credito", "card_name": "Visa", "bank": null, "card_last4": "4521", "installment_number": null, "installment_total": null}}
+"Débito en cuenta Galicia por $8.500 Netflix" → {{"amount": 8500.0, "description": "Netflix", "date": "{today}", "currency": "ARS", "card_type": "debito", "card_name": null, "bank": "Galicia", "card_last4": null, "installment_number": null, "installment_total": null}}
+"Se debitó $15.000 de tu cuenta Galicia - Pago Tarjeta Visa" → {{"amount": 15000.0, "description": "Pago Tarjeta Visa", "date": "{today}", "currency": "ARS", "card_type": "debito", "card_name": "Visa", "bank": "Galicia", "card_last4": null, "installment_number": null, "installment_total": null}}
+"Resumen Visa Galicia - Cuota 3 de 12 de $15.000 Netflix" → {{"amount": 15000.0, "description": "Netflix", "date": "{today}", "currency": "ARS", "card_type": "credito", "card_name": "Visa", "bank": "Galicia", "card_last4": null, "installment_number": 3, "installment_total": 12}}
+"Compra 6 cuotas $24.000 Fravega" → {{"amount": 24000.0, "description": "Fravega", "date": "{today}", "currency": "ARS", "card_type": "credito", "card_name": null, "bank": null, "card_last4": null, "installment_number": 1, "installment_total": 6}}
+"Compra débito automático Mastercard ****9876 $3.200 Spotify" → {{"amount": 3200.0, "description": "Spotify", "date": "{today}", "currency": "ARS", "card_type": "debito", "card_name": "Mastercard", "bank": null, "card_last4": "9876", "installment_number": null, "installment_total": null}}
+"Te acercamos el detalle de tu consumo con la Tarjeta Santander Visa Débito terminada en 3001. Monto $8.616,00 Comercio WORK CAFE GARAY Fecha 27/08/2026" → {{"amount": 8616.0, "description": "WORK CAFE GARAY", "date": "2026-08-27", "currency": "ARS", "card_type": "debito", "card_name": "Visa Débito", "bank": "Santander", "card_last4": "3001", "installment_number": null, "installment_total": null}}
 
 Respondé ÚNICAMENTE con un objeto JSON válido, sin markdown, sin texto adicional."""

--- a/src/backend/app/telegram_bot.py
+++ b/src/backend/app/telegram_bot.py
@@ -255,7 +255,12 @@ def _parse_bank_notification(text: str) -> dict | None:
 
 
 def _match_card_from_notification(
-    user_id: int, card_last4: str | None, bank: str | None, card_type: str | None, db
+    user_id: int,
+    card_last4: str | None,
+    bank: str | None,
+    card_type: str | None,
+    card_name: str | None,
+    db,
 ) -> Card | None:
     """Match a bank notification to an existing card in DB."""
     cards = db.query(Card).filter(Card.user_id == user_id).all()
@@ -270,12 +275,25 @@ def _match_card_from_notification(
             if card.card_name and card.card_name[-4:] == card_last4:
                 return card
 
-    # Pass 1: match by card_name (Visa/Mastercard) + bank + type
+    # Pass 1: match by card_name + bank + type
     for card in cards:
         if card.card_type != target_type:
             continue
         if bank and card.bank and card.bank.lower() != bank.lower():
             continue
+        # If notification mentions a card name, match it (case-insensitive, accent-insensitive)
+        if card_name:
+            import unicodedata
+
+            def _strip_accents(s: str) -> str:
+                nfkd = unicodedata.normalize("NFKD", s.lower().strip())
+                return "".join(c for c in nfkd if not unicodedata.combining(c))
+
+            card_lower = _strip_accents(card.card_name)
+            name_lower = _strip_accents(card_name)
+            # Check if DB card contains the notification name or vice versa
+            if name_lower not in card_lower and card_lower not in name_lower:
+                continue
         # Check if card_name contains a known franchise
         card_lower = card.card_name.lower()
         if any(
@@ -1022,6 +1040,7 @@ async def _handle_bank_notification(
             parsed.get("card_last4"),
             parsed.get("bank"),
             parsed.get("card_type"),
+            parsed.get("card_name"),
             db,
         )
 

--- a/src/backend/app/whatsapp_bot.py
+++ b/src/backend/app/whatsapp_bot.py
@@ -501,6 +501,7 @@ async def _handle_bank_notification(
             parsed.get("card_last4"),
             parsed.get("bank"),
             parsed.get("card_type"),
+            parsed.get("card_name"),
             db,
         )
 


### PR DESCRIPTION
## Issue #161: No detecta tarjetas Visa débito en mensajes

### Problem

Bank notifications with "Tarjeta Santander Visa Débito terminada en 3001" were being matched to "Mastercard Santander" instead of the correct "Visa Débito Santander" card.

### Root Cause

1. The LLM prompt for bank notifications (`BANK_NOTIFICATION_PARSE_PROMPT`) did not extract the card franchise (Visa/Mastercard) from the notification text
2. The `_match_card_from_notification()` function did not filter by card name from the notification
3. When the user had multiple cards at the same bank, the system matched the wrong one

### Fix

**Backend changes:**
- Updated `BANK_NOTIFICATION_PARSE_PROMPT` to extract `card_name` field (full card name like "Visa Débito", "Mastercard Crédito")
- Added example for "Tarjeta Santander Visa Débito terminada en 3001" to the prompt
- Updated `_match_card_from_notification()` to accept `card_name` parameter and filter cards by it (case-insensitive, accent-insensitive)
- Updated callers in `telegram_bot.py` and `whatsapp_bot.py` to pass `card_name`

**Expected behavior:**
- Input: "Te acercamos el detalle de tu consumo con la Tarjeta Santander Visa Débito terminada en 3001"
- Before: Detected "Mastercard Santander" (wrong card)
- After: Detected "Visa Débito Santander" (correct card)

## SDLC: Human in the Loop Validation

Added process improvement to ensure AI agents explain changes before applying them:
- Updated `.sdd/guides/ai-agent-guide.md` with Rule 1b: Human in the Loop Validation
- Updated `.github/PULL_REQUEST_TEMPLATE.md` with "Changes explained before implementation" checklist item
- Created `.sdd/guides/human-in-the-loop.md` guide documenting the process

## Files Changed

| File | Change |
|------|--------|
| `src/backend/app/prompts.py` | Added `card_name` field to BANK_NOTIFICATION_PARSE_PROMPT |
| `src/backend/app/telegram_bot.py` | Updated `_match_card_from_notification()` to use card_name |
| `src/backend/app/whatsapp_bot.py` | Updated caller to pass card_name |
| `.github/PULL_REQUEST_TEMPLATE.md` | Added Human in the Loop checklist item |
| `.github/workflows/issue-status.yml` | Fixed permission key |
| `.sdd/guides/ai-agent-guide.md` | Added Rule 1b |
| `.sdd/guides/human-in-the-loop.md` | Created new guide |

Closes #161