### PR TITLE
fix: card swap bug + SDD local linting framework

### DIFF
--- a/.github/workflows/issue-status.yml
+++ b/.github/workflows/issue-status.yml
@@ -58,10 +58,11 @@ jobs:
       - name: Extract linked issues
         if: steps.status.outputs.skip != 'true'
         id: issues
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
         run: |
           # Extract from PR body (Closes #123, Fixes #456, Resolves #789)
-          BODY='${{ github.event.pull_request.body }}'
-          BODY_ISSUES=$(echo "$BODY" | grep -oiE '(closes|fixes|resolves)\s+#([0-9]+)' | grep -oE '#[0-9]+' | tr -d '#' | sort -u)
+          BODY_ISSUES=$(echo "$PR_BODY" | grep -oiE '(closes|fixes|resolves)\s+#([0-9]+)' | grep -oE '#[0-9]+' | tr -d '#' | sort -u)
 
           # Get linked issues from GitHub API (Linked Issues feature)
           PR_NUMBER="${{ github.event.pull_request.number }}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,63 @@
+# CLAUDE.md
+
+## Project: Oikonomia (creditCardAnalyzer)
+
+Personal finance app with Telegram bot, WhatsApp bot, FastAPI backend, React frontend.
+
+## Lint Commands
+
+Run before every commit:
+
+```bash
+./scripts/lint.sh
+```
+
+Run with auto-fix:
+
+```bash
+./scripts/lint.sh --fix
+```
+
+Individual commands:
+
+```bash
+# Frontend
+cd src/frontend && npm run lint && npx prettier --check src/ && npm run typecheck
+
+# Backend
+cd src/backend && ruff check app/ && ruff format --check app/ && mypy app/
+```
+
+## Test Commands
+
+```bash
+cd src/backend && SECRET_KEY="test-secret-key-that-is-at-least-32-chars-long-for-testing" pytest tests/ -v
+```
+
+## Key Paths
+
+| Path | Description |
+|------|-------------|
+| `src/backend/app/` | Backend application code |
+| `src/frontend/src/` | Frontend application code |
+| `.sdd/` | SDD framework (submodule) |
+| `scripts/` | Build and utility scripts |
+| `docs/` | Documentation |
+| `.sdd/guides/` | Framework guides and rules |
+
+## SDD Framework
+
+Follow the rules in `.sdd/guides/ai-agent-guide.md`:
+
+1. **Never auto-apply** — Present a plan before any code modification
+2. **Read specs before code** — Understand requirements before implementing
+3. **Documentation is mandatory** — Update docs with every feature
+4. **Pre-commit verification** — Run linters before committing (Rule 8)
+
+## Architecture
+
+- **Backend**: FastAPI + SQLAlchemy + PostgreSQL
+- **Frontend**: React + TanStack Query + TypeScript
+- **Bots**: Telegram + WhatsApp integration
+- **Deployment**: Podman Compose
+- **Specs**: OpenAPI + feature specs in `docs/specs/`

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+set -e
+
+# Lint script for Oikonomia (creditCardAnalyzer)
+# Usage:
+#   ./scripts/lint.sh          # Check mode (reports errors)
+#   ./scripts/lint.sh --fix    # Auto-fix mode
+#
+# This script runs all linters for frontend and backend.
+# See .sdd/guides/local-linting.md for details.
+
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FIX_MODE="${1:-}"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+failed=0
+
+run_linter() {
+    local name="$1"
+    local cmd="$2"
+    local dir="$3"
+
+    echo -e "${YELLOW}[$name]${NC} Running..."
+    if (cd "$dir" && eval "$cmd"); then
+        echo -e "${GREEN}[$name]${NC} Passed"
+    else
+        echo -e "${RED}[$name]${NC} FAILED"
+        failed=1
+    fi
+    echo ""
+}
+
+echo "=== Frontend Linting ==="
+run_linter "ESLint" "npm run lint" "$PROJECT_ROOT/src/frontend"
+
+if [ "$FIX_MODE" = "--fix" ]; then
+    run_linter "Prettier" "npx prettier --write src/" "$PROJECT_ROOT/src/frontend"
+else
+    run_linter "Prettier" "npx prettier --check src/" "$PROJECT_ROOT/src/frontend"
+fi
+
+run_linter "TypeScript" "npm run typecheck" "$PROJECT_ROOT/src/frontend"
+
+echo "=== Backend Linting ==="
+run_linter "Ruff Lint" "ruff check app/" "$PROJECT_ROOT/src/backend"
+
+if [ "$FIX_MODE" = "--fix" ]; then
+    run_linter "Ruff Format" "ruff format app/" "$PROJECT_ROOT/src/backend"
+else
+    run_linter "Ruff Format" "ruff format --check app/" "$PROJECT_ROOT/src/backend"
+fi
+
+run_linter "MyPy" "mypy app/" "$PROJECT_ROOT/src/backend"
+
+echo "=== Tests ==="
+run_linter "Unit Tests" \
+    "SECRET_KEY='test-secret-key-that-is-at-least-32-chars-long-for-testing' pytest tests/test_card_matching.py tests/test_encryption.py -v" \
+    "$PROJECT_ROOT/src/backend"
+
+if [ "$failed" -eq 0 ]; then
+    echo -e "${GREEN}All linters passed${NC}"
+    exit 0
+else
+    echo -e "${RED}Some linters failed${NC}"
+    exit 1
+fi

