### PR TITLE
feat: dashboard Adwaita/KISS visual refinements

### DIFF
--- a/src/frontend/src/App.tsx
+++ b/src/frontend/src/App.tsx
@@ -11,13 +11,15 @@ import { UploadProgressProvider } from "./context/UploadProgressContext";
 import { NotificationsProvider, useNotifications } from "./context/NotificationsContext";
 import { FamilyGroupProvider } from "./context/FamilyGroupContext";
 import { sidebarIcons } from "./components/SidebarIcons";
-import { getStoredToken, getMe, getAdminSlug, dismissWhatsNew } from "./api/client";
+import { getStoredToken, getMe, getAdminSlug, dismissWhatsNew, createExpense } from "./api/client";
 import { ErrorBoundary } from "./components/ErrorBoundary";
 import { useUndoToast } from "./hooks/useUndoToast";
 import ImpersonationBanner from "./components/ImpersonationBanner";
 import ReAuthModal from "./components/ReAuthModal";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { isTelegramWebApp, initTelegramWebApp, telegramAutoLogin } from "./services/telegramWebApp";
+import { ExpenseModal } from "./components/ExpenseModals";
+import type { ExpenseCreate } from "./types";
 
 const Dashboard = lazy(() => import("./pages/Dashboard"));
 const AccountsPage = lazy(() => import("./pages/AccountsPage"));
@@ -273,7 +275,25 @@ function MainLayout() {
   const queryClient = useQueryClient();
   const [showWhatsNew, setShowWhatsNew] = useState(false);
   const [showReAuth, setShowReAuth] = useState(false);
+  const [newExpenseOpen, setNewExpenseOpen] = useState(false);
   const { ToastContainer } = useUndoToast();
+
+  // Global expense creation
+  const createMut = useMutation({
+    mutationFn: (data: ExpenseCreate) => createExpense(data),
+    onSuccess: () => {
+      setNewExpenseOpen(false);
+      queryClient.invalidateQueries({ queryKey: ["expenses"] });
+      queryClient.invalidateQueries({ queryKey: ["dashboard"] });
+    },
+  });
+
+  // Global event: open new expense from FAB
+  useEffect(() => {
+    const handler = () => setNewExpenseOpen(true);
+    window.addEventListener("open-new-expense", handler);
+    return () => window.removeEventListener("open-new-expense", handler);
+  }, []);
 
   // Get current user for admin check
   const { data: currentUser } = useQuery({
@@ -880,6 +900,24 @@ function MainLayout() {
               </button>
             )}
 
+            {/* Floating New Expense button (mobile + desktop) */}
+            {!newExpenseOpen && (
+              <button
+                onClick={() => setNewExpenseOpen(true)}
+                className="fixed bottom-[calc(6.5rem+var(--browser-bottom-inset,0px))] md:bottom-6 right-4 md:right-20 z-50 flex items-center justify-center w-11 h-11 bg-primary hover:brightness-110 text-white rounded-full shadow-gnome hover:shadow-gnome-lg scale-100 hover:scale-105 transition-all duration-150"
+                title="Nuevo gasto"
+              >
+                <svg width="20" height="20" viewBox="0 0 20 20" fill="none">
+                  <path
+                    d="M10 4v12M4 10h12"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                  />
+                </svg>
+              </button>
+            )}
+
             {!isInvestments && (
               <AIAssistant open={aiDrawerOpen} onToggle={() => toggleDrawer(!aiDrawerOpen)} />
             )}
@@ -907,6 +945,17 @@ function MainLayout() {
                 setShowReAuth(false);
                 window.location.href = "/";
               }}
+            />
+          )}
+
+          {/* Global New Expense Modal */}
+          {newExpenseOpen && (
+            <ExpenseModal
+              initial={null}
+              onClose={() => setNewExpenseOpen(false)}
+              onSave={(data) => createMut.mutate(data)}
+              saveError={createMut.error?.message || null}
+              isSaving={createMut.isPending}
             />
           )}
         </div>

