### PR TITLE
fix(expenses): remove redundant date display (#173)

### DIFF
--- a/src/frontend/src/components/ExpenseDetailModal.tsx
+++ b/src/frontend/src/components/ExpenseDetailModal.tsx
@@ -31,12 +31,7 @@ export default function ExpenseDetailModal({ expense, onClose, onEdit }: Props) 
   const categoryColor = expense.category_color || "#9a9996";
 
   return (
-    <DetailModal
-      isOpen={true}
-      onClose={onClose}
-      title={toUpperCase(expense.description)}
-      subtitle={formatDateDMY(expense.date)}
-    >
+    <DetailModal isOpen={true} onClose={onClose} title={toUpperCase(expense.description)}>
       <div className="space-y-4">
         {/* Monto */}
         <div className="bg-[var(--color-base-alt)] rounded-lg p-4 text-center">

--- a/src/frontend/src/pages/ExpensesPage.tsx
+++ b/src/frontend/src/pages/ExpensesPage.tsx
@@ -1010,7 +1010,7 @@ export default function ExpensesPage() {
                 </>
               ) : expenses.length === 0 ? (
                 <tr>
-                  <td colSpan={5} className="px-4 py-4">
+                  <td colSpan={selectMode ? 6 : 5} className="px-4 py-4">
                     <EmptyState
                       icon="📋"
                       title={
@@ -1034,17 +1034,18 @@ export default function ExpensesPage() {
                 </tr>
               ) : (
                 (() => {
+                  const isDateSort = sort.field === "date";
                   let lastDate = "";
                   return sortedExpenses.map((exp) => {
                     const missing = hasMissingData(exp);
-                    const showDateHeader = exp.date !== lastDate;
+                    const showDateHeader = isDateSort && exp.date !== lastDate;
                     if (showDateHeader) lastDate = exp.date;
                     return (
                       <Fragment key={exp.id}>
                         {showDateHeader && (
                           <tr key={`date-${exp.date}`}>
                             <td
-                              colSpan={5}
+                              colSpan={selectMode ? 6 : 5}
                               className="px-4 py-2 text-xs font-medium text-[var(--text-tertiary)] bg-[var(--color-base-alt)]"
                             >
                               {formatDateDMY(exp.date)}
@@ -1073,18 +1074,22 @@ export default function ExpensesPage() {
                               />
                             </td>
                           )}
-                          <td className="px-4 py-3 text-[var(--text-tertiary)] whitespace-nowrap">
-                            <button
-                              type="button"
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                setDetailExpense(exp);
-                              }}
-                              className="text-left hover:text-primary transition"
-                            >
-                              {formatDateDMY(exp.date)}
-                            </button>
-                          </td>
+                          {isDateSort ? (
+                            <td className="px-4 py-3" />
+                          ) : (
+                            <td className="px-4 py-3 text-[var(--text-tertiary)] whitespace-nowrap">
+                              <button
+                                type="button"
+                                onClick={(e) => {
+                                  e.stopPropagation();
+                                  setDetailExpense(exp);
+                                }}
+                                className="text-left hover:text-primary transition"
+                              >
+                                {formatDateDMY(exp.date)}
+                              </button>
+                            </td>
+                          )}
                           <td className="px-4 py-3">
                             <div className="flex items-center gap-2">
                               {missing && (


### PR DESCRIPTION
## Summary
Closes #173 — Date shown twice in expenses list and detail modal.

## Changes

### List view (`ExpensesPage.tsx`)
**Smart grouping** — two modes depending on sort:
- **Sort by Fecha**: group header rows carry the date; per-row date cell is empty
- **Sort by other field**: no group headers; per-row date cell shows the date

Also fixes: group headers appearing chaotically when sorting by Monto/Categoría (bonus bug from same code). Fixes `colSpan` in select mode for group header and empty state rows.

### Detail modal (`ExpenseDetailModal.tsx`)
Remove subtitle date — keep labeled "Fecha" field in the detail grid (Option A).

## Before / After

**Sorted by Fecha:**
```
Before:  27/08/2026 (header) → 27/08/2026 WORK CAFE GARAY (row)
After:   27/08/2026 (header) → WORK CAFE GARAY (row)
```

**Sorted by Monto:**
```
Before: random date headers + per-row dates (chaotic)
After:  no headers, clean per-row dates
```

**Detail modal:**
```
Before: subtitle 27/08/2026 + field Fecha 27/08/2026
After:  field Fecha 27/08/2026 (single)
```

## Testing
- [x] ESLint passes
- [x] Prettier passes
- [x] TypeScript passes