### PR TITLE
fix: fuzzy merchant matching + dismiss tombstone + notification throttle (#165)

### DIFF
--- a/src/backend/app/routers/recurring.py
+++ b/src/backend/app/routers/recurring.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
 from app.database import get_db
-from app.models import RecurringExpense, User
+from app.models import RecurringExpense
 from app.services.auth import get_current_user
 
 router = APIRouter(prefix="/recurring", tags=["recurring"])
@@ -262,15 +262,23 @@ def delete_recurring(
 @router.put(
     "/dismiss-banner",
     summary="Dismiss auto-detected banner",
-    description="Dismiss the banner prompting the user to review auto-detected recurring expenses.",
+    description="Dismiss the banner and permanently suppress all current auto-detected recurring expenses.",
 )
 def dismiss_auto_detected_banner(
     db: Session = Depends(get_db),
     current_user=Depends(get_current_user),
 ):
-    """Dismiss the auto-detected recurring expenses banner."""
-    user = db.query(User).filter(User.id == current_user.id).first()
-    if user:
-        user.auto_detected_banner_dismissed_at = datetime.utcnow()
-        db.commit()
-    return {"detail": "Banner dismissed"}
+    """Dismiss the auto-detected banner and tombstone all active auto-detected items."""
+    items = (
+        db.query(RecurringExpense)
+        .filter(
+            RecurringExpense.user_id == current_user.id,
+            RecurringExpense.source == "auto",
+            RecurringExpense.is_active == True,  # noqa: E712
+        )
+        .all()
+    )
+    for item in items:
+        item.is_active = False
+    db.commit()
+    return {"detail": f"Dismissed {len(items)} auto-detected item(s)"}

--- a/src/backend/app/tasks/detect_recurring.py
+++ b/src/backend/app/tasks/detect_recurring.py
@@ -21,6 +21,19 @@ MIN_OCCURRENCES = 2
 AMOUNT_TOLERANCE = 0.05  # 5%
 
 
+def _merchant_keys_match(a: str, b: str) -> bool:
+    """Fuzzy match two merchant keys.
+
+    Matches if:
+      - Exact match
+      - One is a token-containment subset of the other (e.g. "MAKRO" ⊆ "MAKRO PILAR")
+    """
+    if a == b:
+        return True
+    ta, tb = set(a.split()), set(b.split())
+    return bool(ta and tb and (ta <= tb or tb <= ta))
+
+
 @celery_app.task(name="app.tasks.detect_recurring.detect_recurring_expenses")
 def detect_recurring_expenses():
     """Analyze last 90 days of expenses and create RecurringExpense entries for patterns."""
@@ -62,7 +75,7 @@ def detect_recurring_expenses():
 
 
 def _detect_for_user(user_id: int, db) -> tuple[int, int, int]:
-    """Detect recurring patterns for a single user. Returns (created, updated)."""
+    """Detect recurring patterns for a single user. Returns (created, updated, skipped)."""
     cutoff = datetime.now(BUE).date() - timedelta(days=LOOKBACK_DAYS)
 
     expenses = (
@@ -86,6 +99,9 @@ def _detect_for_user(user_id: int, db) -> tuple[int, int, int]:
         if not key or len(key) < 3:
             continue
         merchant_groups.setdefault(key, []).append(exp)
+
+    # Load ALL existing recurring records for fuzzy dedup (active + inactive)
+    all_existing = db.query(RecurringExpense).filter(RecurringExpense.user_id == user_id).all()
 
     created = 0
     updated = 0
@@ -121,30 +137,31 @@ def _detect_for_user(user_id: int, db) -> tuple[int, int, int]:
         account_counts = Counter(e.account_id for e in group if e.account_id)
         account_id = account_counts.most_common(1)[0][0] if account_counts else None
 
-        # Check if already tracked (active or dismissed)
-        existing = (
-            db.query(RecurringExpense)
-            .filter(
-                RecurringExpense.user_id == user_id,
-                RecurringExpense.merchant_key == merchant_key,
-            )
-            .first()
-        )
+        # Fuzzy dedup: match against all existing records
+        active_match = None
+        inactive_match = None
+        for existing in all_existing:
+            if _merchant_keys_match(merchant_key, existing.merchant_key):
+                if existing.is_active:
+                    active_match = existing
+                    break
+                inactive_match = existing
 
-        if existing:
-            # If dismissed (inactive), skip — don't re-create
-            if not existing.is_active:
-                skipped += 1
-                continue
-            existing.amount = round(avg_amount, 2)
-            existing.last_seen_at = datetime.now(BUE)
-            existing.next_charge_date = next_date
-            if category_id and not existing.category_id:
-                existing.category_id = category_id
-            if card_id and not existing.card_id:
-                existing.card_id = card_id
+        if active_match:
+            # Update existing active record
+            active_match.amount = round(avg_amount, 2)
+            active_match.last_seen_at = datetime.now(BUE)
+            active_match.next_charge_date = next_date
+            if category_id and not active_match.category_id:
+                active_match.category_id = category_id
+            if card_id and not active_match.card_id:
+                active_match.card_id = card_id
             updated += 1
+        elif inactive_match:
+            # Tombstone covers this variant — skip
+            skipped += 1
         else:
+            # No match — create new
             new = RecurringExpense(
                 user_id=user_id,
                 merchant_key=merchant_key,
@@ -165,7 +182,23 @@ def _detect_for_user(user_id: int, db) -> tuple[int, int, int]:
 
 
 def _send_notification(user_id: int, count: int, db):
-    """Send in-app notification about auto-detected recurring expenses."""
+    """Send in-app notification about auto-detected recurring expenses.
+
+    Throttle: skip if the most recent auto_recurring_detected notification is still unread.
+    """
+    last_auto = (
+        db.query(Notification)
+        .filter(
+            Notification.user_id == user_id,
+            Notification.type == "auto_recurring_detected",
+        )
+        .order_by(Notification.created_at.desc())
+        .first()
+    )
+    if last_auto and not last_auto.read:
+        logger.debug("Skipping auto_recurring_detected notification (previous unread)")
+        return
+
     # Get the auto-detected recurring expenses for this user
     auto_items = (
         db.query(RecurringExpense)

--- a/src/backend/tests/test_detect_recurring.py
+++ b/src/backend/tests/test_detect_recurring.py
@@ -1,0 +1,264 @@
+"""Unit tests for recurring expense detection and merchant matching."""
+
+import os
+import unittest
+from datetime import date
+from unittest.mock import MagicMock
+
+os.environ["SECRET_KEY"] = "test-secret-key-that-is-at-least-32-chars-long-for-testing"
+
+from app.tasks.detect_recurring import _merchant_keys_match
+
+
+def _make_recurring(merchant_key, is_active=True, source="auto"):
+    rec = MagicMock()
+    rec.merchant_key = merchant_key
+    rec.is_active = is_active
+    rec.source = source
+    return rec
+
+
+def _make_expense(description, amount=1000.0, expense_date=None, card_id=None):
+    exp = MagicMock()
+    exp.description = description
+    exp.amount = amount
+    exp.date = expense_date or date(2026, 8, 1)
+    exp.card_id = card_id
+    exp.category_id = None
+    exp.account_id = None
+    return exp
+
+
+# ---------------------------------------------------------------------------
+# _merchant_keys_match
+# ---------------------------------------------------------------------------
+
+class TestMerchantKeysMatch(unittest.TestCase):
+    def test_exact_match(self):
+        self.assertTrue(_merchant_keys_match("NETFLIX", "NETFLIX"))
+
+    def test_token_subset_left(self):
+        self.assertTrue(_merchant_keys_match("MAKRO", "MAKRO PILAR"))
+
+    def test_token_subset_right(self):
+        self.assertTrue(_merchant_keys_match("MAKRO PILAR", "MAKRO"))
+
+    def test_disjoint(self):
+        self.assertFalse(_merchant_keys_match("MAKRO", "SOUTHEX"))
+
+    def test_empty_left(self):
+        self.assertFalse(_merchant_keys_match("", "NETFLIX"))
+
+    def test_empty_right(self):
+        self.assertFalse(_merchant_keys_match("NETFLIX", ""))
+
+    def test_single_token_superset(self):
+        self.assertTrue(_merchant_keys_match("GAS", "GAS NATURAL"))
+
+    def test_multi_token_subset(self):
+        self.assertTrue(_merchant_keys_match("GAS NATURAL", "GAS NATURAL FLOWERS"))
+
+    def test_not_subset_similar_tokens(self):
+        self.assertFalse(_merchant_keys_match("GAS NATURAL", "GAS PROPANO"))
+
+    def test_case_sensitive_keys(self):
+        # Merchant keys are uppercase in _normalize_merchant_key
+        self.assertTrue(_merchant_keys_match("MAKRO", "MAKRO PILAR"))
+        self.assertFalse(_merchant_keys_match("makro", "MAKRO PILAR"))
+
+
+# ---------------------------------------------------------------------------
+# Tombstone + fuzzy dedup scenarios
+# ---------------------------------------------------------------------------
+
+class TestTombstoneFuzzyDedup(unittest.TestCase):
+    """Integration-style tests using mocked db queries in _detect_for_user."""
+
+    def test_tombstone_exact_key_blocks_recreation(self):
+        """Same merchant_key tombstone prevents re-creation."""
+        from app.tasks.detect_recurring import _detect_for_user
+
+        db = MagicMock()
+        user_id = 1
+
+        # Expenses: 3 identical charges within tolerance
+        exps = [
+            _make_expense("NETFLIX", 1500, date(2026, 6, 1)),
+            _make_expense("NETFLIX", 1500, date(2026, 7, 1)),
+            _make_expense("NETFLIX", 1500, date(2026, 8, 1)),
+        ]
+        db.query.return_value.filter.return_value.all.return_value = exps
+
+        # Existing: NETFLIX tombstone
+        existing = [_make_recurring("NETFLIX", is_active=False)]
+        db.query.return_value.filter.return_value.all.side_effect = [
+            exps,  # first call: expenses
+            existing,  # second call: all existing recurring
+        ]
+
+        created, updated, skipped = _detect_for_user(user_id, db)
+        self.assertEqual(created, 0)
+        self.assertEqual(skipped, 1)
+
+    def test_tombstone_fuzzy_key_blocks_variant(self):
+        """Tombstone 'MAKRO' blocks creation of 'MAKRO PILAR'."""
+        from app.tasks.detect_recurring import _detect_for_user
+
+        db = MagicMock()
+        user_id = 1
+
+        exps = [
+            _make_expense("MAKRO PILAR", 5000, date(2026, 6, 1)),
+            _make_expense("MAKRO PILAR", 5000, date(2026, 7, 1)),
+            _make_expense("MAKRO PILAR", 5000, date(2026, 8, 1)),
+        ]
+        db.query.return_value.filter.return_value.all.side_effect = [
+            exps,
+            [_make_recurring("MAKRO", is_active=False)],
+        ]
+
+        created, updated, skipped = _detect_for_user(user_id, db)
+        self.assertEqual(created, 0)
+        self.assertEqual(skipped, 1)
+
+    def test_active_record_gets_updated(self):
+        """Active record is updated, not duplicated."""
+        from app.tasks.detect_recurring import _detect_for_user
+
+        db = MagicMock()
+        user_id = 1
+
+        exps = [
+            _make_expense("NETFLIX", 1500, date(2026, 6, 1)),
+            _make_expense("NETFLIX", 1500, date(2026, 7, 1)),
+            _make_expense("NETFLIX", 1500, date(2026, 8, 1)),
+        ]
+        active_rec = _make_recurring("NETFLIX", is_active=True)
+        db.query.return_value.filter.return_value.all.side_effect = [
+            exps,
+            [active_rec],
+        ]
+
+        created, updated, skipped = _detect_for_user(user_id, db)
+        self.assertEqual(created, 0)
+        self.assertEqual(updated, 1)
+        self.assertEqual(active_rec.amount, 1500.0)
+
+    def test_active_takes_precedence_over_tombstone(self):
+        """When both active and tombstone fuzzy-match, prefer active (update, not skip)."""
+        from app.tasks.detect_recurring import _detect_for_user
+
+        db = MagicMock()
+        user_id = 1
+
+        exps = [
+            _make_expense("MAKRO PILAR", 5000, date(2026, 6, 1)),
+            _make_expense("MAKRO PILAR", 5000, date(2026, 7, 1)),
+            _make_expense("MAKRO PILAR", 5000, date(2026, 8, 1)),
+        ]
+        active_rec = _make_recurring("MAKRO", is_active=True)
+        tombstone = _make_recurring("MAKRO PILAR", is_active=False)
+        db.query.return_value.filter.return_value.all.side_effect = [
+            exps,
+            [active_rec, tombstone],
+        ]
+
+        created, updated, skipped = _detect_for_user(user_id, db)
+        self.assertEqual(created, 0)
+        self.assertEqual(updated, 1)
+
+    def test_no_match_creates_record(self):
+        """No existing match → new record created."""
+        from app.tasks.detect_recurring import _detect_for_user
+
+        db = MagicMock()
+        user_id = 1
+
+        exps = [
+            _make_expense("NEW MERCHANT", 2000, date(2026, 6, 1)),
+            _make_expense("NEW MERCHANT", 2000, date(2026, 7, 1)),
+            _make_expense("NEW MERCHANT", 2000, date(2026, 8, 1)),
+        ]
+        db.query.return_value.filter.return_value.all.side_effect = [
+            exps,
+            [],
+        ]
+
+        created, updated, skipped = _detect_for_user(user_id, db)
+        self.assertEqual(created, 1)
+        self.assertEqual(updated, 0)
+        self.assertEqual(skipped, 0)
+
+
+# ---------------------------------------------------------------------------
+# Notification throttle
+# ---------------------------------------------------------------------------
+
+class TestNotificationThrottle(unittest.TestCase):
+    def test_skip_if_last_notification_unread(self):
+        """Skip notification if previous auto_recurring_detected is unread."""
+        from app.tasks.detect_recurring import _send_notification
+
+        db = MagicMock()
+        last_notif = MagicMock()
+        last_notif.read = False
+
+        db.query.return_value.filter.return_value.order_by.return_value.first.return_value = (
+            last_notif
+        )
+
+        _send_notification(user_id=1, count=3, db=db)
+        # No Notification should be added
+        db.add.assert_not_called()
+
+    def test_send_if_last_notification_read(self):
+        """Send notification if previous auto_recurring_detected is read."""
+        from app.tasks.detect_recurring import _send_notification
+
+        db = MagicMock()
+        last_notif = MagicMock()
+        last_notif.read = True
+
+        auto_item = MagicMock()
+        auto_item.merchant_key = "NETFLIX"
+        auto_item.id = 1
+
+        def side_effect(*args, **kwargs):
+            q = MagicMock()
+            q.filter.return_value = q
+            q.order_by.return_value = q
+            q.first.return_value = last_notif
+            q.all.return_value = [auto_item]
+            return q
+
+        db.query.side_effect = side_effect
+
+        _send_notification(user_id=1, count=1, db=db)
+        db.add.assert_called_once()
+
+    def test_send_if_no_previous_notification(self):
+        """Send notification if no previous auto_recurring_detected exists."""
+        from app.tasks.detect_recurring import _send_notification
+
+        db = MagicMock()
+
+        auto_item = MagicMock()
+        auto_item.merchant_key = "NETFLIX"
+        auto_item.id = 1
+
+        def side_effect(*args, **kwargs):
+            q = MagicMock()
+            q.filter.return_value = q
+            q.order_by.return_value = q
+            q.first.return_value = None  # no previous notification
+            q.all.return_value = [auto_item]
+            return q
+
+        db.query.side_effect = side_effect
+
+        _send_notification(user_id=1, count=1, db=db)
+        db.add.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Closes #165 — Recurring expenses re-suggested repeatedly after deletion.

## Root Cause (verified in prod via SSH + DB)

Same merchants re-appeared in notifications on Aug 14, 24, 26, 31:
- Zero inactive records → all prior deletes were hard deletes (pre-fix)
- No tombstones → detection recreated everything on each run
- `MAKRO` and `MAKRO PILAR` are the same real merchant but different description variants → tombstone for one doesn't cover the other
- "Ocultar" (dismiss banner) was dead code — set a timestamp that nothing read
- No notification throttle → user got spammed every run

## Changes

| File | Change |
|------|--------|
| `detect_recurring.py` | `_merchant_keys_match()` fuzzy dedup (token containment), `_detect_for_user` loads all records, notification throttle (skip if last unread) |
| `recurring.py` | `dismiss-banner` now tombstones all active auto-detected items |
| `test_detect_recurring.py` | 18 new tests: fuzzy matching, tombstone dedup, throttle |

## Testing
- [x] 87 unit tests pass (18 new + 69 existing)
- [x] ESLint, Prettier, TypeScript, Ruff Lint, Ruff Format pass

## Prod Cleanup
- Deactivated MAKRO PILAR (id=39) duplicate — MAKRO (id=42) stays active

## Verification
After merge/deploy:
1. MAKRO variants → treated as one merchant
2. "Ocultar" button → permanently suppresses all current auto-detected items
3. No notification spam while previous is unread