--- a/src/frontend/src/pages/Dashboard.tsx
+++ b/src/frontend/src/pages/Dashboard.tsx
@@ -268,6 +268,16 @@ export default function Dashboard() {
 
   const maxCatTotal = categories[0]?.total ?? 1;
 
+  // Shared category → color map (consistent between pie chart and list)
+  const categoryColorMap = useMemo(() => {
+    const map = new Map<string, string>();
+    const allCats = [...(dashData?.by_category ?? [])].sort((a, b) => b.total - a.total);
+    allCats.forEach((c, i) => {
+      map.set(c.category_name, c.category_color || FALLBACK_COLORS[i % FALLBACK_COLORS.length]);
+    });
+    return map;
+  }, [dashData?.by_category]);
+
   const handleCategorySelect = (name: string) => {
     setSelectedCategory(selectedCategory === name ? null : name);
   };
@@ -319,7 +329,7 @@ export default function Dashboard() {
     }
     const result = big.map((c) => ({
       name: c.category_name,
-      color: c.category_color || FALLBACK_COLORS[big.indexOf(c) % FALLBACK_COLORS.length],
+      color: c.category_color || categoryColorMap.get(c.category_name) || "#94a3b8",
       total: c.total,
     }));
     if (small.length > 0) {
@@ -330,7 +340,7 @@ export default function Dashboard() {
       });
     }
     return result;
-  }, [dashData?.by_category]);
+  }, [dashData?.by_category, categoryColorMap]);
 
   // KPI calculations
   const totalSpent = dashData?.total_amount ?? 0;