--- a/src/backend/app/services/csv_parser.py
+++ b/src/backend/app/services/csv_parser.py
@@ -601,7 +601,9 @@ async def run_deterministic_import(content: bytes, filename: str, db, user_id: i
     detected_cards = []
     for card_header, txns in card_groups.items():
         detected_bank, detected_card_type = _parse_card_header(card_header)
-        matched_card = _match_card_to_existing(detected_bank, detected_card_type, user_cards_list)
+        matched_card = _match_card_to_existing(
+            detected_bank, detected_card_type, user_cards_list, None
+        )
 
         detected_cards.append(
             {

--- a/src/backend/app/services/smart_import_core.py
+++ b/src/backend/app/services/smart_import_core.py
@@ -77,22 +77,33 @@ def _match_card_to_existing(
     detected_bank: str,
     detected_card: str,
     user_cards: list[Card],
+    card_type: str | None = None,
 ) -> Card | None:
     """
     Match detected bank+card to an existing user card.
+    When multiple cards match, prefer the one matching card_type if provided.
     Returns the matched Card or None.
     """
     if not detected_bank or not detected_card:
         return None
 
+    matches = []
     for card in user_cards:
         card_bank = normalize_bank(card.bank or "")
         card_name = (card.card_name or "").lower()
 
         if card_bank == detected_bank and detected_card.lower() in card_name:
-            return card
+            matches.append(card)
 
-    return None
+    if len(matches) == 1:
+        return matches[0]
+    elif len(matches) > 1 and card_type:
+        for card in matches:
+            if card.card_type == card_type:
+                return card
+        return matches[0]
+
+    return matches[0] if matches else None
 
 
 def _parse_full_name(full_name: str) -> tuple[str, str]:
@@ -387,7 +398,7 @@ async def run_smart_import(file_content: bytes, filename: str, db: Session, user
     card_type = closing_info.get("card_type") or "credito"
     for card_header, txns in card_groups.items():
         detected_bank, detected_card = _parse_card_header(card_header)
-        matched_card = _match_card_to_existing(detected_bank, detected_card, user_cards)
+        matched_card = _match_card_to_existing(detected_bank, detected_card, user_cards, card_type)
 
         detected_cards.append(
             {

--- a/src/backend/app/telegram_bot.py
+++ b/src/backend/app/telegram_bot.py
@@ -3,6 +3,7 @@ import json
 import logging
 import os
 import re
+import unicodedata
 import uuid
 from datetime import datetime
 from zoneinfo import ZoneInfo
@@ -146,6 +147,12 @@ BANK_NAME_PATTERNS = [
 ]
 
 
+def _strip_accents(s: str) -> str:
+    """Strip accents from text for accent-insensitive matching."""
+    nfkd = unicodedata.normalize("NFKD", s.lower().strip())
+    return "".join(c for c in nfkd if not unicodedata.combining(c))
+
+
 def _extract_card_from_text(text: str) -> tuple[str | None, str | None, str | None]:
     """Try to extract card_name, bank, and card_type from natural language text."""
     lower = text.lower()
@@ -256,64 +263,83 @@ def _parse_bank_notification(text: str) -> dict | None:
 
 def _match_card_from_notification(
     user_id: int,
-    card_last4: str | None,
     bank: str | None,
     card_type: str | None,
     card_name: str | None,
     db,
 ) -> Card | None:
-    """Match a bank notification to an existing card in DB."""
+    """Match a bank notification to an existing card in DB.
+
+    Matching priority:
+      Pass 1: card_name + bank (ignore card_type) — card_name is the most reliable identifier
+      Pass 2: bank + card_type (fallback when card_name doesn't match)
+      Pass 3: card_type only (last resort — auto-select if single card of that type)
+    """
     cards = db.query(Card).filter(Card.user_id == user_id).all()
     if not cards:
         return None
 
     target_type = card_type or "credito"
 
-    # Pass 0: match by last 4 digits (most precise)
-    if card_last4:
+    # Pass 1: match by card_name + bank (ignore card_type)
+    # card_name is the most reliable identifier — the LLM often gets card_type wrong
+    if card_name:
+        matches = []
         for card in cards:
-            if card.card_name and card.card_name[-4:] == card_last4:
-                return card
-
-    # Pass 1: match by card_name + bank + type
-    for card in cards:
-        if card.card_type != target_type:
-            continue
-        if bank and card.bank and card.bank.lower() != bank.lower():
-            continue
-        # If notification mentions a card name, match it (case-insensitive, accent-insensitive)
-        if card_name:
-            import unicodedata
-
-            def _strip_accents(s: str) -> str:
-                nfkd = unicodedata.normalize("NFKD", s.lower().strip())
-                return "".join(c for c in nfkd if not unicodedata.combining(c))
-
+            if bank and card.bank and card.bank.lower() != bank.lower():
+                continue
             card_lower = _strip_accents(card.card_name)
             name_lower = _strip_accents(card_name)
-            # Check if DB card contains the notification name or vice versa
-            if name_lower not in card_lower and card_lower not in name_lower:
-                continue
-        # Check if card_name contains a known franchise
-        card_lower = card.card_name.lower()
-        if any(
-            card_lower.startswith(f) or f in card_lower
-            for f in ["visa", "mastercard", "naranja", "amex", "cabal"]
-        ):
-            return card
+            if name_lower in card_lower or card_lower in name_lower:
+                matches.append(card)
 
-    # Pass 2: match by bank + type only (ignore card_name)
+        if len(matches) == 1:
+            logger.debug(
+                "[CARD_MATCH] Pass 1 (card_name+bank): matched %s",
+                matches[0].card_name,
+            )
+            return matches[0]
+        elif len(matches) > 1:
+            # Disambiguate by card_type when multiple cards match
+            for card in matches:
+                if card.card_type == target_type:
+                    logger.debug(
+                        "[CARD_MATCH] Pass 1 (card_name+bank+type): matched %s",
+                        card.card_name,
+                    )
+                    return card
+            logger.debug(
+                "[CARD_MATCH] Pass 1 (card_name+bank): multiple matches, returning first: %s",
+                matches[0].card_name,
+            )
+            return matches[0]
+
+    # Pass 2: match by bank + card_type (ignore card_name)
     for card in cards:
         if card.card_type != target_type:
             continue
         if bank and card.bank and card.bank.lower() == bank.lower():
+            logger.debug(
+                "[CARD_MATCH] Pass 2 (bank+type): matched %s",
+                card.card_name,
+            )
             return card
 
-    # Pass 3: match by type only — if only one card of that type, auto-select
+    # Pass 3: match by card_type only — if only one card of that type, auto-select
     type_cards = [c for c in cards if c.card_type == target_type]
     if len(type_cards) == 1:
+        logger.debug(
+            "[CARD_MATCH] Pass 3 (type only): matched %s",
+            type_cards[0].card_name,
+        )
         return type_cards[0]
 
+    logger.debug(
+        "[CARD_MATCH] No match found. card_name=%s, bank=%s, card_type=%s",
+        card_name,
+        bank,
+        card_type,
+    )
     return None
 
 
@@ -1037,7 +1063,6 @@ async def _handle_bank_notification(
         # Match card from notification
         card = _match_card_from_notification(
             user_id,
-            parsed.get("card_last4"),
             parsed.get("bank"),
             parsed.get("card_type"),
             parsed.get("card_name"),
@@ -1260,14 +1285,9 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
             for card in cards:
                 card_lower = card.card_name.lower()
                 text_lower = text_card_name.lower()
-                # Match if DB card starts with the extracted name or vice versa
-                # e.g. "visa" matches "visa debito", "visa debito" matches "visa"
                 name_match = (
-                    card_lower == text_lower
-                    or card_lower.startswith(text_lower)
-                    or text_lower.startswith(card_lower)
+                    card_lower == text_lower or text_lower in card_lower or card_lower in text_lower
                 )
-                # Match card type if extracted (debito/credito)
                 type_match = not text_card_type or card.card_type == text_card_type
                 if (
                     name_match

--- a/src/backend/app/whatsapp_bot.py
+++ b/src/backend/app/whatsapp_bot.py
@@ -404,14 +404,9 @@ async def _handle_text_message(
             for card in cards:
                 card_lower = card.card_name.lower()
                 text_lower = text_card_name.lower()
-                # Match if DB card starts with the extracted name or vice versa
-                # e.g. "visa" matches "visa debito", "visa debito" matches "visa"
                 name_match = (
-                    card_lower == text_lower
-                    or card_lower.startswith(text_lower)
-                    or text_lower.startswith(card_lower)
+                    card_lower == text_lower or text_lower in card_lower or card_lower in text_lower
                 )
-                # Match card type if extracted (debito/credito)
                 type_match = not text_card_type or card.card_type == text_card_type
                 if (
                     name_match
@@ -498,7 +493,6 @@ async def _handle_bank_notification(
     try:
         card = _match_card_from_notification(
             user_id,
-            parsed.get("card_last4"),
             parsed.get("bank"),
             parsed.get("card_type"),
             parsed.get("card_name"),

--- a/src/backend/tests/test_card_matching.py
+++ b/src/backend/tests/test_card_matching.py
@@ -1,0 +1,255 @@
+"""Unit tests for card matching logic in telegram_bot and smart_import_core."""
+
+import os
+import unittest
+from unittest.mock import MagicMock
+
+os.environ["SECRET_KEY"] = "test-secret-key-that-is-at-least-32-chars-long-for-testing"
+
+from app.telegram_bot import (
+    _extract_card_from_text,
+    _match_card_from_notification,
+    _strip_accents,
+)
+from app.services.smart_import_core import _match_card_to_existing
+
+
+def _make_card(card_name, bank="", card_type="credito", user_id=1):
+    """Create a mock Card object."""
+    card = MagicMock()
+    card.card_name = card_name
+    card.bank = bank
+    card.card_type = card_type
+    card.user_id = user_id
+    return card
+
+
+def _make_db(cards):
+    """Create a mock DB that returns the given cards."""
+    db = MagicMock()
+    db.query.return_value.filter.return_value.all.return_value = cards
+    return db
+
+
+class TestStripAccents(unittest.TestCase):
+    def test_basic(self):
+        self.assertEqual(_strip_accents("Visa Débito"), "visa debito")
+
+    def test_no_accents(self):
+        self.assertEqual(_strip_accents("Mastercard"), "mastercard")
+
+    def test_empty(self):
+        self.assertEqual(_strip_accents(""), "")
+
+    def test_whitespace(self):
+        self.assertEqual(_strip_accents("  Visa Débito  "), "visa debito")
+
+
+class TestMatchCardFromNotification(unittest.TestCase):
+    def test_single_card_exact_match(self):
+        """Single card matches by card_name + bank."""
+        visa = _make_card("Visa Débito", bank="Santander", card_type="debito")
+        db = _make_db([visa])
+        result = _match_card_from_notification(1, "Santander", "debito", "Visa Débito", db)
+        self.assertEqual(result, visa)
+
+    def test_card_name_substring_match(self):
+        """card_name substring matches DB card_name."""
+        mastercard = _make_card("Santander Mastercard", bank="Santander", card_type="credito")
+        db = _make_db([mastercard])
+        result = _match_card_from_notification(1, "Santander", None, "Mastercard", db)
+        self.assertEqual(result, mastercard)
+
+    def test_card_name_abbreviated_match(self):
+        """'Visa' matches 'Santander Visa Débito'."""
+        visa = _make_card("Santander Visa Débito", bank="Santander", card_type="debito")
+        db = _make_db([visa])
+        result = _match_card_from_notification(1, "Santander", "debito", "Visa", db)
+        self.assertEqual(result, visa)
+
+    def test_disambiguation_by_type(self):
+        """Multiple cards match name+bank, card_type disambiguates."""
+        visa_credito = _make_card("Santander Visa Crédito", bank="Santander", card_type="credito")
+        visa_debito = _make_card("Santander Visa Débito", bank="Santander", card_type="debito")
+        db = _make_db([visa_credito, visa_debito])
+
+        # Request debito → should match Visa Débito
+        result = _match_card_from_notification(1, "Santander", "debito", "Visa", db)
+        self.assertEqual(result, visa_debito)
+
+        # Request credito → should match Visa Crédito
+        result = _match_card_from_notification(1, "Santander", "credito", "Visa", db)
+        self.assertEqual(result, visa_credito)
+
+    def test_no_card_name_uses_bank_type(self):
+        """No card_name falls back to bank + type matching."""
+        visa = _make_card("Santander Visa Débito", bank="Santander", card_type="debito")
+        mastercard = _make_card("Santander Mastercard", bank="Santander", card_type="credito")
+        db = _make_db([visa, mastercard])
+
+        result = _match_card_from_notification(1, "Santander", "debito", None, db)
+        self.assertEqual(result, visa)
+
+    def test_bank_only_fallback(self):
+        """Only bank matches, no card_name → returns first matching bank+type."""
+        visa = _make_card("Visa", bank="Santander", card_type="credito")
+        mastercard = _make_card("Mastercard", bank="Santander", card_type="debito")
+        db = _make_db([visa, mastercard])
+
+        result = _match_card_from_notification(1, "Santander", "credito", None, db)
+        self.assertEqual(result, visa)
+
+    def test_type_only_single_card(self):
+        """No bank match, but single card of target type → auto-select."""
+        visa = _make_card("Visa", bank="Galicia", card_type="debito")
+        db = _make_db([visa])
+
+        result = _match_card_from_notification(1, "Santander", "debito", None, db)
+        self.assertEqual(result, visa)
+
+    def test_type_only_multiple_cards_returns_none(self):
+        """Multiple cards of target type, no bank match → None."""
+        visa = _make_card("Visa", bank="Galicia", card_type="credito")
+        mastercard = _make_card("Mastercard", bank="BBVA", card_type="credito")
+        db = _make_db([visa, mastercard])
+
+        result = _match_card_from_notification(1, "Santander", "credito", None, db)
+        self.assertIsNone(result)
+
+    def test_no_cards_returns_none(self):
+        """Empty card list → None."""
+        db = _make_db([])
+        result = _match_card_from_notification(1, "Santander", "credito", "Visa", db)
+        self.assertIsNone(result)
+
+    def test_accent_insensitive_match(self):
+        """Accent-insensitive matching works."""
+        visa = _make_card("Santander Visa Débito", bank="Santander", card_type="debito")
+        db = _make_db([visa])
+        result = _match_card_from_notification(1, "Santander", "debito", "Visa Debito", db)
+        self.assertEqual(result, visa)
+
+    def test_swap_scenario_1(self):
+        """Issue #161 Scenario 1: 'Santander Mastercard' → should match Mastercard, not Visa Débito."""
+        visa_debito = _make_card("Santander Visa Débito", bank="Santander", card_type="debito")
+        mastercard = _make_card("Santander Mastercard", bank="Santander", card_type="credito")
+        db = _make_db([visa_debito, mastercard])
+
+        # LLM returns card_type=None (no explicit type in "Santander Mastercard")
+        result = _match_card_from_notification(1, "Santander", None, "Mastercard", db)
+        self.assertEqual(result, mastercard)
+
+    def test_swap_scenario_1_wrong_type(self):
+        """Issue #161: Even if LLM returns wrong card_type, card_name should win."""
+        visa_debito = _make_card("Santander Visa Débito", bank="Santander", card_type="debito")
+        mastercard = _make_card("Santander Mastercard", bank="Santander", card_type="credito")
+        db = _make_db([visa_debito, mastercard])
+
+        # LLM returns card_type="debito" (WRONG for Mastercard) — card_name should still match
+        result = _match_card_from_notification(1, "Santander", "debito", "Mastercard", db)
+        self.assertEqual(result, mastercard)
+
+    def test_swap_scenario_2(self):
+        """Issue #161 Scenario 2: 'Visa Débito terminada en 3001' → should match Visa Débito."""
+        visa_debito = _make_card("Santander Visa Débito", bank="Santander", card_type="debito")
+        mastercard = _make_card("Santander Mastercard", bank="Santander", card_type="credito")
+        db = _make_db([visa_debito, mastercard])
+
+        result = _match_card_from_notification(1, "Santander", "debito", "Visa Débito", db)
+        self.assertEqual(result, visa_debito)
+
+    def test_swap_scenario_2_wrong_type(self):
+        """Issue #161: Even if LLM returns wrong type for Visa Débito, card_name should win."""
+        visa_debito = _make_card("Santander Visa Débito", bank="Santander", card_type="debito")
+        mastercard = _make_card("Santander Mastercard", bank="Santander", card_type="credito")
+        db = _make_db([visa_debito, mastercard])
+
+        # LLM returns card_type="credito" (WRONG for Visa Débito)
+        result = _match_card_from_notification(1, "Santander", "credito", "Visa Débito", db)
+        self.assertEqual(result, visa_debito)
+
+
+class TestMatchCardToExisting(unittest.TestCase):
+    def test_exact_match(self):
+        """Exact bank + franchise match."""
+        visa = _make_card("Visa Débito", bank="Santander", card_type="debito")
+        result = _match_card_to_existing("Santander", "Visa", [visa])
+        self.assertEqual(result, visa)
+
+    def test_substring_match(self):
+        """Franchise substring matches card_name."""
+        mastercard = _make_card("Santander Mastercard", bank="Santander", card_type="credito")
+        result = _match_card_to_existing("Santander", "Mastercard", [mastercard])
+        self.assertEqual(result, mastercard)
+
+    def test_disambiguation_by_card_type(self):
+        """Multiple matches, card_type disambiguates."""
+        visa_credito = _make_card("Santander Visa Crédito", bank="Santander", card_type="credito")
+        visa_debito = _make_card("Santander Visa Débito", bank="Santander", card_type="debito")
+
+        result = _match_card_to_existing("Santander", "Visa", [visa_credito, visa_debito], "debito")
+        self.assertEqual(result, visa_debito)
+
+    def test_no_match(self):
+        """No matching card."""
+        visa = _make_card("Visa", bank="Galicia", card_type="credito")
+        result = _match_card_to_existing("Santander", "Mastercard", [visa])
+        self.assertIsNone(result)
+
+    def test_missing_bank(self):
+        """No bank detected → None."""
+        visa = _make_card("Visa", bank="Santander", card_type="credito")
+        result = _match_card_to_existing("", "Visa", [visa])
+        self.assertIsNone(result)
+
+    def test_missing_card(self):
+        """No card detected → None."""
+        visa = _make_card("Visa", bank="Santander", card_type="credito")
+        result = _match_card_to_existing("Santander", "", [visa])
+        self.assertIsNone(result)
+
+
+class TestExtractCardFromText(unittest.TestCase):
+    def test_visa_debito(self):
+        card_name, bank, card_type = _extract_card_from_text("visa debito")
+        self.assertEqual(card_name, "Visa Debito")
+        self.assertIsNone(bank)
+        self.assertEqual(card_type, "debito")
+
+    def test_visa_debito_accented(self):
+        card_name, bank, card_type = _extract_card_from_text("visa débito")
+        self.assertEqual(card_name, "Visa Débito")
+        self.assertIsNone(bank)
+        self.assertEqual(card_type, "debito")
+
+    def test_mastercard_santander(self):
+        card_name, bank, card_type = _extract_card_from_text("santander mastercard")
+        self.assertEqual(card_name, "Mastercard")
+        self.assertEqual(bank, "Santander")
+        self.assertIsNone(card_type)
+
+    def test_visa_credito_galicia(self):
+        card_name, bank, card_type = _extract_card_from_text("visa credito galicia")
+        self.assertEqual(card_name, "Visa Credito")
+        self.assertEqual(bank, "Galicia")
+        self.assertEqual(card_type, "credito")
+
+    def test_no_card_info(self):
+        card_name, bank, card_type = _extract_card_from_text("farmacity 3200")
+        self.assertIsNone(card_name)
+        self.assertIsNone(bank)
+        self.assertIsNone(card_type)
+
+    def test_compound_form_visa_debito(self):
+        card_name, bank, card_type = _extract_card_from_text("compre visa debito en farmacity")
+        self.assertEqual(card_name, "Visa Debito")
+        self.assertEqual(card_type, "debito")
+
+    def test_compound_form_mastercard_debito(self):
+        card_name, bank, card_type = _extract_card_from_text("pague mastercard debito supermercado")
+        self.assertEqual(card_name, "Mastercard Debito")
+        self.assertEqual(card_type, "debito")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Closes #161 — Fix card swap bug in bank notification matching and add SDD framework-level local linting guide.

## Changes

### Card Matching Fix (Issue #161)
- **Root cause**: `_match_card_from_notification()` had 3 compounding bugs:
  - Pass 0 (card_last4) was dead code comparing card name chars with card digits
  - Pass 2 ignored `card_name` when `card_type` didn't match, returning wrong card
  - Normal flow used `startswith()` instead of substring matching
- **Fix**: Restructure matching passes to prioritize `card_name` over `card_type`
- **Files**: `telegram_bot.py`, `whatsapp_bot.py`, `smart_import_core.py`, `csv_parser.py`
- **Tests**: 31 new unit tests in `test_card_matching.py`

### SDD Local Linting Framework
- **New guide**: `.sdd/guides/local-linting.md` — framework-level guide for local linting
- **Rule 8**: Added to `ai-agent-guide.md` — Pre-Commit Verification
- **Local Verification**: Added to `testing-strategy.md`
- **Lint script**: `scripts/lint.sh` — one-command lint for all linters
- **CLAUDE.md**: Project-specific AI agent instructions

## Testing
- [x] Unit tests pass (56 tests)
- [x] ESLint passes
- [x] Prettier passes
- [x] TypeScript passes
- [x] Ruff Lint passes
- [x] Ruff Format passes
- [ ] MyPy: 1 pre-existing error (ZoneInfo redefinition in whatsapp_bot.py)

## Documentation
- [x] `.sdd/guides/local-linting.md` created
- [x] `.sdd/guides/ai-agent-guide.md` updated (Rule 8)
- [x] `.sdd/guides/testing-strategy.md` updated
- [x] `.sdd/README.md` updated
- [x] `CLAUDE.md` created