### PR TITLE
fix(landing): remove card number from carousel demo #3

### DIFF
--- a/src/frontend/src/pages/LandingPage.tsx
+++ b/src/frontend/src/pages/LandingPage.tsx
@@ -15,7 +15,7 @@ const TELEGRAM_DEMOS = [
       "✅ ¡Listo! Guardé el gasto.\n\n💰 $12.000 (3 cuotas de $4.000)\n💳 Santander Visa\n📅 12 de julio de 2026\n\n🛒 Supermercado\n└ 📂 Compras del hogar",
   },
   {
-    user: "Compra aprobada Visa ****4521 $3.200 Café Tortoni",
+    user: "Compra aprobada Visa $3.200 Café Tortoni",
     reply:
       "✅ ¡Listo! Guardé el gasto.\n\n💰 $3.200\n📅 12 de julio de 2026\n\n☕ Café y snacks\n└ 📂 Café/Bar",
   },


### PR DESCRIPTION
## Summary
The carousel demo #3 showed a bank notification containing `****4521`, suggesting the bot saves card data (last 4 digits). Removed the card number while keeping the realistic merchant name.

**Before:** `Compra aprobada Visa ****4521 $3.200 Café Tortoni`
**After:** `Compra aprobada Visa $3.200 Café Tortoni`

The reply (bot response) was already fixed in PR #203 to omit the `💳 Galicia Visa` line. This PR completes the fix by also removing the card number from the user message.

Follow-up to PR #203 / issue #197.

## Verification
- `./scripts/lint.sh` — all pass (except MyPy, pre-existing)
- `./scripts/smoke.sh` — 6/6 phases pass