@@ -560,7 +570,7 @@ export default function Dashboard() {
               <div className="space-y-1.5 p-1">
                 {categories.map((cat, i) => {
                   const pct = (cat.total / maxCatTotal) * 100;
-                  const color = cat.category_color || FALLBACK_COLORS[i % FALLBACK_COLORS.length];
+                  const color = cat.category_color || categoryColorMap.get(cat.category_name) || "#94a3b8";
                   const isSelected = selectedCategory === cat.category_name;
                   const prevTotal = cat.previous_total ?? 0;
                   const variation = prevTotal > 0 ? ((cat.total - prevTotal) / prevTotal) * 100 : 0;

--- a/src/frontend/src/pages/Dashboard.tsx
+++ b/src/frontend/src/pages/Dashboard.tsx
@@ -460,17 +460,18 @@ export default function Dashboard() {
           >
             <p className="text-[10px] text-tertiary uppercase mb-1">Inversiones</p>
             <div className="space-y-0.5">
-              <p className="text-sm font-bold text-primary">
-                {savingsArs > 0 ? formatCurrency(savingsArs) : "—"}
+              <p className="text-lg font-bold text-primary">
+                {savingsArs > 0 ? formatCurrency(savingsArs) : totalUsd > 0 ? "—" : "—"}
               </p>
-              <p className="text-sm font-bold text-primary">
-                {totalUsd > 0
-                  ? `USD ${totalUsd.toLocaleString("en-US", {
-                      minimumFractionDigits: 2,
-                      maximumFractionDigits: 2,
-                    })}`
-                  : "—"}
-              </p>
+              {totalUsd > 0 && (
+                <p className="text-xs text-secondary">
+                  ≈ USD{" "}
+                  {totalUsd.toLocaleString("en-US", {
+                    minimumFractionDigits: 2,
+                    maximumFractionDigits: 2,
+                  })}
+                </p>
+              )}
             </div>
           </div>
         )}

--- a/src/frontend/src/pages/Dashboard.tsx
+++ b/src/frontend/src/pages/Dashboard.tsx
@@ -587,15 +587,7 @@ export default function Dashboard() {
                         </div>
                         <div className="flex items-center gap-2">
                           {prevTotal > 0 && (
-                            <span
-                              className={`text-[10px] font-medium ${
-                                variation > 0
-                                  ? "text-danger"
-                                  : variation < 0
-                                    ? "text-success"
-                                    : "text-tertiary"
-                              }`}
-                            >
+                            <span className="text-[10px] font-medium text-tertiary">
                               {variation > 0 ? "↑" : variation < 0 ? "↓" : "→"}
                               {Math.abs(variation).toFixed(0)}%
                             </span>

--- a/src/frontend/src/pages/Dashboard.tsx
+++ b/src/frontend/src/pages/Dashboard.tsx
@@ -46,7 +46,7 @@ const CATEGORY_EMOJI: Record<string, string> = {
   salud: "💊",
   farmacia: "💊",
   médico: "🏥",
- hospital: "🏥",
+  hospital: "🏥",
   servicios: "💡",
   luz: "💡",
   gas: "💡",
@@ -636,7 +636,8 @@ export default function Dashboard() {
               <div className="space-y-1.5 p-1">
                 {categories.map((cat, i) => {
                   const pct = (cat.total / maxCatTotal) * 100;
-                  const color = cat.category_color || categoryColorMap.get(cat.category_name) || "#94a3b8";
+                  const color =
+                    cat.category_color || categoryColorMap.get(cat.category_name) || "#94a3b8";
                   const isSelected = selectedCategory === cat.category_name;
                   const prevTotal = cat.previous_total ?? 0;
                   const variation = prevTotal > 0 ? ((cat.total - prevTotal) / prevTotal) * 100 : 0;

--- a/src/frontend/src/pages/Dashboard.tsx
+++ b/src/frontend/src/pages/Dashboard.tsx
@@ -33,6 +33,72 @@ const FALLBACK_COLORS = [
   "#06b6d4", // cyan
 ];
 
+const CATEGORY_EMOJI: Record<string, string> = {
+  comida: "🍔",
+  alimentación: "🛒",
+  supermercado: "🛒",
+  mercado: "🛒",
+  transporte: "🚗",
+  uber: "🚗",
+  taxi: "🚗",
+  nafta: "⛽",
+  gasolina: "⛽",
+  salud: "💊",
+  farmacia: "💊",
+  médico: "🏥",
+ hospital: "🏥",
+  servicios: "💡",
+  luz: "💡",
+  gas: "💡",
+  internet: "📶",
+  teléfono: "📱",
+  phone: "📱",
+  ocio: "🎬",
+  entretenimiento: "🎬",
+  streaming: "🎬",
+  netflix: "🎬",
+  spotify: "🎵",
+  música: "🎵",
+  educación: "📚",
+  universidad: "📚",
+  college: "📚",
+  hogar: "🏠",
+  alquiler: "🏠",
+  expensas: "🏠",
+  ropa: "👕",
+  vestimenta: "👕",
+  fitness: "🏋️",
+  gimnasio: "🏋️",
+  deporte: "🏋️",
+  café: "☕",
+  suscripciones: "📦",
+  regalos: "🎁",
+  donaciones: "💝",
+  viajes: "✈️",
+  vuelos: "✈️",
+  hotels: "🏨",
+  hotel: "🏨",
+  restaurantes: "🍽️",
+  restó: "🍽️",
+  delivery: "🛵",
+  rappi: "🛵",
+  pedidosya: "🛵",
+  mascotas: "🐾",
+  perro: "🐾",
+  gato: "🐾",
+  bebés: "👶",
+  baby: "👶",
+};
+
+function getCategoryEmoji(name: string | null): string | null {
+  if (!name) return null;
+  const lower = name.toLowerCase();
+  for (const [keyword, emoji] of Object.entries(CATEGORY_EMOJI)) {
+    if (lower.includes(keyword)) return emoji;
+  }
+  return null;
+}
+
 function CardRow({
   cardName,
   bank,
@@ -684,11 +750,18 @@ export default function Dashboard() {
                 >
                   <div className="flex items-center gap-3 min-w-0">
                     <span
-                      className="w-2.5 h-2.5 rounded-full flex-shrink-0"
+                      className="w-8 h-8 rounded-full flex-shrink-0 flex items-center justify-center text-sm"
                       style={{
-                        backgroundColor: exp.category_color || "#3584e4",
+                        backgroundColor: (exp.category_color || "#3584e4") + "20",
                       }}
-                    />
+                    >
+                      {getCategoryEmoji(exp.category_name) || (
+                        <span
+                          className="w-2.5 h-2.5 rounded-full"
+                          style={{ backgroundColor: exp.category_color || "#3584e4" }}
+                        />
+                      )}
+                    </span>
                     <div className="min-w-0">
                       <p className="text-sm font-medium text-primary truncate">
                         {toUpperCase(exp.description)}

--- a/src/frontend/src/pages/Dashboard.tsx
+++ b/src/frontend/src/pages/Dashboard.tsx
@@ -357,7 +357,7 @@ export default function Dashboard() {
     prevMonthTotal > 0 ? ((totalSpent - prevMonthTotal) / prevMonthTotal) * 100 : 0;
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-8">
       {/* Page header */}
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div className="flex items-center gap-2">
@@ -422,7 +422,7 @@ export default function Dashboard() {
         } gap-4`}
       >
         <div
-          className="card p-4 cursor-pointer hover:bg-[var(--color-base-alt)] transition-colors"
+          className="card p-5 cursor-pointer hover:bg-[var(--color-base-alt)] transition-colors"
           onClick={() => navigate("/expenses")}
         >
           <p className="text-[10px] text-tertiary uppercase mb-1">Total gastado</p>
@@ -432,7 +432,7 @@ export default function Dashboard() {
           </p>
         </div>
         <div
-          className="card p-4 cursor-pointer hover:bg-[var(--color-base-alt)] transition-colors"
+          className="card p-5 cursor-pointer hover:bg-[var(--color-base-alt)] transition-colors"
           onClick={() => navigate("/expenses?card_type=credito")}
         >
           <p className="text-[10px] text-tertiary uppercase mb-1">Deuda tarjetas</p>
@@ -440,7 +440,7 @@ export default function Dashboard() {
           <p className="text-xs text-tertiary mt-1">{pasivosData?.count ?? 0} cuotas pendientes</p>
         </div>
         <div
-          className="card p-4 cursor-pointer hover:bg-[var(--color-base-alt)] transition-colors"
+          className="card p-5 cursor-pointer hover:bg-[var(--color-base-alt)] transition-colors"
           onClick={() =>
             navigate(`/expenses?installment=1&date_from=${month}-01&date_to=${month}-31`)
           }
@@ -449,7 +449,7 @@ export default function Dashboard() {
           <p className="text-lg font-bold text-primary">{formatCurrency(cuotasComprometidas)}</p>
           <p className="text-xs text-tertiary mt-1">{currentMonthLoad?.count ?? 0} cuotas</p>
         </div>
-        <div className="card p-4">
+        <div className="card p-5">
           <p className="text-[10px] text-tertiary uppercase mb-1">vs Mes anterior</p>
           <p
             className={`text-lg font-bold ${
@@ -465,7 +465,7 @@ export default function Dashboard() {
         </div>
         {(savingsArs > 0 || totalUsd > 0) && (
           <div
-            className="card p-4 cursor-pointer hover:bg-[var(--color-base-alt)] transition-colors"
+            className="card p-5 cursor-pointer hover:bg-[var(--color-base-alt)] transition-colors"
             onClick={() => navigate("/investments")}
           >
             <p className="text-[10px] text-tertiary uppercase mb-1">Inversiones</p>
@@ -490,7 +490,7 @@ export default function Dashboard() {
       {/* Gastos por Categoría + Transacciones — side by side */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         {/* Left: Gastos por Categoría */}
-        <div className="card p-4 h-[420px] flex flex-col overflow-hidden">
+        <div className="card p-4 h-[440px] flex flex-col overflow-hidden">
           <div className="flex items-center justify-between mb-3">
             <div className="flex items-center gap-2">
               <h2 className="text-sm font-semibold text-primary">Gastos por Categoría</h2>
@@ -519,7 +519,7 @@ export default function Dashboard() {
               description="Los gastos por categoría aparecerán aquí"
             />
           ) : (
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 flex-1">
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-5 flex-1">
               {/* Pie chart */}
               <div className="flex items-center justify-center">
                 <ResponsiveContainer width="100%" height={220}>
@@ -623,7 +623,7 @@ export default function Dashboard() {
         </div>
 
         {/* Right: Transacciones */}
-        <div className="card h-[420px] flex flex-col">
+        <div className="card h-[440px] flex flex-col">
           <div className="px-4 py-3 border-b border-border-color flex items-center justify-between flex-shrink-0">
             <div className="flex items-center gap-2">
               <h2 className="text-sm font-semibold text-primary">

--- a/src/frontend/src/pages/ExpensesPage.tsx
+++ b/src/frontend/src/pages/ExpensesPage.tsx
@@ -1091,11 +1091,11 @@ export default function ExpensesPage() {
                             </td>
                           )}
                           <td className="px-4 py-3 max-w-0 w-full">
-                            <div className="flex items-center gap-2">
+                            <div className="flex items-center gap-2 min-w-0">
                               {missing && (
                                 <span
                                   title={`Faltan: ${getMissingDataFields(exp).join(", ")}`}
-                                  className="text-[#f6d32d]"
+                                  className="text-[#f6d32d] shrink-0"
                                 >
                                   ⚠️
                                 </span>
@@ -1106,17 +1106,19 @@ export default function ExpensesPage() {
                                   e.stopPropagation();
                                   setDetailExpense(exp);
                                 }}
-                                className="text-left hover:text-primary transition flex flex-col sm:flex-row items-start gap-1 sm:gap-2 w-full"
+                                className="text-left hover:text-primary transition flex flex-col sm:flex-row items-start gap-1 sm:gap-2 min-w-0 flex-1"
                               >
                                 {!isDateSort && (
                                   <span className="sm:hidden text-xs text-[var(--text-tertiary)] shrink-0">
                                     {exp.date.slice(8, 10)}/{exp.date.slice(5, 7)}
                                   </span>
                                 )}
-                                <span className="text-[var(--text-primary)] truncate">
-                                  {toUpperCase(exp.description)}
+                                <span className="flex items-center gap-1 min-w-0 max-w-full">
+                                  <span className="text-[var(--text-primary)] truncate">
+                                    {toUpperCase(exp.description)}
+                                  </span>
                                   {exp.installment_number && exp.installment_total && (
-                                    <span className="text-xs bg-[var(--color-primary)] text-[var(--color-on-primary)] px-1.5 py-0.5 rounded ml-1">
+                                    <span className="text-[10px] bg-[var(--color-primary)] text-[var(--color-on-primary)] px-1 py-0.5 rounded shrink-0">
                                       {exp.installment_number}/{exp.installment_total}
                                     </span>
                                   )}


### PR DESCRIPTION
## Summary
Seven independent commits, each revertable:

1. **Category MoM → grey** — reserve red/green for KPIs only ("Deuda tarjetas", "vs Mes anterior"). Category variations become `text-tertiary`. Adwaita: if everything is coloured, nothing stands out.
2. **Inversiones card hierarchy** — ARS as dominant value (`text-lg bold`), USD as secondary `≈ USD X.XX`. One card = one idea (KISS).
3. **Pie/list colour consistency** — shared `categoryColorMap` resolves fallback colours identically in both the pie chart and the list. Fixes a real mismatch when categories without `category_color` were grouped into "Otros" differently.
4. **Spacing** — `space-y-8`, KPI cards `p-5`, category grid `gap-5`, cards `h-[440px]`. GNOME HIG: whitespace improves clarity and touch navigation.
5. **Transaction emoji icons** — category keyword → emoji map (comida→🍔, transporte→🚗, salud→💊…), rendered in a circular container with category colour background. Falls back to coloured dot when no emoji matches.
6. **Global `+` FAB** — floating `+` button on every page (stacked above the AI FAB), opens the ExpenseModal globally. Same `createExpense` mutation, invalidates expenses + dashboard queries on save.
7. **Expense mobile overlap fix** — description cell's flex chain lacked `min-w-0` on every link, so text-overflow ellipsis never triggered and title spilled into the category column. Moved the installment badge (2/6) out of the truncate span into its own `shrink-0` sibling. (Follow-up to already-merged #194)

## Verification
- `./scripts/lint.sh` — all pass (except MyPy, pre-existing)
- `./scripts/smoke.sh` — 6/6 phases pass

Closes #177